### PR TITLE
Fix using a constant for device name

### DIFF
--- a/languages/ast_manip.js
+++ b/languages/ast_manip.js
@@ -104,7 +104,7 @@ function betaReduce(ast, pname, value) {
         const varref = slot.get();
         if (varref.isVarRef && varref.name === pname) {
             // no parameter passing into device attributes
-            if (value.isVarRef && slot.tag.startsWith('attribute.'))
+            if (value.isVarRef && !value.name.startsWith('__const') && slot.tag.startsWith('attribute.'))
                 return null;
 
             slot.set(value);


### PR DESCRIPTION
During generation, constants are VarRef nodes with __const_ type,
but that tripped our check to avoid parameter passing.