### PR TITLE
Wip/cardiology intervals

### DIFF
--- a/languages/en/thingtalk.genie
+++ b/languages/en/thingtalk.genie
@@ -305,7 +305,7 @@ $root = {
         let stream = C.tableToStream(table, null);
         if (!stream)
             return null;
-        return C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction()]));
+        return C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction()]), principal);
     };
     !nofilter ('if' | 'when') filter:atom_filter 'in' table:complete_table ('for' | 'of') principal:constant_Entity__tt__username 'then' ('alert me' | 'tell me' | 'notify me' | 'let me know')  => {
         if (C.hasGetPredicate(filter))
@@ -320,7 +320,7 @@ $root = {
         let stream = C.tableToStream(table, null);
         if (!stream)
             return null;
-        return C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction()]));
+        return C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction()]), principal);
     };
     !nofilter ('alert me' | 'tell me' | 'notify me' | 'let me know') ('if' | 'when') filter:atom_filter 'in' table:complete_table => {
         if (C.hasGetPredicate(filter))

--- a/languages/en/thingtalk.genie
+++ b/languages/en/thingtalk.genie
@@ -292,6 +292,36 @@ $root = {
         // note that we intentionally don't use tableToStream here, because we don't want to introduce edge filters
         return C.makeProgram(new Ast.Statement.Rule(new Ast.Stream.Monitor(proj.table, null, proj.table.schema), [C.notifyAction()]));
     };
+    !nofilter ('alert me' | 'tell me' | 'notify me' | 'let me know') ('if' | 'when') filter:atom_filter 'in' table:complete_table ('for' | 'of') principal:constant_Entity__tt__username => {
+        if (C.hasGetPredicate(filter))
+            return null;
+        if (!table.schema.is_monitorable || !C.checkFilter(table, filter))
+            return null;
+        if ($options.flags.turking && table.schema.is_list)
+            return null;
+        table = C.addFilter(table, filter, $options);
+        if (!table)
+            return null;
+        let stream = C.tableToStream(table, null);
+        if (!stream)
+            return null;
+        return C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction()]));
+    };
+    !nofilter ('if' | 'when') filter:atom_filter 'in' table:complete_table ('for' | 'of') principal:constant_Entity__tt__username 'then' ('alert me' | 'tell me' | 'notify me' | 'let me know')  => {
+        if (C.hasGetPredicate(filter))
+            return null;
+        if (!table.schema.is_monitorable || !C.checkFilter(table, filter))
+            return null;
+        if ($options.flags.turking && table.schema.is_list)
+            return null;
+        table = C.addFilter(table, filter, $options);
+        if (!table)
+            return null;
+        let stream = C.tableToStream(table, null);
+        if (!stream)
+            return null;
+        return C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction()]));
+    };
     !nofilter ('alert me' | 'tell me' | 'notify me' | 'let me know') ('if' | 'when') filter:atom_filter 'in' table:complete_table => {
         if (C.hasGetPredicate(filter))
             return null;
@@ -447,7 +477,6 @@ $root = {
                 ('tell' | 'command' | 'order' | 'request' | 'ask') principal:constant_Entity__tt__username 'to' action:thingpedia_action stream:timer
                 | ('tell' | 'command' | 'order' | 'request' | 'inform') principal:constant_Entity__tt__username 'that' ('he needs' | 'she needs' | 'i need him' | 'i need her') 'to' action:thingpedia_action stream:timer
             ) if complete => C.makeProgram(new Ast.Statement.Rule(stream, [action]), principal);
-            ('tell' | 'command' | 'order' | 'request' | 'ask') principal:constant_Entity__tt__username 'to' ('let me know' | 'inform me' | 'notify me' | 'alert me') stream:timer => C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction('return')]), principal);
         }
     }
 

--- a/languages/en/thingtalk.genie
+++ b/languages/en/thingtalk.genie
@@ -441,6 +441,14 @@ $root = {
             | ('tell' | 'command' | 'order' | 'request' | 'ask') principal:constant_Entity__tt__username 'to send me' table:complete_table
         ) => C.makeProgram(new Ast.Statement.Command(table, [C.notifyAction('return')]), principal);
         ('tell' | 'command' | 'order' | 'request' | 'ask') principal:constant_Entity__tt__username 'to' ('let me know' | 'inform me' | 'notify me' | 'alert me') stream:stream => C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction('return')]), principal);
+
+        ?extended_timers {
+            (
+                ('tell' | 'command' | 'order' | 'request' | 'ask') principal:constant_Entity__tt__username 'to' action:thingpedia_action stream:timer
+                | ('tell' | 'command' | 'order' | 'request' | 'inform') principal:constant_Entity__tt__username 'that' ('he needs' | 'she needs' | 'i need him' | 'i need her') 'to' action:thingpedia_action stream:timer
+            ) if complete => C.makeProgram(new Ast.Statement.Rule(stream, [action]), principal);
+            ('tell' | 'command' | 'order' | 'request' | 'ask') principal:constant_Entity__tt__username 'to' ('let me know' | 'inform me' | 'notify me' | 'alert me') stream:timer => C.makeProgram(new Ast.Statement.Rule(stream, [C.notifyAction('return')]), principal);
+        }
     }
 
     // policies

