### PR TITLE
chore: pin mmap-io to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "argparse": "^1.0.10",
     "byline": "^5.0.0",
     "csv": "^5.0.0",
-    "mmap-io": "^1.0.0",
+    "mmap-io": "1.0.0",
     "seedrandom": "^3.0.0",
     "shuffle-array": "^1.0.1",
     "sockaddr": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,7 +1245,7 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mmap-io@^1.0.0:
+mmap-io@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mmap-io/-/mmap-io-1.0.0.tgz#dc0225df5c21a10cfbaa9add54e53bc0a41e19ac"
   integrity sha512-7k9bU9Zlg+REIPiCaGCJ8TEcnl3qAhx+yoFeU+6SFT1Eu27v3gEhOMMvto4QZB4jJHQ+mr/v/umqMBFgcMRlqg==


### PR DESCRIPTION
mmap-io 1.1.0 is busted, see https://github.com/ozra/mmap-io/issues/17