### PR TITLE
parallelize: close the message port when done

### DIFF
--- a/lib/parallelize-worker.js
+++ b/lib/parallelize-worker.js
@@ -38,7 +38,10 @@ const output = new Stream.Writable({
     },
     final(callback) {
         parentPort.postMessage({ data: undefined, end: true });
-        callback();
+        process.nextTick(() => {
+            parentPort.close();
+            callback();
+        });
     }
 });
 

--- a/tool/generate-contextual.js
+++ b/tool/generate-contextual.js
@@ -15,6 +15,7 @@ const argparse = require('argparse');
 const { DatasetStringifier } = require('../lib/dataset-parsers');
 const { maybeCreateReadStream, readAllLines } = require('./lib/argutils');
 const parallelize = require('../lib/parallelize');
+const StreamUtils = require('../lib/stream-utils');
 
 class ActionSetFlag extends argparse.Action {
     call(parser, namespace, values) {
@@ -114,10 +115,10 @@ module.exports = {
 
         delete args.input_file;
         delete args.output;
-        const output = inputFile
+        inputFile
             .pipe(parallelize(args.parallelize, require.resolve('./workers/generate-contextual-worker.js'), args))
             .pipe(new DatasetStringifier())
             .pipe(outputFile);
-        output.on('finish', () => process.exit());
+        await StreamUtils.waitFinish(outputFile);
     }
 };


### PR DESCRIPTION
Otherwise, we leak the resource, which prevents the process from
exiting. In the tool, we hacked around with an explicit process.exit(),
but we cannot do that in the server, so fix it properly.