### PR TITLE
Compare different measurements with different words

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ genie download-dataset -o dataset.tt
 ```
 
 The resulting `synthesized.tsv` file can be used to train directly. To do so, skip to Step 4, Dataset preprocessing. If you wish instead to paraphrase, you'll probably want to restrict the synthesized set
-to paraphrase-friendly construct templates, by passing `--flag-set turking` on the command line.
+to paraphrase-friendly construct templates, by passing `--set-flag turking` on the command line.
 
 NOTE: the `generate` command can require significant amounts of memory. If you experience out of memory,
 it can help to invoke `node` as:

--- a/languages/en/filters.genie
+++ b/languages/en/filters.genie
@@ -54,7 +54,7 @@ atom_filter = {
     p:out_param_Number 'is' ('greater than' | 'higher than' | 'larger than' | 'more than' | 'at least' | 'not less than') x:constant_Number => C.makeFilter($options, p, '>=', x);
     p:out_param_Number 'is' ('smaller than' | 'lower than' | 'less than' | 'at most' | 'not more than') x:constant_Number  => C.makeFilter($options, p, '<=', x);
 
-    p:out_param_Currency 'is' ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    p:out_param_Currency 'is' ('more expensive' | 'more costly' | 'more') 'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     p:out_param_Currency 'is' ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
     p:out_param_Measure_ms 'is' 'longer than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
@@ -109,7 +109,7 @@ edge_filter = {
     p:out_param_Number ('is now' | 'becomes' | 'goes') ('greater than' | 'higher than' | 'larger than' | 'more than' | 'at least' | 'not less than') x:constant_Number => C.makeFilter($options, p, '>=', x);
     p:out_param_Number ('is now' | 'becomes' | 'goes') ('smaller than' | 'lower than' | 'less than' | 'at most' | 'not more than') x:constant_Number  => C.makeFilter($options, p, '<=', x);
 
-    p:out_param_Currency ('is now' | 'becomes' | 'goes') ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    p:out_param_Currency ('is now' | 'becomes' | 'goes') ('more expensive' | 'more costly' | 'more') 'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     p:out_param_Currency ('is now' | 'becomes' | 'goes') ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
     p:out_param_Measure_ms ('is now' | 'becomes' | 'goes') 'longer than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
@@ -220,7 +220,7 @@ with_filter = {
     p:out_param_Number ('greater than' | 'higher than' | 'larger than' | 'more than' | 'at least' | 'not less than') x:constant_Number => C.makeFilter($options, p, '>=', x);
     p:out_param_Number ('smaller than' | 'lower than' | 'less than' | 'at most' | 'not more than') x:constant_Number  => C.makeFilter($options, p, '<=', x);
 
-    p:out_param_Currency ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    p:out_param_Currency ('more expensive' | 'more costly' | 'more') 'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     p:out_param_Currency ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
     p:out_param_Measure_ms 'longer than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
@@ -251,7 +251,7 @@ with_filter = {
     ('greater' | 'higher' | 'larger' | 'more') p:out_param_Number 'than' x:constant_Number => C.makeFilter($options, p, '>=', x);
     ('smaller' | 'lower' | 'less') p:out_param_Number 'than' x:constant_Number  => C.makeFilter($options, p, '<=', x);
 
-    ('more expensive' | 'more costly' | 'more'）p:out_param_Currency 'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    ('more expensive' | 'more costly' | 'more') p:out_param_Currency 'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     ('less expensive' | 'cheaper' | 'less') p:out_param_Currency 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
     'longer' p:out_param_Measure_ms 'than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);

--- a/languages/en/filters.genie
+++ b/languages/en/filters.genie
@@ -48,8 +48,32 @@ atom_filter = {
             return C.makeFilter($options, p, '==', x, true);
     };
 
-    p:the_out_param_Numeric 'is' ('greater' | 'higher' | 'bigger' | 'more' | 'at least' | 'not less than') x:constant_Numeric => C.makeFilter($options, p, '>=', x);
-    p:the_out_param_Numeric 'is' ('smaller' | 'lower' | 'less' | 'at most' | 'not more than') x:constant_Numeric             => C.makeFilter($options, p, '<=', x);
+    //p:the_out_param_Numeric 'is' ('greater' | 'higher' | 'bigger' | 'more' | 'at least' | 'not less than') x:constant_Numeric => C.makeFilter($options, p, '>=', x);
+    //p:the_out_param_Numeric 'is' ('smaller' | 'lower' | 'less' | 'at most' | 'not more than') x:constant_Numeric             => C.makeFilter($options, p, '<=', x);
+    
+    p:out_param_Number 'is' ('greater than' | 'higher than' | 'larger than' | 'more than' | 'at least' | 'not less than') x:constant_Number => C.makeFilter($options, p, '>=', x);
+    p:out_param_Number 'is' ('smaller than' | 'lower than' | 'less than' | 'at most' | 'not more than') x:constant_Number  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Currency 'is' ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    p:out_param_Currency 'is' ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_ms 'is' 'later than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_ms 'is' ('sooner' | 'earlier') 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_byte 'is' ('larger' | 'more') 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_byte 'is' ('smaller' | 'less') 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_kg 'is' ('heavier' | 'larger') 'than' x:constant_Measure_kg => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_kg 'is' ('lighter' | 'smaller') 'than' x:constant_Measure_kg  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_C 'is' ('hotter' | 'higher') 'than' x:constant_Measure_C => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_C 'is' ('cooler' | 'colder' | 'lower') 'than' x:constant_Measure_C  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_m 'is' ('farther' | 'more distant' | 'longer') 'than' x:constant_Measure_m => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_m 'is' ('nearer' | 'closer' | 'shorter') 'than' x:constant_Measure_m  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_mps 'is' ('faster' | 'quicker' | 'speedier') 'than' x:constant_Measure_mps => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_mps 'is' ('slower' | 'more slowly') 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
 
     !turking {
         p:the_out_param_Date 'is' ('after' | 'later than') x:constant_Date => C.makeFilter($options, p, '>=', x);
@@ -77,8 +101,32 @@ edge_filter = {
         else
             return C.makeFilter($options, p, '==', x);
     };
-    p:the_out_param_Numeric ('is now greater than' | 'becomes greater than' | 'becomes higher than' | 'goes above' | 'increases above' | 'goes over' | 'rises above') x:constant_Numeric => C.makeFilter($options, p, '>=', x);
-    p:the_out_param_Numeric ('is now smaller than' | 'becomes smaller than' | 'becomes lower than' | 'goes below' | 'decreases below' | 'goes under') x:constant_Numeric => C.makeFilter($options, p, '<=', x);
+    //p:the_out_param_Numeric ('is now greater than' | 'becomes greater than' | 'becomes higher than' | 'goes above' | 'increases above' | 'goes over' | 'rises above') x:constant_Numeric => C.makeFilter($options, p, '>=', x);
+    //p:the_out_param_Numeric ('is now smaller than' | 'becomes smaller than' | 'becomes lower than' | 'goes below' | 'decreases below' | 'goes under') x:constant_Numeric => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Number ('is now' | 'becomes' | 'goes') ('greater than' | 'higher than' | 'larger than' | 'more than' | 'at least' | 'not less than') x:constant_Number => C.makeFilter($options, p, '>=', x);
+    p:out_param_Number ('is now' | 'becomes' | 'goes') ('smaller than' | 'lower than' | 'less than' | 'at most' | 'not more than') x:constant_Number  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Currency ('is now' | 'becomes' | 'goes') ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    p:out_param_Currency ('is now' | 'becomes' | 'goes') ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_ms ('is now' | 'becomes' | 'goes') 'later than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_ms ('is now' | 'becomes' | 'goes') ('sooner' | 'earlier') 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_byte ('is now' | 'becomes' | 'goes') ('larger' | 'more') 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_byte ('is now' | 'becomes' | 'goes') ('smaller' | 'less') 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_kg ('is now' | 'becomes' | 'goes') ('heavier' | 'larger') 'than' x:constant_Measure_kg => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_kg ('is now' | 'becomes' | 'goes') ('lighter' | 'smaller') 'than' x:constant_Measure_kg  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_C ('is now' | 'becomes' | 'goes') ('hotter' | 'higher') 'than' x:constant_Measure_C => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_C ('is now' | 'becomes' | 'goes') ('cooler' | 'colder' | 'lower') 'than' x:constant_Measure_C  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_m ('is now' | 'becomes' | 'goes') ('farther' | 'more distant' | 'longer') 'than' x:constant_Measure_m => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_m ('is now' | 'becomes' | 'goes') ('nearer' | 'closer' | 'shorter') 'than' x:constant_Measure_m  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_mps ('is now' | 'becomes' | 'goes') ('faster' | 'quicker' | 'speedier') 'than' x:constant_Measure_mps => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_mps ('is now' | 'becomes' | 'goes') ('slower' | 'more slowly') 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
 }
 
 either_filter = {
@@ -160,10 +208,57 @@ with_filter = {
     !turking p:out_param_String ('containing' | 'including') x:constant_String => C.makeFilter($options, p, '=~', x);
     !turking x:constant_String ('in the' | 'in its' | 'in their') p:out_param_String => C.makeFilter($options, p, '=~', x);
 
-    p:out_param_Numeric ('higher' | 'larger' | 'bigger') 'than' x:constant_Numeric => C.makeFilter($options, p, '>=', x);
-    p:out_param_Numeric ('smaller' | 'lower') 'than' x:constant_Numeric => C.makeFilter($options, p, '<=', x);
-    ('higher' | 'larger' | 'bigger') p:out_param_Numeric 'than' x:constant_Numeric => C.makeFilter($options, p, '>=', x);
-    ('smaller' | 'lower') p:out_param_Numeric 'than' x:constant_Numeric => C.makeFilter($options, p, '<=', x);
+    //p:out_param_Numeric ('higher' | 'larger' | 'bigger') 'than' x:constant_Numeric => C.makeFilter($options, p, '>=', x);
+    //p:out_param_Numeric ('smaller' | 'lower') 'than' x:constant_Numeric => C.makeFilter($options, p, '<=', x);
+    p:out_param_Number ('greater than' | 'higher than' | 'larger than' | 'more than' | 'at least' | 'not less than') x:constant_Number => C.makeFilter($options, p, '>=', x);
+    p:out_param_Number ('smaller than' | 'lower than' | 'less than' | 'at most' | 'not more than') x:constant_Number  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Currency ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    p:out_param_Currency ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_ms 'later than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_ms ('sooner' | 'earlier') 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_byte ('larger' | 'more') 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_byte ('smaller' | 'less') 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_kg ('heavier' | 'larger') 'than' x:constant_Measure_kg => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_kg ('lighter' | 'smaller') 'than' x:constant_Measure_kg  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_C ('hotter' | 'higher') 'than' x:constant_Measure_C => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_C ('cooler' | 'colder' | 'lower') 'than' x:constant_Measure_C  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_m ('farther' | 'more distant' | 'longer') 'than' x:constant_Measure_m => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_m ('nearer' | 'closer' | 'shorter') 'than' x:constant_Measure_m  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Measure_mps ('faster' | 'quicker' | 'speedier') 'than' x:constant_Measure_mps => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_mps ('slower' | 'more slowly') 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
+
+    //('higher' | 'larger' | 'bigger') p:out_param_Numeric 'than' x:constant_Numeric => C.makeFilter($options, p, '>=', x);
+    //('smaller' | 'lower') p:out_param_Numeric 'than' x:constant_Numeric => C.makeFilter($options, p, '<=', x);
+    ('greater' | 'higher' | 'larger' | 'more') p:out_param_Number 'than' x:constant_Number => C.makeFilter($options, p, '>=', x);
+    ('smaller' | 'lower' | 'less') p:out_param_Number 'than' x:constant_Number  => C.makeFilter($options, p, '<=', x);
+
+    ('more expensive' | 'more costly' | 'more'）p:out_param_Currency 'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
+    ('less expensive' | 'cheaper' | 'less') p:out_param_Currency 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
+
+    'later' p:out_param_Measure_ms 'than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    ('sooner' | 'earlier') p:out_param_Measure_ms 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+
+    ('larger' | 'more') p:out_param_Measure_byte 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
+    ('smaller' | 'less') p:out_param_Measure_byte 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
+
+    ('heavier' | 'larger') p:out_param_Measure_kg 'than' x:constant_Measure_kg => C.makeFilter($options, p, '>=', x);
+    ('lighter' | 'smaller') p:out_param_Measure_kg 'than' x:constant_Measure_kg  => C.makeFilter($options, p, '<=', x);
+
+    ('hotter' | 'higher') p:out_param_Measure_C 'than' x:constant_Measure_C => C.makeFilter($options, p, '>=', x);
+    ('cooler' | 'colder' | 'lower') p:out_param_Measure_C 'than' x:constant_Measure_C  => C.makeFilter($options, p, '<=', x);
+
+    ('farther' | 'more distant' | 'longer') p:out_param_Measure_m 'than' x:constant_Measure_m => C.makeFilter($options, p, '>=', x);
+    ('nearer' | 'closer' | 'shorter') p:out_param_Measure_m 'than' x:constant_Measure_m  => C.makeFilter($options, p, '<=', x);
+
+    ('faster' | 'quicker' | 'speedier') p:out_param_Measure_mps 'than' x:constant_Measure_mps => C.makeFilter($options, p, '>=', x);
+    ('slower' | 'more slowly') p:out_param_Measure_mps 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
 
     !turking {
         f:range_with_filter => f;

--- a/languages/en/filters.genie
+++ b/languages/en/filters.genie
@@ -57,8 +57,8 @@ atom_filter = {
     p:out_param_Currency 'is' ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     p:out_param_Currency 'is' ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
-    p:out_param_Measure_ms 'is' 'later than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
-    p:out_param_Measure_ms 'is' ('sooner' | 'earlier') 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+    p:out_param_Measure_ms 'is' 'longer than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_ms 'is' 'shorter than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
 
     p:out_param_Measure_byte 'is' ('larger' | 'more') 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
     p:out_param_Measure_byte 'is' ('smaller' | 'less') 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
@@ -76,8 +76,10 @@ atom_filter = {
     p:out_param_Measure_mps 'is' ('slower' | 'more slowly') 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
 
     !turking {
-        p:the_out_param_Date 'is' ('after' | 'later than') x:constant_Date => C.makeFilter($options, p, '>=', x);
-        p:the_out_param_Date 'is' ('before' | 'earlier than') x:constant_Date => C.makeFilter($options, p, '<=', x);
+        p:out_param_Date 'is' ('after' | 'later than') x:constant_Date => C.makeFilter($options, p, '>=', x);
+        p:out_param_Date 'is' ('before' | 'earlier than' | 'sooner than') x:constant_Date => C.makeFilter($options, p, '<=', x);
+        p:out_param_Time 'is' ('after' | 'later than') x:constant_Time => C.makeFilter($options, p, '>=', x);
+        p:out_param_Time 'is' ('before' | 'earlier than' | 'sooner than') x:constant_Time => C.makeFilter($options, p, '<=', x);
     }
 
     // there are too few arrays, so keep both
@@ -110,8 +112,8 @@ edge_filter = {
     p:out_param_Currency ('is now' | 'becomes' | 'goes') ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     p:out_param_Currency ('is now' | 'becomes' | 'goes') ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
-    p:out_param_Measure_ms ('is now' | 'becomes' | 'goes') 'later than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
-    p:out_param_Measure_ms ('is now' | 'becomes' | 'goes') ('sooner' | 'earlier') 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+    p:out_param_Measure_ms ('is now' | 'becomes' | 'goes') 'longer than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_ms ('is now' | 'becomes' | 'goes') 'shorter than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
 
     p:out_param_Measure_byte ('is now' | 'becomes' | 'goes') ('larger' | 'more') 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
     p:out_param_Measure_byte ('is now' | 'becomes' | 'goes') ('smaller' | 'less') 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
@@ -127,6 +129,11 @@ edge_filter = {
 
     p:out_param_Measure_mps ('is now' | 'becomes' | 'goes') ('faster' | 'quicker' | 'speedier') 'than' x:constant_Measure_mps => C.makeFilter($options, p, '>=', x);
     p:out_param_Measure_mps ('is now' | 'becomes' | 'goes') ('slower' | 'more slowly') 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
+
+    p:out_param_Date ('is now' | 'becomes' | 'goes') ('after' | 'later than') x:constant_Date => C.makeFilter($options, p, '>=', x);
+    p:out_param_Date ('is now' | 'becomes' | 'goes') ('before' | 'earlier than' | 'sooner than') x:constant_Date => C.makeFilter($options, p, '<=', x);
+    p:out_param_Time ('is now' | 'becomes' | 'goes') ('after' | 'later than') x:constant_Time => C.makeFilter($options, p, '>=', x);
+    p:out_param_Time ('is now' | 'becomes' | 'goes') ('before' | 'earlier than' | 'sooner than') x:constant_Time => C.makeFilter($options, p, '<=', x);
 }
 
 either_filter = {
@@ -216,8 +223,8 @@ with_filter = {
     p:out_param_Currency ('more expensive' | 'more costly' | 'more'）'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     p:out_param_Currency ('less expensive' | 'cheaper' | 'less') 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
-    p:out_param_Measure_ms 'later than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
-    p:out_param_Measure_ms ('sooner' | 'earlier') 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+    p:out_param_Measure_ms 'longer than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    p:out_param_Measure_ms 'shorter than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
 
     p:out_param_Measure_byte ('larger' | 'more') 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
     p:out_param_Measure_byte ('smaller' | 'less') 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
@@ -234,6 +241,11 @@ with_filter = {
     p:out_param_Measure_mps ('faster' | 'quicker' | 'speedier') 'than' x:constant_Measure_mps => C.makeFilter($options, p, '>=', x);
     p:out_param_Measure_mps ('slower' | 'more slowly') 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
 
+    p:out_param_Date ('after' | 'later than') x:constant_Date => C.makeFilter($options, p, '>=', x);
+    p:out_param_Date ('before' | 'earlier than' | 'sooner than') x:constant_Date => C.makeFilter($options, p, '<=', x);
+    p:out_param_Time ('after' | 'later than') x:constant_Time => C.makeFilter($options, p, '>=', x);
+    p:out_param_Time ('before' | 'earlier than' | 'sooner than') x:constant_Time => C.makeFilter($options, p, '<=', x);
+
     //('higher' | 'larger' | 'bigger') p:out_param_Numeric 'than' x:constant_Numeric => C.makeFilter($options, p, '>=', x);
     //('smaller' | 'lower') p:out_param_Numeric 'than' x:constant_Numeric => C.makeFilter($options, p, '<=', x);
     ('greater' | 'higher' | 'larger' | 'more') p:out_param_Number 'than' x:constant_Number => C.makeFilter($options, p, '>=', x);
@@ -242,8 +254,8 @@ with_filter = {
     ('more expensive' | 'more costly' | 'more'）p:out_param_Currency 'than' x:constant_Currency => C.makeFilter($options, p, '>=', x);
     ('less expensive' | 'cheaper' | 'less') p:out_param_Currency 'than' x:constant_Currency  => C.makeFilter($options, p, '<=', x);
 
-    'later' p:out_param_Measure_ms 'than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
-    ('sooner' | 'earlier') p:out_param_Measure_ms 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
+    'longer' p:out_param_Measure_ms 'than' x:constant_Measure_ms => C.makeFilter($options, p, '>=', x);
+    'shorter' p:out_param_Measure_ms 'than' x:constant_Measure_ms  => C.makeFilter($options, p, '<=', x);
 
     ('larger' | 'more') p:out_param_Measure_byte 'than' x:constant_Measure_byte => C.makeFilter($options, p, '>=', x);
     ('smaller' | 'less') p:out_param_Measure_byte 'than' x:constant_Measure_byte  => C.makeFilter($options, p, '<=', x);
@@ -259,6 +271,11 @@ with_filter = {
 
     ('faster' | 'quicker' | 'speedier') p:out_param_Measure_mps 'than' x:constant_Measure_mps => C.makeFilter($options, p, '>=', x);
     ('slower' | 'more slowly') p:out_param_Measure_mps 'than' x:constant_Measure_mps  => C.makeFilter($options, p, '<=', x);
+
+    'later' p:out_param_Date 'than' x:constant_Date => C.makeFilter($options, p, '>=', x);
+    ('earlier' | 'sooner') p:out_param_Date 'than' x:constant_Date => C.makeFilter($options, p, '<=', x);
+    'later' p:out_param_Time 'than' x:constant_Time => C.makeFilter($options, p, '>=', x);
+    ('earlier' | 'sooner') p:out_param_Time 'than' x:constant_Time => C.makeFilter($options, p, '<=', x);
 
     !turking {
         f:range_with_filter => f;

--- a/languages/en/stream_tables.genie
+++ b/languages/en/stream_tables.genie
@@ -158,7 +158,7 @@ arg_min_max_table = {
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
     };
 
-    t:complete_table ('with' | 'which has') 'the latest' p:out_param_Measure_ms => {
+    t:complete_table ('with' | 'which has') 'the' ('longest' | 'most lasting') p:out_param_Measure_ms => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
         if (!t.schema.is_list || t.isIndex)
@@ -167,7 +167,7 @@ arg_min_max_table = {
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
     };
 
-    t:complete_table ('with' | 'which has') 'the' ('soonest' | 'earliest') p:out_param_Measure_ms => {
+    t:complete_table ('with' | 'which has') 'the shortest' p:out_param_Measure_ms => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
         if (!t.schema.is_list || t.isIndex)
@@ -259,6 +259,40 @@ arg_min_max_table = {
 
     t:complete_table ('with' | 'which has') 'the' ('slowest' | 'most slowly') p:out_param_Measure_mps => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
+            return null;
+        if (!t.schema.is_list || t.isIndex)
+            return null;
+        const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
+        return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
+    };
+
+    t:complete_table ('with' | 'which has') 'the latest' p:out_param_Date => {
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isDate())
+            return null;
+        if (!t.schema.is_list || t.isIndex)
+            return null;
+        const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
+        return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
+    };
+    t:complete_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Date => {
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isDate())
+            return null;
+        if (!t.schema.is_list || t.isIndex)
+            return null;
+        const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
+        return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
+    };
+
+    t:complete_table ('with' | 'which has') 'the latest' p:out_param_Time => {
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isTime())
+            return null;
+        if (!t.schema.is_list || t.isIndex)
+            return null;
+        const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
+        return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
+    };
+    t:complete_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Time => {
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isTime())
             return null;
         if (!t.schema.is_list || t.isIndex)
             return null;

--- a/languages/en/stream_tables.genie
+++ b/languages/en/stream_tables.genie
@@ -125,7 +125,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('maximum' | 'highest') p:out_param_Number => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex) //avoid conflict with primitives
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -134,7 +134,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('minimum' | 'lowest') p:out_param_Number => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -143,7 +143,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('most costly' | 'most expensive' | 'maximum') p:out_param_Currency => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -152,7 +152,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('least costly'| 'cheapest' | 'minimum') p:out_param_Currency => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -161,7 +161,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the latest' p:out_param_Measure_ms => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -170,7 +170,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('soonest' | 'earliest') p:out_param_Measure_ms => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -179,7 +179,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('maximum' | 'largest') p:out_param_Measure_byte => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -188,7 +188,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('minimum' | 'smallest') p:out_param_Measure_byte => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -197,7 +197,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('heaviest' | 'largest' | 'maximum') p:out_param_Measure_kg => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -206,7 +206,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('lightest' | 'smallest' | 'minimum') p:out_param_Measure_kg => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -215,7 +215,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('hottest' | 'highest' | 'maximum') p:out_param_Measure_C => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -224,25 +224,25 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('coolest' | 'lowest' | 'minimum') p:out_param_Measure_C => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
     };
 
-    t:complete_table ('with' | 'which has') 'the' ('farthest' | 'most distant') p:out_param_Measure_m => {
+    t:complete_table ('with' | 'which has') 'the' ('farthest' | 'most distant' | 'longest') p:out_param_Measure_m => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
     };
 
-    t:complete_table ('with' | 'which has') 'the' ('nearest' | 'closest') p:out_param_Measure_m => {
+    t:complete_table ('with' | 'which has') 'the' ('nearest' | 'closest' | 'shortest') p:out_param_Measure_m => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -251,7 +251,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('fastest' | 'quickest' | 'speediest') p:out_param_Measure_mps => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'desc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
@@ -260,7 +260,7 @@ arg_min_max_table = {
     t:complete_table ('with' | 'which has') 'the' ('slowest' | 'most slowly') p:out_param_Measure_mps => {
         if (!t.schema.out[p.name] || !t.schema.out[p.name].isNumeric())
             return null;
-        if (!t.schema.is_list)
+        if (!t.schema.is_list || t.isIndex)
             return null;
         const t_sort = new Ast.Table.Sort(t, p.name, 'asc', t.schema);        
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);

--- a/languages/en/stream_tables.genie
+++ b/languages/en/stream_tables.genie
@@ -267,7 +267,7 @@ arg_min_max_table = {
     };
 
     t:complete_table ('with' | 'which has') 'the latest' p:out_param_Date => {
-        if (!t.schema.out[p.name] || !t.schema.out[p.name].isDate())
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isDate)
             return null;
         if (!t.schema.is_list || t.isIndex)
             return null;
@@ -275,7 +275,7 @@ arg_min_max_table = {
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
     };
     t:complete_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Date => {
-        if (!t.schema.out[p.name] || !t.schema.out[p.name].isDate())
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isDate)
             return null;
         if (!t.schema.is_list || t.isIndex)
             return null;
@@ -284,7 +284,7 @@ arg_min_max_table = {
     };
 
     t:complete_table ('with' | 'which has') 'the latest' p:out_param_Time => {
-        if (!t.schema.out[p.name] || !t.schema.out[p.name].isTime())
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isTime)
             return null;
         if (!t.schema.is_list || t.isIndex)
             return null;
@@ -292,7 +292,7 @@ arg_min_max_table = {
         return new Ast.Table.Index(t_sort, [new Ast.Value.Number(1)], t.schema);
     };
     t:complete_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Time => {
-        if (!t.schema.out[p.name] || !t.schema.out[p.name].isTime())
+        if (!t.schema.out[p.name] || !t.schema.out[p.name].isTime)
             return null;
         if (!t.schema.is_list || t.isIndex)
             return null;


### PR DESCRIPTION
Current filters treat all numeric measurements the same: use 'greater/higher/bigger/more' to denote A>B. But different measurement should use different words, e.g., 'more expensive' for out_param_Currency and 'faster' for out_param_Measure_mps.

Besides, we should use 'long/short' for out_param_Measure_ms (which denotes a period of time), 'early/late' for out_param_Date and out_param_Time (which denotes a point of time).