### PR TITLE
Add an option to control the target size of generated datasets

### DIFF
--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -538,8 +538,8 @@ class ContextualSentenceGenerator extends stream.Transform {
     constructor(options = {}) {
         super({ objectMode: true });
         options.contextual = true;
-        if (options.targetGenSize === undefined)
-            options.targetGenSize = CONTEXTUAL_TARGET_GEN_SIZE;
+        if (options.targetPruningSize === undefined)
+            options.targetPruningSize = CONTEXTUAL_TARGET_GEN_SIZE;
 
         this._idPrefix = options.idPrefix;
         this._debug = options.debug;
@@ -639,8 +639,8 @@ class BasicSentenceGenerator extends stream.Readable {
     constructor(options = {}) {
         super({ objectMode: true });
         options.contextual = false;
-        if (options.targetGenSize === undefined)
-            options.targetGenSize = BASIC_TARGET_GEN_SIZE;
+        if (options.targetPruningSize === undefined)
+            options.targetPruningSize = BASIC_TARGET_GEN_SIZE;
         this._generator = new SentenceGenerator(options);
         this._generator.on('progress', (value) => {
             this.emit('progress', value);

--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -538,7 +538,8 @@ class ContextualSentenceGenerator extends stream.Transform {
     constructor(options = {}) {
         super({ objectMode: true });
         options.contextual = true;
-        options.targetGenSize = CONTEXTUAL_TARGET_GEN_SIZE;
+        if (options.targetGenSize === undefined)
+            options.targetGenSize = CONTEXTUAL_TARGET_GEN_SIZE;
 
         this._idPrefix = options.idPrefix;
         this._debug = options.debug;
@@ -638,7 +639,8 @@ class BasicSentenceGenerator extends stream.Readable {
     constructor(options = {}) {
         super({ objectMode: true });
         options.contextual = false;
-        options.targetGenSize = BASIC_TARGET_GEN_SIZE;
+        if (options.targetGenSize === undefined)
+            options.targetGenSize = BASIC_TARGET_GEN_SIZE;
         this._generator = new SentenceGenerator(options);
         this._generator.on('progress', (value) => {
             this.emit('progress', value);

--- a/lib/sentence-generator/runtime.js
+++ b/lib/sentence-generator/runtime.js
@@ -534,10 +534,10 @@ class Grammar extends events.EventEmitter {
             estimates.length = rules.length;
             for (let rulenumber = 0; rulenumber < rules.length; rulenumber++) {
                 const [expansion,] = rules[rulenumber];
-                let [/*maxdepth*/, /*worstCaseGenSize*/, estimatedGenSize, targetGenSize]
+                let [/*maxdepth*/, /*worstCaseGenSize*/, estimatedGenSize, targetPruningSize]
                     = estimateRuleSize(charts, depth, nonterminal, rulenumber, expansion, this._averagePruningFactor, this._options);
 
-                estimatedGenSize = Math.min(Math.round(estimatedGenSize), targetGenSize);
+                estimatedGenSize = Math.min(Math.round(estimatedGenSize), targetPruningSize);
                 estimates[rulenumber] = estimatedGenSize;
                 estimate += estimatedGenSize;
             }
@@ -755,10 +755,10 @@ function estimateRuleSize(charts, depth, nonterminal, rulenumber, expansion, ave
 
     const estimatedPruneFactor = averagePruningFactor[nonterminal][rulenumber];
     const estimatedGenSize = worstCaseGenSize * estimatedPruneFactor;
-    //const targetGenSize = nonterminal === 'root' ? Infinity : TARGET_GEN_SIZE * POWERS[depth];
-    const targetGenSize = options.targetGenSize * POWERS[depth];
+    //const targetPruningSize = nonterminal === 'root' ? Infinity : TARGET_GEN_SIZE * POWERS[depth];
+    const targetPruningSize = options.targetPruningSize * POWERS[depth];
 
-    return [maxdepth, worstCaseGenSize, estimatedGenSize, targetGenSize, estimatedPruneFactor];
+    return [maxdepth, worstCaseGenSize, estimatedGenSize, targetPruningSize, estimatedPruneFactor];
 }
 
 function *expandRule(charts, depth, nonterminal, rulenumber, [expansion, combiner], averagePruningFactor, options) {
@@ -827,17 +827,17 @@ function *expandRule(charts, depth, nonterminal, rulenumber, [expansion, combine
     // algorithm to not go above maxdepth for all but one non-terminal,
     // and then cycle through which non-terminal is allowed to grow
 
-    const [maxdepth, worstCaseGenSize, estimatedGenSize, targetGenSize, estimatedPruneFactor] =
+    const [maxdepth, worstCaseGenSize, estimatedGenSize, targetPruningSize, estimatedPruneFactor] =
         estimateRuleSize(charts, depth, nonterminal, rulenumber, expansion, averagePruningFactor, options);
 
     if (maxdepth < depth-1 && options.debug)
         console.log(`expand NT[${nonterminal}] -> ${expansion.join(' ')} : reduced max depth to avoid exponential behavior`);
 
     if (options.debug)
-        console.log(`expand NT[${nonterminal}] -> ${expansion.join(' ')} : worst case ${worstCaseGenSize}, expect ${Math.round(estimatedGenSize)} (target ${targetGenSize})`);
+        console.log(`expand NT[${nonterminal}] -> ${expansion.join(' ')} : worst case ${worstCaseGenSize}, expect ${Math.round(estimatedGenSize)} (target ${targetPruningSize})`);
     const now = Date.now();
 
-    const basicCoinProbability = Math.min(1, targetGenSize/estimatedGenSize);
+    const basicCoinProbability = Math.min(1, targetPruningSize/estimatedGenSize);
     let coinProbability = basicCoinProbability;
 
     let choices = [];
@@ -854,7 +854,7 @@ function *expandRule(charts, depth, nonterminal, rulenumber, [expansion, combine
                     let v = combiner(choices.map((c) => c instanceof Choice ? c.choose(rng) : c));
                     if (v !== null) {
                         actualGenSize ++;
-                        if (actualGenSize < targetGenSize / 2 &&
+                        if (actualGenSize < targetPruningSize / 2 &&
                             actualGenSize + prunedGenSize >= 1000 &&
                             actualGenSize / (actualGenSize + prunedGenSize) < 0.001 * estimatedPruneFactor) {
                             // this combiner is pruning so aggressively it's messing up our sampling
@@ -862,7 +862,7 @@ function *expandRule(charts, depth, nonterminal, rulenumber, [expansion, combine
                             coinProbability = 1;
                         }
                         // unless we have generated more than half of our target size, then we bring it back
-                        if (actualGenSize >= targetGenSize / 2)
+                        if (actualGenSize >= targetPruningSize / 2)
                             coinProbability = basicCoinProbability;
 
                         yield v;

--- a/tool/generate-contextual.js
+++ b/tool/generate-contextual.js
@@ -84,6 +84,12 @@ module.exports = {
             defaultValue: 4,
             help: 'Maximum depth of sentence generation',
         });
+        parser.addArgument('--target-gen-size', {
+            required: false,
+            type: Number,
+            defaultValue: 10000,
+            help: 'Approximate target size of the generate dataset, for each $root rule and each depth',
+        });
 
         parser.addArgument('--debug', {
             nargs: 0,

--- a/tool/generate-contextual.js
+++ b/tool/generate-contextual.js
@@ -84,7 +84,7 @@ module.exports = {
             defaultValue: 4,
             help: 'Maximum depth of sentence generation',
         });
-        parser.addArgument('--target-gen-size', {
+        parser.addArgument('--target-pruning-size', {
             required: false,
             type: Number,
             defaultValue: 10000,

--- a/tool/generate.js
+++ b/tool/generate.js
@@ -80,6 +80,12 @@ module.exports = {
             defaultValue: 5,
             help: 'Maximum depth of sentence generation',
         });
+        parser.addArgument('--target-gen-size', {
+            required: false,
+            type: Number,
+            defaultValue: 100000,
+            help: 'Approximate target size of the generate dataset, for each $root rule and each depth',
+        });
         
         parser.addArgument('--debug', {
             nargs: 0,
@@ -114,6 +120,7 @@ module.exports = {
             flags: args.flags || {},
             templateFile: args.template,
             thingpediaClient: tpClient,
+            targetGenSize: args.target_gen_size,
             maxDepth: args.maxdepth,
             debug: args.debug
         };

--- a/tool/generate.js
+++ b/tool/generate.js
@@ -80,7 +80,7 @@ module.exports = {
             defaultValue: 5,
             help: 'Maximum depth of sentence generation',
         });
-        parser.addArgument('--target-gen-size', {
+        parser.addArgument('--target-pruning-size', {
             required: false,
             type: Number,
             defaultValue: 100000,
@@ -120,7 +120,7 @@ module.exports = {
             flags: args.flags || {},
             templateFile: args.template,
             thingpediaClient: tpClient,
-            targetGenSize: args.target_gen_size,
+            targetPruningSize: args.target_pruning_size,
             maxDepth: args.maxdepth,
             debug: args.debug
         };

--- a/tool/workers/generate-contextual-worker.js
+++ b/tool/workers/generate-contextual-worker.js
@@ -23,7 +23,7 @@ module.exports = function worker(args, shard) {
         templateFile: args.template,
         thingpediaClient: tpClient,
         maxDepth: args.maxdepth,
-        targetGenSize: args.target_gen_size,
+        targetPruningSize: args.target_pruning_size,
         debug: args.debug,
     };
     return new ContextualSentenceGenerator(options);

--- a/tool/workers/generate-contextual-worker.js
+++ b/tool/workers/generate-contextual-worker.js
@@ -23,6 +23,7 @@ module.exports = function worker(args, shard) {
         templateFile: args.template,
         thingpediaClient: tpClient,
         maxDepth: args.maxdepth,
+        targetGenSize: args.target_gen_size,
         debug: args.debug,
     };
     return new ContextualSentenceGenerator(options);


### PR DESCRIPTION
The option maps directly to the targetGenSize hyperparameter,
which is the approximate maximum size of each rule at each depth
(incl. the $root rules, which have the most effect).

The main reason I want this patch is because Travis CI for almond-cloud takes too long to test the dataset generation, and I want to pass options to generate smaller sets. But it could be useful to tune for different template packs and/or different Thingpedia sizes.