### PR TITLE
Tokenizer: pass expected value down to Almond Tokenizer

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -33,23 +33,23 @@ class CachingTokenizerWrapper {
         return cache;
     }
 
-    _tryCache(locale, sentence) {
+    _tryCache(locale, sentence, expect) {
         let cache = this._getCacheForLanguage(locale);
-        return cache.get(sentence);
+        return cache.get(expect + ': ' + sentence);
     }
 
-    _storeCache(locale, sentence, result) {
+    _storeCache(locale, sentence, expect, result) {
         let cache = this._getCacheForLanguage(locale);
-        cache.set(sentence, result);
+        cache.set(expect + ': ' + sentence, result);
     }
 
-    async tokenize(locale, utterance) {
-        let cached = this._tryCache(locale, utterance);
+    async tokenize(locale, utterance, expect = null) {
+        let cached = this._tryCache(locale, utterance, expect);
         if (cached)
             return cached;
 
-        const result = this._wrapped.tokenize(locale, utterance);
-        this._storeCache(locale, utterance, result);
+        const result = this._wrapped.tokenize(locale, utterance, expect);
+        this._storeCache(locale, utterance, expect, result);
         return result;
     }
 }
@@ -95,13 +95,13 @@ class LocalTokenizer {
         this._socket.end();
     }
 
-    tokenize(locale, utterance) {
+    tokenize(locale, utterance, expect = null) {
         const languageTag = locale.split('-')[0];
         const reqId = this._nextRequest++;
         return new Promise((resolve, reject) => {
             this._requests.set(reqId, { resolve, reject });
 
-            this._socket.write({ req: reqId, utterance, languageTag });
+            this._socket.write({ req: reqId, utterance, languageTag, expect });
         });
     }
 }
@@ -111,8 +111,8 @@ class RemoteTokenizer {
         this._url = url;
     }
 
-    async tokenize(locale, utterance) {
-        let url = this._url + '/' + locale + '/tokenize?q=' + encodeURIComponent(utterance);
+    async tokenize(locale, utterance, expect = null) {
+        let url = this._url + '/' + locale + '/tokenize?q=' + encodeURIComponent(utterance) + '&expect=' + expect;
         const result = JSON.parse(await Tp.Helpers.Http.get(url));
         return result;
     }


### PR DESCRIPTION
When expecting MultipleChoice, entity handling is disabled.
When expecting Location, everything is treated as LOCATION and
passed to the location search.

This is necessary because otherwise CoreNLP will not recognize
something as location without some form of context.