### PR TITLE
FileThingpediaClient: switch to loading ThingTalk instead of JSON

### DIFF
--- a/I18N.md
+++ b/I18N.md
@@ -63,7 +63,7 @@ genie download-dataset -o dataset.en-US.tt
 We recommend you clean the dataset before translating. The downloaded dataset includes not only utterances to translate but also `preprocessed`, `id`, `click_count`, and `like_count`. You will definitely feel better if you don't see these extra information when translating the utterances.
 
 ```bash
-genie dataset -i dataset.en-US.tt -o dataset.raw.en-US.tt -l zh-tw --thingpedia thingpedia.json --actions clean
+genie dataset -i dataset.en-US.tt -o dataset.raw.en-US.tt -l zh-tw --thingpedia thingpedia.tt --actions clean
 ```
 
 Modify the language tag in the first line of the dataset. Note that the language tag here does not equal to the locale. E.g. English is "en"; Chinese is "zh"; etc. The language tag will be recognized by the Almond tokenizer later.
@@ -93,7 +93,7 @@ export GENIE_USE_TOKENIZER=local
 After the Almond tokenizer listening on http://localhost:8888, you can preprocess the sentences.
 
 ```bash
-genie dataset -i dataset.raw.zh-tw.tt -o dataset.zh-tw.tt -l zh-tw --thingpedia thingpedia.json --actions preprocess
+genie dataset -i dataset.raw.zh-tw.tt -o dataset.zh-tw.tt -l zh-tw --thingpedia thingpedia.tt --actions preprocess
 ```
 
 The Almond tokenizer does not support Traditional Chinese and perform poorly on it. So our workaround is to convert sentences from Tranditional Chinese to Simplified Chinese first, segment them, and convert them back.
@@ -103,5 +103,7 @@ The Almond tokenizer does not support Traditional Chinese and perform poorly on 
 Then you can start to synthesize sentences from your translated dataset!
 
 ```bash
-genie generate --locale zh-tw --template languages/zh-tw/thingtalk.genie --thingpedia thingpedia.json --dataset dataset.zh-tw.tt -o synthetic.zh-tw.tsv
+genie generate --locale zh-tw --template languages/zh-tw/thingtalk.genie
+  --thingpedia thingpedia.tt --entities entities.json --dataset dataset.zh-tw.tt
+  -o synthetic.zh-tw.tsv
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Please refer to the almond-tokenizer documentation for details.
 To synthesize a set of sentences, use:
 
 ```
-genie generate --locale en --template template.genie --thingpedia thingpedia.json --dataset dataset.tt -o synthesized.tsv
+genie generate --locale en --template template.genie
+  --thingpedia thingpedia.tt --entities entities.json --dataset dataset.tt
+  -o synthesized.tsv
 ```
 
 The `--template` flag can be used to point to a template file definining the construct templates,
@@ -87,7 +89,7 @@ The `--thingpedia` flag should point to a Thingpedia snapshot file,
 which defines the types and signatures of the primitives to use. You can download a snapshot file
 for the reference Thingpedia with:
 ```
-genie download-snapshot [--snapshot <snapshot_id>] -o thingpedia.json
+genie download-snapshot [--snapshot <snapshot_id>] -o thingpedia.tt --entities entities.json
 ```
 If you omit the `--snapshot` parameter, the latest content of Thingpedia will be used.
 
@@ -170,7 +172,7 @@ is not necessary. The script will still perform automatic validation.
 After creating the synthesized and paraphrase datasets, use the following command to augment the dataset
 and apply parameter replacement:
 ```
-genie augment paraphrasing.tsv synthesized.tsv --thingpedia thingpedia.json --ppdb compiled-ppdb.bin --parameter-datasets parameter-datasets.tsv
+genie augment paraphrasing.tsv synthesized.tsv --thingpedia thingpedia.tt --ppdb compiled-ppdb.bin --parameter-datasets parameter-datasets.tsv
  -o everything.tsv
  [--ppdb-synthetic-fraction FRACTION] [--ppdb-paraphrase-fraction FRACTION]
  [--quoted-fraction FRACTION]
@@ -239,7 +241,7 @@ scores and error analysis.
 
 To evaluate on the test set, use:
 ```
-genie evaluate-server --url file://<OUTPUTDIR> --thingpedia thingpedia.json test.tsv
+genie evaluate-server --url file://<OUTPUTDIR> --thingpedia thingpedia.tt test.tsv
 ```
 You can pass `--debug` for additional error analysis, and `--csv` to generate machine parseable
 output.
