### PR TITLE
Add parameter-dataset.tsv sample links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ You can obtain the datasets Almond uses at <https://almond.stanford.edu/thingped
 <https://almond.stanford.edu/thingpedia/entities>. Download
 is available after registration and accepting the terms and conditions.
 
+The sample parameter-datasets.tsv can found in [here](https://github.com/Stanford-Mobisocial-IoT-Lab/genie-toolkit/blob/master/test/data/parameter-datasets.tsv).
+
 Given the created everything.tsv file, you can split in train/eval/test with:
 ```
 genie split-train-eval -i everything.tsv --train train.tsv --eval eval.tsv [--test test.tsv] --eval-prob 0.1

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The sample parameter-datasets.tsv can found in [here](https://github.com/Stanfor
 
 Given the created everything.tsv file, you can split in train/eval/test with:
 ```
-genie split-train-eval -i everything.tsv --train train.tsv --eval eval.tsv [--test test.tsv] --eval-prob 0.1
+genie split-train-eval everything.tsv --train train.tsv --eval eval.tsv --test test.tsv --eval-prob 0.1
   --split-strategy sentence
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The sample parameter-datasets.tsv can found in [here](https://github.com/Stanfor
 
 Given the created everything.tsv file, you can split in train/eval/test with:
 ```
-genie split-train-eval everything.tsv --train train.tsv --eval eval.tsv --test test.tsv --eval-prob 0.1
+genie split-train-eval everything.tsv --train train.tsv --eval eval.tsv [--test test.tsv] --eval-prob 0.1
   --split-strategy sentence
 ```
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ in both.
 
 #### Step 5. Training
 
+First, set the `GENIE_PARSER_PATH` to where you put [genie-parser](https://github.com/Stanford-Mobisocial-IoT-Lab/genie-parser):
+```
+export GENIE_PARSER_PATH='your_path_to/genie-parser'
+```
+
 To train, use:
 ```
 genie train --datadir <DATADIR> --outputdir <OUTPUTDIR> --workdir <WORKDIR>


### PR DESCRIPTION
When trying to train a model, I have met some problems, that can be explained in README.md which will help future users and save their time.

1. Add parameter-dataset.tsv sample links in README.md
2. Add GENIE_PARSER_PATH setting in README.md
3. Fix split-train-eval command, remove -i and []