--- a/languages/en/timers.genie
+++ b/languages/en/timers.genie
@@ -349,7 +349,7 @@ when_brushing_teeth = {
 
 on = {
   'on' => 'on';
-  'when it\'s' => 'when it\'s';
+  'when it \'s' => 'when it \'s';
   'when it is' => 'when it is';
 }
 
@@ -380,8 +380,8 @@ timer = {
             optional_once each interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, null, TIMER_SCHEMA);
             once_per_day => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
             // twice_per_day and thrice_per_day still need to be AtTimer until we can explicitly set the frequency param in Timer
-            twice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
-            thrice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_NOON, TIME_EVENING], null, AT_TIMER_SCHEMA);
+            // twice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
+            // thrice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_NOON, TIME_EVENING], null, AT_TIMER_SCHEMA);
             optional_once each 'year' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'year'), null, TIMER_SCHEMA);
             optional_once each 'month' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'mon'), null, TIMER_SCHEMA);
             optional_once each 'week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), null, TIMER_SCHEMA);

--- a/languages/en/timers.genie
+++ b/languages/en/timers.genie
@@ -347,6 +347,12 @@ when_brushing_teeth = {
   'after i brush my teeth' => 'after i brush my teeth';
 }
 
+on = {
+  'on' => 'on';
+  'when it\'s' => 'when it\'s';
+  'when it is' => 'when it is';
+}
+
 timer = {
     !extended_timers {
          'every day at' time:constant_Time => new Ast.Stream.AtTimer([time], null, AT_TIMER_SCHEMA);
@@ -372,7 +378,8 @@ timer = {
 
         !turking {
             optional_once each interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, null, TIMER_SCHEMA);
-            once_per_day => new Ast.Stream.AtTimer([TIME_MORNING], null, AT_TIMER_SCHEMA);
+            once_per_day => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
+            // twice_per_day and thrice_per_day still need to be AtTimer until we can explicitly set the frequency param in Timer
             twice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
             thrice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_NOON, TIME_EVENING], null, AT_TIMER_SCHEMA);
             optional_once each 'year' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'year'), null, TIMER_SCHEMA);
@@ -380,11 +387,29 @@ timer = {
             optional_once each 'week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), null, TIMER_SCHEMA);
             optional_once each 'hour' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'h'), null, TIMER_SCHEMA);
 
+            // this noon one can be removed since noon maps to TIME_0?
             optional_once optional_emphasis at_noon => new Ast.Stream.AtTimer([TIME_NOON], null, AT_TIMER_SCHEMA);
             optional_once optional_emphasis at_morning => new Ast.Stream.AtTimer([TIME_MORNING], null, AT_TIMER_SCHEMA);
             optional_once optional_emphasis at_evening => new Ast.Stream.AtTimer([TIME_EVENING], null, AT_TIMER_SCHEMA);
             optional_twice optional_per_day optional_comma optional_first optional_emphasis at_morning and optional_second optional_emphasis at_evening_second => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
             when_brushing_teeth => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
+
+            // FREQ times per minute
+            freq:constant_Number 'times' each 'minute' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'min'), freq, TIMER_SCHEMA);
+            // FREQ times per hour
+            freq:constant_Number 'times' each 'hour' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'h'), freq, TIMER_SCHEMA);
+            // FREQ times per day
+            freq:constant_Number 'times' each 'day' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), freq, TIMER_SCHEMA);
+            // FREQ times per week
+            freq:constant_Number 'times' each 'week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), freq, TIMER_SCHEMA);
+            // FREQ times per month
+            freq:constant_Number 'times' each 'month' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'mon'), freq, TIMER_SCHEMA);
+            // FREQ times per year
+            freq:constant_Number 'times' each 'year' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'year'), freq, TIMER_SCHEMA);
+            // FREQ 'times' every INTERVAL
+            freq:constant_Number 'times' each interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, freq, TIMER_SCHEMA);
+            // FREQ 'times' on DATE (requires expiry on Timer)
+            // freq:constant_Number 'times' on date:constant_Date => new Ast.Stream.Timer(date, new Ast.Value.Measure(1, 'day'), freq, TIMER_SCHEMA);
         }
     }
 }


### PR DESCRIPTION
Updated extended_timers in timers.genie and added them to remote_commands in thingtalk.genie. But the generated code wouldn't work yet because we still need to fix Timer in [thingengine-core/lib/apps/timers.js](https://github.com/stanford-oval/thingengine-core/blob/master/lib/apps/timers.js) to take frequency (see [relevant PR by Ricky](https://github.com/stanford-oval/thingengine-core/pull/86)).