@@ -251,7 +253,7 @@ genie predict --url file://<OUTPUTDIR> -o predictions.tsv test.tsv
 
 The prediction file can also be evaluated as:
 ```
-genie evaluate-server --thingpedia thingpedia.json --dataset test.tsv --predictions predictions.tsv
+genie evaluate-server --thingpedia thingpedia.tt --dataset test.tsv --predictions predictions.tsv
 ```
 Sentence IDs in the test.tsv file and the prediction file must match, or an error occurs.
 

--- a/test/cmdline.sh
+++ b/test/cmdline.sh
@@ -24,20 +24,22 @@ node $srcdir/tool/genie.js --help
 node $srcdir/tool/genie.js download-snapshot --help
 node $srcdir/tool/genie.js download-dataset --help
 
-node $srcdir/tool/genie.js download-snapshot -o thingpedia.json --snapshot -1
+node $srcdir/tool/genie.js download-snapshot -o thingpedia.tt --entities entities.json --snapshot -1
 node $srcdir/tool/genie.js download-dataset -o dataset.tt
 
-node $srcdir/tool/genie.js dataset -i dataset.tt -o foo.tt --thingpedia thingpedia.json --actions clean
+node $srcdir/tool/genie.js dataset -i dataset.tt -o foo.tt --thingpedia thingpedia.tt --actions clean
 
 # generate
 node $srcdir/tool/genie.js generate --help
-node $srcdir/tool/genie.js generate --maxdepth 2 --thingpedia thingpedia.json --dataset dataset.tt \
+node $srcdir/tool/genie.js generate --maxdepth 2 \
+  --thingpedia thingpedia.tt --entities entities.json --dataset dataset.tt \
   --template $srcdir/languages/en/thingtalk.genie -o /dev/null -l en
 
 # generate-contextual
 node $srcdir/tool/genie.js extract-contexts -l en-US -o contexts.txt \
-   --thingpedia thingpedia.json $srcdir/test/data/synthetic.tsv
-node $srcdir/tool/genie.js generate-contextual --maxdepth 3 --thingpedia thingpedia.json --dataset dataset.tt \
+   --thingpedia thingpedia.tt $srcdir/test/data/synthetic.tsv
+node $srcdir/tool/genie.js generate-contextual --maxdepth 3 \
+   --thingpedia thingpedia.tt --entities entities.json --dataset dataset.tt \
    --template $srcdir/languages/en/contextual.genie -o /dev/null -l en contexts.txt
 node $srcdir/tool/genie.js contextualize -o /dev/null -l en --context contexts.txt $srcdir/test/data/synthetic.tsv
 
@@ -53,12 +55,12 @@ diff -u $srcdir/test/data/expected-mturk-paraphrasing.csv mturk-paraphrasing.csv
 # time passes...
 
 # make validation hits
-node $srcdir/tool/genie.js mturk-make-validation-hits -o mturk-validation.csv --thingpedia thingpedia.json < $srcdir/test/data/paraphrasing-results.csv
+node $srcdir/tool/genie.js mturk-make-validation-hits -o mturk-validation.csv --thingpedia thingpedia.tt < $srcdir/test/data/paraphrasing-results.csv
 diff -u $srcdir/test/data/expected-mturk-validation.csv mturk-validation.csv
 
 # more time passes...
 
-node $srcdir/tool/genie.js mturk-validate -o paraphrase.tsv -l en-US --thingpedia thingpedia.json \
+node $srcdir/tool/genie.js mturk-validate -o paraphrase.tsv -l en-US --thingpedia thingpedia.tt \
   --paraphrasing-input $srcdir/test/data/paraphrasing-results.csv \
   --validation-input $srcdir/test/data/validation-results.csv \
   --paraphrasing-rejects ./paraphrasing-rejects.csv \
@@ -70,14 +72,14 @@ diff -u $srcdir/test/data/expected-validation-rejects.csv validation-rejects.csv
 
 # now test we can validate without validation results (auto validation only)
 
-node $srcdir/tool/genie.js mturk-validate -o paraphrase.tsv -l en-US --thingpedia thingpedia.json \
+node $srcdir/tool/genie.js mturk-validate -o paraphrase.tsv -l en-US --thingpedia thingpedia.tt \
   --paraphrasing-input $srcdir/test/data/paraphrasing-results.csv \
   --paraphrasing-rejects /dev/null \
   --validation-threshold 0
 diff -u $srcdir/test/data/expected-paraphrase2.tsv paraphrase.tsv
 
 # test that we can skip the reject files
