### PR TITLE
tokenizer: update to pass the full locale tag (including script/country)

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -96,12 +96,11 @@ class LocalTokenizer {
     }
 
     tokenize(locale, utterance, expect = null) {
-        const languageTag = locale.split('-')[0];
         const reqId = this._nextRequest++;
         return new Promise((resolve, reject) => {
             this._requests.set(reqId, { resolve, reject });
 
-            this._socket.write({ req: reqId, utterance, languageTag, expect });
+            this._socket.write({ req: reqId, utterance, languageTag: locale, expect });
         });
     }
 }


### PR DESCRIPTION
Because now almond-tokenizer can distinguish Simplified/Mainland
Chinese and Traditional/Taiwan Chinese