### PR TITLE
Make it possible to bundle Genie templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 node_modules/
 coverage/
+bundle/
 .nyc_output/
 .idea/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+bundle/%: languages/%/*.genie languages/*.genie languages/*.js
+	mkdir -p $@
+	cp -r languages/$* languages/*.genie languages/*.js $@
+	echo "import '$*/thingtalk.genie';" > $@/index.genie
+	touch $@
+
+bundle/%.zip: bundle/%
+	cd $< ; zip -r ../$*.zip *
+
+all: bundle/en.zip bundle/zh-tw.zip

--- a/languages/ast_manip.js
+++ b/languages/ast_manip.js
@@ -18,7 +18,7 @@ const Type = ThingTalk.Type;
 const { isUnaryTableToTableOp,
         isUnaryStreamToTableOp,
         isUnaryStreamToStreamOp,
-        isUnaryTableToStreamOp } = require('../utils');
+        isUnaryTableToStreamOp } = require('./utils');
 const { notifyAction } = ThingTalk.Generate;
 
 function typeToStringSafe(type) {

--- a/languages/common-parameters.genie
+++ b/languages/common-parameters.genie
@@ -10,7 +10,7 @@
 
 {
 // import the combinator library
-const C = require('../lib/sentence-generator/ast_manip');
+const C = require('./ast_manip');
 }
 
 out_param_Numeric = {

--- a/languages/en/aggregation.genie
+++ b/languages/en/aggregation.genie
@@ -15,10 +15,9 @@
     const Ast = ThingTalk.Ast;
     const Type = ThingTalk.Type;
     const Generate = ThingTalk.Generate;
-    const { clean } = require('../../lib/utils');
 
 // import the combinator library
-    const C = require('../../lib/sentence-generator/ast_manip');
+    const C = require('../ast_manip');
 }
 
 projection_Number = {

--- a/languages/en/bookkeeping.genie
+++ b/languages/en/bookkeeping.genie
@@ -16,7 +16,7 @@ const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 
 function special(specialType) {
     return new Ast.Input.Bookkeeping(new Ast.BookkeepingIntent.Special(specialType));

--- a/languages/en/constants.genie
+++ b/languages/en/constants.genie
@@ -14,10 +14,9 @@ const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
-const { clean } = require('../../lib/utils');
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 }
 
 constant_Number = {

--- a/languages/en/contextual.genie
+++ b/languages/en/contextual.genie
@@ -16,10 +16,9 @@ const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
-const { clean } = require('../../lib/utils');
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 
 function addParamToAction(command, pname, joinArg) {
     let actiontype = command.action.schema.inReq[pname];

--- a/languages/en/filters.genie
+++ b/languages/en/filters.genie
@@ -14,10 +14,9 @@ const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
-const { clean } = require('../../lib/utils');
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 }
 
 // generic filters (npp)

--- a/languages/en/parameters.genie
+++ b/languages/en/parameters.genie
@@ -14,10 +14,9 @@ const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
-const { clean } = require('../../lib/utils');
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 }
 
 import '../common-parameters';

--- a/languages/en/stream_tables.genie
+++ b/languages/en/stream_tables.genie
@@ -16,7 +16,7 @@ const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 
 }
 

--- a/languages/en/thingtalk.genie
+++ b/languages/en/thingtalk.genie
@@ -16,7 +16,7 @@ const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 
 }
 

--- a/languages/en/who_questions.genie
+++ b/languages/en/who_questions.genie
@@ -16,7 +16,7 @@ const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 
 }
 

--- a/languages/utils.js
+++ b/languages/utils.js
@@ -1,0 +1,39 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2015-2019 The Board of Trustees of the Leland Stanford Junior University
+//           2019 National Taiwan University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//         Elvis Yu-Jing Lin <r06922068@ntu.edu.tw> <elvisyjlin@gmail.com>
+//
+// See COPYING for details
+"use strict";
+
+module.exports = {
+    isUnaryTableToTableOp(table) {
+        return table.isFilter ||
+            table.isProjection ||
+            table.isCompute ||
+            table.isAlias ||
+            table.isAggregation ||
+            table.isArgMinMax ||
+            table.isSequence ||
+            table.isHistory;
+    },
+    isUnaryStreamToTableOp(table) {
+        return table.isWindow || table.isTimeSeries;
+    },
+    isUnaryStreamToStreamOp(stream) {
+        return stream.isEdgeNew ||
+            stream.isEdgeFilter ||
+            stream.isFilter ||
+            stream.isProjection ||
+            stream.isCompute ||
+            stream.isAlias;
+    },
+    isUnaryTableToStreamOp(stream) {
+        return stream.isMonitor;
+    }
+};

--- a/languages/zh-tw/aggregation.genie
+++ b/languages/zh-tw/aggregation.genie
@@ -15,10 +15,9 @@
     const Ast = ThingTalk.Ast;
     const Type = ThingTalk.Type;
     const Generate = ThingTalk.Generate;
-    const { clean } = require('../../lib/utils');
 
 // import the combinator library
-    const C = require('../../lib/sentence-generator/ast_manip');
+    const C = require('../ast_manip');
 }
 
 projection_Number = {

--- a/languages/zh-tw/constants.genie
+++ b/languages/zh-tw/constants.genie
@@ -14,10 +14,9 @@ const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
-const { clean } = require('../../lib/utils');
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 }
 
 constant_Number = {

--- a/languages/zh-tw/filters.genie
+++ b/languages/zh-tw/filters.genie
@@ -14,10 +14,9 @@ const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
-const { clean } = require('../../lib/utils');
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 }
 
 atom_filter = {

--- a/languages/zh-tw/parameters.genie
+++ b/languages/zh-tw/parameters.genie
@@ -14,10 +14,9 @@ const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
-const { clean } = require('../../lib/utils');
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 }
 
 import '../common-parameters';

--- a/languages/zh-tw/thingtalk.genie
+++ b/languages/zh-tw/thingtalk.genie
@@ -16,7 +16,7 @@ const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
 
 // import the combinator library
-const C = require('../../lib/sentence-generator/ast_manip');
+const C = require('../ast_manip');
 
 }
 

--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -26,7 +26,7 @@ const { clean, makeDummyEntities } = require('../utils');
 
 const $runtime = require('./runtime');
 const importGenie = require('../genie-compiler');
-const { typeToStringSafe } = require('./ast_manip');
+const { typeToStringSafe } = require('../../languages/ast_manip');
 const i18n = require('../i18n');
 
 function identity(x) {


### PR DESCRIPTION
Very soon Almond Cloud will start using developer-provided bundles of Genie templates instead of the templates in this repo.
I originally thought we would move out the templates in a separate `genie-templates` repo that would be easy to bundle, similar to `thingpedia-common-devices`, but that did not really happen and the copy there got stale while development kept happening here.
Instead, we can keep the templates here and add scripts to bundle them to upload to almond-cloud.