-node $srcdir/tool/genie.js mturk-validate -o paraphrase.tsv -l en-US --thingpedia thingpedia.json \
+node $srcdir/tool/genie.js mturk-validate -o paraphrase.tsv -l en-US --thingpedia thingpedia.tt \
   --paraphrasing-input $srcdir/test/data/paraphrasing-results.csv \
   --validation-input $srcdir/test/data/validation-results.csv \
   --validation-count 3 --validation-threshold 3
@@ -86,7 +88,7 @@ diff -u $srcdir/test/data/expected-paraphrase1.tsv paraphrase.tsv
 # yay we have a dataset, time to augment it...
 
 node $srcdir/tool/genie.js compile-ppdb -o compiled-ppdb.bin $srcdir/test/data/ppdb-2.0-xs-lexical
-node $srcdir/tool/genie.js augment paraphrase.tsv $srcdir/test/data/synthetic.tsv --thingpedia thingpedia.json \
+node $srcdir/tool/genie.js augment paraphrase.tsv $srcdir/test/data/synthetic.tsv --thingpedia thingpedia.tt \
   --ppdb compiled-ppdb.bin --parameter-datasets $srcdir/test/data/parameter-datasets.tsv \
   -o everything.tsv \
   --ppdb-synthetic-fraction 0.5 --ppdb-paraphrase-fraction 1.0 \

