### PR TITLE
DatasetSplitter: introduce and honor "eval" flag

### DIFF
--- a/lib/dataset_splitter.js
+++ b/lib/dataset_splitter.js
@@ -57,6 +57,7 @@ module.exports = class DatasetSplitter extends Stream.Writable {
         this._rng = options.rng;
         this._locale = options.locale;
         this._evalOnSynthetic = options.evalOnSynthetic;
+        this._useEvalFlag = options.useEvalFlag;
 
         this._train = options.train;
         this._eval = options.eval;
@@ -87,6 +88,28 @@ module.exports = class DatasetSplitter extends Stream.Writable {
         callback();
     }
 
+    /**
+      Check if this example can potentially be used for evaluation.
+
+      If this method returns true, the example is a candidate for sampling
+      in the evaluation sets (validation/test).
+
+      If `useEvalFlag` was passed as option, this uses the `eval` flag
+      exclusively (E flag in TSV format).
+
+      If `useEvalFlag` was not passed (or set to the default false),
+      synthetic (S) and augmented (P) sentences are excluded if `evalOnSynthetic`
+      is false (default). All other sentences are potentially included in the
+      evaluation sets.
+     */
+    _isFlaggedForEval(flags) {
+        if (this._useEvalFlag)
+            return !!flags.eval;
+        if (this._evalOnSynthetic)
+            return true;
+        return !flags.synthetic && !flags.augmented;
+    }
+
     _write(row, encoding, callback) {
         if (this._forDevices.size > 0 && !filterForDevices(this._forDevices, row.target_code)) {
             callback();
@@ -98,7 +121,7 @@ module.exports = class DatasetSplitter extends Stream.Writable {
 
         //console.log(flags, splitKey, this._devtestset);
 
-        if (!this._evalOnSynthetic && (flags.synthetic || flags.augmented)) {
+        if (!this._isFlaggedForEval(flags)) {
             if (splitKey !== undefined && this._devtestset.has(splitKey)) {
                 callback();
                 return;

--- a/lib/flags.js
+++ b/lib/flags.js
@@ -21,13 +21,14 @@ function makeFlags(flags) {
 }
 
 function parseId(ex) {
-    const [, replaced, augmented, contextual, synthetic, id] = /^(R)?(P)?(C)?(S)?(.*)$/.exec(ex.id);
+    const [, replaced, augmented, contextual, synthetic, _eval, id] = /^(R)?(P)?(C)?(S)?(E)?(.*)$/.exec(ex.id);
 
     ex.flags = {
         replaced: !!replaced,
         augmented: !!augmented,
         contextual: !!contextual,
-        synthetic: !!synthetic
+        synthetic: !!synthetic,
+        eval: !!_eval,
     };
     ex.id = id;
 }
@@ -45,6 +46,8 @@ function makeId(ex) {
         prefix += 'C';
     if (ex.flags.synthetic)
         prefix += 'S';
+    if (ex.flags.eval)
+        prefix += 'E';
     return prefix + ex.id;
 }
 


### PR DESCRIPTION
To prevent evaluating on paraphrases when using DatasetSplitter,
there needs a way to mark data that is suitable for evaluation.

Note: in PLDI we did not use DatasetSplitter, and we managed the train & eval sets manually. DatasetSplitter is used by the automatic trainer though.