### PR TITLE
Move interval and frequency timers out of the extended_timers flag

### DIFF
--- a/languages/en/timers.genie
+++ b/languages/en/timers.genie
@@ -354,62 +354,45 @@ on = {
 }
 
 timer = {
-    !extended_timers {
-         'every day at' time:constant_Time => new Ast.Stream.AtTimer([time], null, AT_TIMER_SCHEMA);
-
-        !turking {
-            'every' interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, null,  TIMER_SCHEMA);
-            'once in' interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, null, TIMER_SCHEMA);
-            'every day' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
-            'daily' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
-            'everyday' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
-            'once a day' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
-            'once a month' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'mon'), null, TIMER_SCHEMA);
-            'once a week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), null, TIMER_SCHEMA);
-            'once an hour' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'h'), null, TIMER_SCHEMA);
-            'daily at' time:constant_Time => new Ast.Stream.AtTimer([time], null, AT_TIMER_SCHEMA);
-        }
+    ?extended_timers {
+        // this noon one can be removed since noon maps to TIME_0?
+        optional_once optional_emphasis at_noon => new Ast.Stream.AtTimer([TIME_NOON], null, AT_TIMER_SCHEMA);
+        optional_once optional_emphasis at_morning => new Ast.Stream.AtTimer([TIME_MORNING], null, AT_TIMER_SCHEMA);
+        optional_once optional_emphasis at_evening => new Ast.Stream.AtTimer([TIME_EVENING], null, AT_TIMER_SCHEMA);
+        optional_twice optional_per_day optional_comma optional_first optional_emphasis at_morning and optional_second optional_emphasis at_evening_second => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
+        when_brushing_teeth => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
     }
 
-    ?extended_timers {
-        once_per_day 'at' time:constant_Time => new Ast.Stream.AtTimer([time], null, AT_TIMER_SCHEMA);
-        twice_per_day 'at' time1:constant_Time and time2:constant_Time => new Ast.Stream.AtTimer([time1, time2], null, AT_TIMER_SCHEMA);
-        thrice_per_day 'at' time1:constant_Time and time2:constant_Time and time3:constant_Time => new Ast.Stream.AtTimer([time1, time2, time3], null, AT_TIMER_SCHEMA);
+    once_per_day 'at' time:constant_Time => new Ast.Stream.AtTimer([time], null, AT_TIMER_SCHEMA);
+    twice_per_day 'at' time1:constant_Time and time2:constant_Time => new Ast.Stream.AtTimer([time1, time2], null, AT_TIMER_SCHEMA);
+    thrice_per_day 'at' time1:constant_Time and time2:constant_Time and time3:constant_Time => new Ast.Stream.AtTimer([time1, time2, time3], null, AT_TIMER_SCHEMA);
 
-        !turking {
-            optional_once each interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, null, TIMER_SCHEMA);
-            once_per_day => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
-            // twice_per_day and thrice_per_day still need to be AtTimer until we can explicitly set the frequency param in Timer
-            // twice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
-            // thrice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_NOON, TIME_EVENING], null, AT_TIMER_SCHEMA);
-            optional_once each 'year' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'year'), null, TIMER_SCHEMA);
-            optional_once each 'month' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'mon'), null, TIMER_SCHEMA);
-            optional_once each 'week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), null, TIMER_SCHEMA);
-            optional_once each 'hour' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'h'), null, TIMER_SCHEMA);
+    !turking {
+        optional_once each interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, null, TIMER_SCHEMA);
+        once_per_day => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), null, TIMER_SCHEMA);
+        // twice_per_day and thrice_per_day still need to be AtTimer until we can explicitly set the frequency param in Timer
+        // twice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
+        // thrice_per_day => new Ast.Stream.AtTimer([TIME_MORNING, TIME_NOON, TIME_EVENING], null, AT_TIMER_SCHEMA);
+        optional_once each 'year' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'year'), null, TIMER_SCHEMA);
+        optional_once each 'month' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'mon'), null, TIMER_SCHEMA);
+        optional_once each 'week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), null, TIMER_SCHEMA);
+        optional_once each 'hour' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'h'), null, TIMER_SCHEMA);
 
-            // this noon one can be removed since noon maps to TIME_0?
-            optional_once optional_emphasis at_noon => new Ast.Stream.AtTimer([TIME_NOON], null, AT_TIMER_SCHEMA);
-            optional_once optional_emphasis at_morning => new Ast.Stream.AtTimer([TIME_MORNING], null, AT_TIMER_SCHEMA);
-            optional_once optional_emphasis at_evening => new Ast.Stream.AtTimer([TIME_EVENING], null, AT_TIMER_SCHEMA);
-            optional_twice optional_per_day optional_comma optional_first optional_emphasis at_morning and optional_second optional_emphasis at_evening_second => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
-            when_brushing_teeth => new Ast.Stream.AtTimer([TIME_MORNING, TIME_EVENING], null, AT_TIMER_SCHEMA);
-
-            // FREQ times per minute
-            freq:constant_Number 'times' each 'minute' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'min'), freq, TIMER_SCHEMA);
-            // FREQ times per hour
-            freq:constant_Number 'times' each 'hour' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'h'), freq, TIMER_SCHEMA);
-            // FREQ times per day
-            freq:constant_Number 'times' each 'day' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), freq, TIMER_SCHEMA);
-            // FREQ times per week
-            freq:constant_Number 'times' each 'week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), freq, TIMER_SCHEMA);
-            // FREQ times per month
-            freq:constant_Number 'times' each 'month' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'mon'), freq, TIMER_SCHEMA);
-            // FREQ times per year
-            freq:constant_Number 'times' each 'year' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'year'), freq, TIMER_SCHEMA);
-            // FREQ 'times' every INTERVAL
-            freq:constant_Number 'times' each interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, freq, TIMER_SCHEMA);
-            // FREQ 'times' on DATE (requires expiry on Timer)
-            // freq:constant_Number 'times' on date:constant_Date => new Ast.Stream.Timer(date, new Ast.Value.Measure(1, 'day'), freq, TIMER_SCHEMA);
-        }
+        // FREQ times per minute
+        freq:constant_Number 'times' each 'minute' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'min'), freq, TIMER_SCHEMA);
+        // FREQ times per hour
+        freq:constant_Number 'times' each 'hour' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'h'), freq, TIMER_SCHEMA);
+        // FREQ times per day
+        freq:constant_Number 'times' each 'day' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'day'), freq, TIMER_SCHEMA);
+        // FREQ times per week
+        freq:constant_Number 'times' each 'week' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'week'), freq, TIMER_SCHEMA);
+        // FREQ times per month
+        freq:constant_Number 'times' each 'month' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'mon'), freq, TIMER_SCHEMA);
+        // FREQ times per year
+        freq:constant_Number 'times' each 'year' => new Ast.Stream.Timer(Ast.Value.Date.now(), new Ast.Value.Measure(1, 'year'), freq, TIMER_SCHEMA);
+        // FREQ 'times' every INTERVAL
+        freq:constant_Number 'times' each interval:constant_Measure_ms => new Ast.Stream.Timer(Ast.Value.Date.now(), interval, freq, TIMER_SCHEMA);
+        // FREQ 'times' on DATE (requires expiry on Timer)
+        // freq:constant_Number 'times' on date:constant_Date => new Ast.Stream.Timer(date, new Ast.Value.Measure(1, 'day'), freq, TIMER_SCHEMA);
     }
 }


### PR DESCRIPTION
And remove the old non-extended versions.
Only the timers that talk about parts of day (with some questionable
references to school, work & meal) are left under default-off flag.