--- a/tool/augment.js
+++ b/tool/augment.js
@@ -39,7 +39,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('--parameter-datasets', {
             required: true,
@@ -135,7 +135,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia, args.dataset);
+        const tpClient = new FileThingpediaClient(args);
         const schemaRetriever = new ThingTalk.SchemaRetriever(tpClient, null, args.debug);
         const constProvider = new FileParameterProvider(args.parameter_datasets);
         await constProvider.open();

--- a/tool/dialog-to-contextual.js
+++ b/tool/dialog-to-contextual.js
@@ -133,7 +133,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('input_file', {
             nargs: '+',
@@ -160,7 +160,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia);
+        const tpClient = new FileThingpediaClient(args);
         const schemas = new ThingTalk.SchemaRetriever(tpClient, null, true);
         const tokenizer = TokenizerService.get('local');
 

--- a/tool/evaluate-dialog.js
+++ b/tool/evaluate-dialog.js
@@ -42,7 +42,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('input_file', {
             nargs: '+',
@@ -74,7 +74,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia);
+        const tpClient = new FileThingpediaClient(args);
         const schemas = new ThingTalk.SchemaRetriever(tpClient, null, true);
         const parser = ParserClient.get(args.url, args.locale);
         await parser.start();

--- a/tool/evaluate-file.js
+++ b/tool/evaluate-file.js
@@ -28,7 +28,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('--dataset', {
             required: true,
@@ -71,7 +71,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia);
+        const tpClient = new FileThingpediaClient(args);
         const schemas = new ThingTalk.SchemaRetriever(tpClient, null, true);
 
         const columns = args.contextual ?

--- a/tool/evaluate-server.js
+++ b/tool/evaluate-server.js
@@ -42,7 +42,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('--contextual', {
             nargs: 0,
@@ -80,7 +80,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia);
+        const tpClient = new FileThingpediaClient(args);
         const schemas = new ThingTalk.SchemaRetriever(tpClient, null, true);
         const parser = ParserClient.get(args.url, args.locale);
         await parser.start();

--- a/tool/extract-contexts.js
+++ b/tool/extract-contexts.js
@@ -59,7 +59,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('input_file', {
             nargs: '+',
@@ -87,7 +87,7 @@ module.exports = {
 
     async execute(args) {
         const rng = seedrandom.alea(args.random_seed);
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia, args.dataset);
+        const tpClient = new FileThingpediaClient(args);
         const schemas = new ThingTalk.SchemaRetriever(tpClient, null, !args.debug);
 
         let allprograms = await readAllLines(args.input_file)

--- a/tool/generate-contextual.js
+++ b/tool/generate-contextual.js
@@ -49,7 +49,11 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
+        });
+        parser.addArgument('--entities', {
+            required: true,
+            help: 'Path to JSON file containing entity type definitions.'
         });
         parser.addArgument('--dataset', {
             required: true,
@@ -101,7 +105,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia, args.dataset);
+        const tpClient = new FileThingpediaClient(args);
         const options = {
             rng: seedrandom.alea(args.random_seed),
             locale: args.locale,

--- a/tool/generate.js
+++ b/tool/generate.js
@@ -43,7 +43,11 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
+        });
+        parser.addArgument('--entities', {
+            required: true,
+            help: 'Path to JSON file containing entity type definitions.'
         });
         parser.addArgument('--dataset', {
             required: true,
@@ -95,7 +99,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia, args.dataset);
+        const tpClient = new FileThingpediaClient(args);
         const options = {
             rng: seedrandom.alea(args.random_seed),
             locale: args.locale,

--- a/tool/lib/thingtalk-dataset.js
+++ b/tool/lib/thingtalk-dataset.js
@@ -35,14 +35,14 @@ module.exports = class ThingTalkDataset {
         };
     }
 
-    async read(locale, thingpedia, datasetFile) {
-        const tpClient = new FileThingpediaClient(locale, thingpedia, datasetFile);
-        const dataset = await this._loadDataset(tpClient);
+    async read(locale, thingpedia, dataset) {
+        const tpClient = new FileThingpediaClient({ locale, thingpedia, dataset });
+        const parsed = await this._loadDataset(tpClient);
 
         if (this._options.debug)
-            console.log('Loaded ' + dataset.examples.length + ' templates');
+            console.log('Loaded ' + parsed.examples.length + ' templates');
         this._locale = locale;
-        this._dataset = dataset;
+        this._dataset = parsed;
     }
 
     write(outputFile, callback) {

--- a/tool/manual-annotate.js
+++ b/tool/manual-annotate.js
@@ -15,7 +15,7 @@ const csv = require('csv');
 const readline = require('readline');
 
 const ParserClient = require('./lib/parserclient');
-const TpClient = require('./lib/file_thingpedia_client');
+const FileThingpediaClient = require('./lib/file_thingpedia_client');
 const { DatasetStringifier } = require('../lib/dataset-parsers');
 
 const ThingTalk = require('thingtalk');
@@ -39,7 +39,7 @@ class Trainer extends events.EventEmitter {
 
         this._rl = rl;
 
-        const tpClient = new TpClient(options.locale, options.thingpedia);
+        const tpClient = new FileThingpediaClient(options);
         this._schemas = new ThingTalk.SchemaRetriever(tpClient, null, true);
         this._parser = ParserClient.get(options.server, 'en-US');
 
@@ -259,9 +259,8 @@ module.exports = {
             help: `BGP 47 locale tag of the natural language being processed (defaults to en-US).`
         });
         parser.addArgument('--thingpedia', {
-            required: false,
-            defaultValue: '../thingpedia.json',
-            help: `The path to the thingpedia.json file.`
+            required: true,
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('--server', {
             required: false,

--- a/tool/mturk-make-validation-hits.js
+++ b/tool/mturk-make-validation-hits.js
@@ -145,7 +145,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'Path to JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('--sentences-per-task', {
             required: false,
@@ -184,7 +184,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia, args.dataset);
+        const tpClient = new FileThingpediaClient(args);
         const schemaRetriever = new ThingTalk.SchemaRetriever(tpClient, null, args.debug);
         const tokenizer = TokenizerService.get(process.env.GENIE_USE_TOKENIZER, true);
         const rng = seedrandom.alea(args.random_seed);

--- a/tool/mturk-validate.js
+++ b/tool/mturk-validate.js
@@ -40,7 +40,7 @@ module.exports = {
         });
         parser.addArgument('--thingpedia', {
             required: true,
-            help: 'JSON file containing signature, type and mixin definitions.'
+            help: 'Path to ThingTalk file containing class definitions.'
         });
         parser.addArgument('--paraphrasing-input', {
             required: true,
@@ -102,7 +102,7 @@ module.exports = {
     },
 
     async execute(args) {
-        const tpClient = new FileThingpediaClient(args.locale, args.thingpedia, args.dataset);
+        const tpClient = new FileThingpediaClient(args);
         const schemaRetriever = new ThingTalk.SchemaRetriever(tpClient, null, args.debug);
         const tokenizer = TokenizerService.get(process.env.GENIE_USE_TOKENIZER, true);
 


### PR DESCRIPTION
ThingTalk class files are easier to read and edit by hand, which
makes it easy to apply changes such as adding or removing devices
in a local snapshot. They are also easily greppable, which
makes it easy to figure out which devices are part of an experiment
and which are excluded.

Entities cannot be represented in ThingTalk, so split them
into a separate file.