### PR TITLE
replace_parameters: fix accessing arg if there is no primitive

### DIFF
--- a/lib/replace_parameters.js
+++ b/lib/replace_parameters.js
@@ -221,12 +221,18 @@ module.exports = class ParameterReplacer {
         else // other slots should have the right number
             throw new Error(`Unrecognized slot tag ${slot.tag}`);
 
-        const arg = prim.schema.getArgument(pname);
-        // if we get here, the program was typechecked, so we know we have this argument
-        assert(arg);
-
-        if (arg.annotations.string_values && arg.annotations.string_values.value)
+        // HACK
+        let arg = slot.arg || slot._arg;
+        if (!arg && prim && prim.schema)
+            arg = prim.schema.getArgument(pname);
+        if (!arg) {
+            if (!this._warned.has('noarg:' + slot.tag + ':' + slot.type)) {
+                console.error(`Found no argument property for ${slot.tag}:${slot.type}`);
+                this._warned.add('noarg:' +slot.tag + ':' + slot.type);
+            }
+        } else if (arg.annotations.string_values && arg.annotations.string_values.value) {
             return ['string', arg.annotations.string_values.toJS()];
+        }
 
         if (slot.type.isEntity)
             return this._getEntityListKey(slot.type.type);
@@ -288,9 +294,9 @@ module.exports = class ParameterReplacer {
         let valueList = await this._loader.get(valueListKey);
         if (valueList.size === 0) {
             if (this._debug) {
-                if (!this._warned.has(slot.tag + ':' + slot.type)) {
+                if (!this._warned.has('novalue:' + slot.tag + ':' + slot.type)) {
                     console.error(`Found no values for ${slot.tag}:${slot.type}`);
-                    this._warned.add(slot.tag + ':' + slot.type);
+                    this._warned.add('novalue:' + slot.tag + ':' + slot.type);
                 }
             }
 


### PR DESCRIPTION
If we're replacing inside the filter of a join, there is no
current primitive (because can come from either primitive), so
"slot.primitive" is null.
Instead, we can access the argument directly from the slot.
Use either the soon-to-be-added public "arg" property of the slot,
or the private "_arg" property, and fall back to trying the prim
anyway if we have one.

Fixes #111 