### PR TITLE
Inference mode dialogue templates

### DIFF
--- a/languages/flags.txt
+++ b/languages/flags.txt
@@ -1,6 +1,6 @@
 thingtalk/en:
   all:
-    always_filter, aggregation, bookkeeping, configure_actions, dialogues, extended_timers, multifilters, no_contextual_bookkeeping, nofilter, nostream, notablejoin, policies, primonly, projection, projection_with_filter, range_filters, remote_commands, schema_org, screen_selection, timer, triple_commands, undefined_filter
+    always_filter, aggregation, bookkeeping, configure_actions, extended_timers, multifilters, no_contextual_bookkeeping, nofilter, nostream, notablejoin, policies, primonly, projection, projection_with_filter, range_filters, remote_commands, schema_org, screen_selection, timer, triple_commands, undefined_filter
   default:
     always_filter, aggregation, bookkeeping, configure_actions, multifilters, policies, projection, projection_with_filter, remote_commands, schema_org, screen_selection, timer, undefined_filter
   developer:

--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -591,6 +591,10 @@ function checkAtomFilter(table, filter) {
         if (!vtype.isEntity && !vtype.isString)
             return false;
         vtype = Type.Array(Type.String);
+    } else if (filter.operator === '=~') {
+        if (!ptype.isEntity && !ptype.isString)
+            return false;
+        vtype = Type.String;
     }
 
     if (!filter.value.getType().equals(vtype))

--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -1729,6 +1729,51 @@ function replaceSlotBagPlaceholder(bag, pname, value) {
     return clone;
 }
 
+/**
+ * Find the filter table in the context.
+ *
+ * Returns filterTable
+ */
+function findFilterTable(root) {
+    let table = root;
+    while (!table.isFilter) {
+        if (table.isSequence ||
+            table.isHistory ||
+            table.isWindow ||
+            table.isTimeSeries)
+            throw new Error('NOT IMPLEMENTED');
+
+        // do not touch these with filters
+        if (table.isAggregation ||
+            table.isVarRef ||
+            table.isResultRef)
+            return null;
+
+        // go inside these
+        if (table.isSort ||
+            table.isIndex ||
+            table.isSlice ||
+            table.isProjection ||
+            table.isCompute ||
+            table.isAlias) {
+            table = table.table;
+            continue;
+        }
+
+        if (table.isJoin) {
+            // go right on join, always
+            table = table.rhs;
+            continue;
+        }
+
+        assert(table.isInvocation);
+        // if we get here, there is no filter table at all
+        return null;
+    }
+
+    return table;
+}
+
 module.exports = {
     typeToStringSafe,
     getFunctionNames,
@@ -1784,6 +1829,7 @@ module.exports = {
     addFilter,
     hasGetPredicate,
     makeGetPredicate,
+    findFilterTable,
 
     makeListExpression,
     makeSortedTable,

--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -1711,6 +1711,24 @@ function addActionInputParam(action, param) {
         return new Ast.Table.Invocation(null, newInvocation, action.schema.removeArgument(param.name));
 }
 
+function replaceSlotBagPlaceholder(bag, pname, value) {
+    if (!value.isConstant())
+        return null;
+    let ptype = bag.schema.getArgType(pname);
+    if (!ptype)
+        return null;
+    if (ptype.isArray)
+        ptype = ptype.elem;
+    const vtype = value.getType();
+    if (!ptype.equals(vtype))
+        return null;
+    if (bag.has(pname))
+        return null;
+    const clone = bag.clone();
+    clone.set(pname, value);
+    return clone;
+}
+
 module.exports = {
     typeToStringSafe,
     getFunctionNames,
@@ -1752,6 +1770,7 @@ module.exports = {
     whenGetStream,
     addInvocationInputParam,
     addActionInputParam,
+    replaceSlotBagPlaceholder,
 
     // filters
     hasUniqueFilter,

--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -1729,6 +1729,13 @@ function replaceSlotBagPlaceholder(bag, pname, value) {
     return clone;
 }
 
+function replaceErrorMessagePlaceholder(msg, pname, value) {
+    const newbag = replaceSlotBagPlaceholder(msg.bag, pname, value);
+    if (newbag === null)
+        return null;
+    return { code: msg.code, bag: newbag };
+}
+
 /**
  * Find the filter table in the context.
  *
@@ -1816,6 +1823,7 @@ module.exports = {
     addInvocationInputParam,
     addActionInputParam,
     replaceSlotBagPlaceholder,
+    replaceErrorMessagePlaceholder,
 
     // filters
     hasUniqueFilter,

--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -1543,10 +1543,14 @@ function makeComputeFilterExpression(table, operation, operands, resultType, fil
     if (table.schema.out[operation])
         return null;
 
-    const computedTable = makeComputeExpression(table, operation, operands, resultType);
-    const filter = new Ast.BooleanExpression.Atom(null, operation, filterOp, filterValue);
+    const expression = new Ast.Value.Computation(operation, operands);
+    if (operation === 'distance') {
+        expression.overload = [Type.Location, Type.Location, Type.Measure('m')];
+        expression.type = Type.Measure('m');
+    }
+    const filter = new Ast.BooleanExpression.Compute(null, expression, filterOp, filterValue);
     if (filter)
-        return addFilter(computedTable, filter);
+        return addFilter(table, filter);
     return null;
 }
 

--- a/languages/thingtalk/common-constants.genie
+++ b/languages/thingtalk/common-constants.genie
@@ -19,48 +19,24 @@ const MAX_SMALL_INTEGER = 12;
 
 for (let i = 0; i <= MAX_SMALL_INTEGER; i++)
     constant_Number = #(String(i)) => new Ast.Value.Number(i);
-// NOTE: normally, we would use _tpLoader.flags.dialogues for these checks, but this code
-// executes before load-thingpedia.js, so _tpLoader cannot be used in this file
-if ($options.flags.dialogues) {
-    for (let i = 0; i < MAX_CONSTANTS; i++)
-        constant_Number = #('NUMBER_' + i) => new Ast.Value.Number(MAX_SMALL_INTEGER + 1 + i);
 
-    for (let i = 0; i < MAX_CONSTANTS; i++) {
-        constant_String = #('QUOTED_STRING_' + i) => new Ast.Value.String('str:QUOTED_STRING::' + i + ':');
-        constant_Entity__tt__url = #('URL_' + i) => new Ast.Value.Entity('str:URL::' + i, 'tt:url', null);
-        constant_Entity__tt__username = #('USERNAME_' + i) => new Ast.Value.Entity('str:USERNAME::' + i + ':', 'tt:url', null);
-        constant_Entity__tt__hashtag = #('HASHTAG_' + i) => new Ast.Value.Entity('str:HASHTAG::' + i + ':', 'tt:hashtag', null);
-        constant_Entity__tt__phone_number = #('PHONE_NUMBER_' + i) => new Ast.Value.Entity('str:PHONE_NUMBER::' + i + ':', 'tt:phone_number', null);
-        constant_Entity__tt__email_address = #('EMAIL_ADDRESS_' + i) => new Ast.Value.Entity('str:EMAIL_ADDRESS::' + i + ':', 'tt:email_address', null);
-        constant_Entity__tt__path_name = #('PATH_NAME_' + i) => new Ast.Value.Entity('str:PATH_NAME::' + i + ':', 'tt:path_name', null);
+constant_String                    = const(QUOTED_STRING, Type.String);
 
-        constant_Currency = #('CURRENCY_' + i) => new Ast.Value.Currency(2 + i, 'usd');
-        constant_Measure_ms = #('DURATION_' + i) => new Ast.Value.Measure(2 + i, 'ms');
+constant_Entity__tt__url           = const(URL, Type.Entity('tt:url'));
 
-        constant_Location = #('LOCATION_' + i) => new Ast.Value.Location(new Ast.Location.Absolute(2 + i, 2 + i, null));
+constant_Entity__tt__username      = const(USERNAME, Type.Entity('tt:username'));
+constant_Entity__tt__hashtag       = const(HASHTAG, Type.Entity('tt:hashtag'));
+constant_Entity__tt__phone_number  = const(PHONE_NUMBER, Type.Entity('tt:phone_number'));
+constant_Entity__tt__email_address = const(EMAIL_ADDRESS, Type.Entity('tt:email_address'));
+constant_Entity__tt__path_name     = const(PATH_NAME, Type.Entity('tt:path_name'));
 
-        constant_Date = #('DATE_' + i) => new Ast.Value.Date(new Date(2018, 0, 2 + i));
-        constant_Time = #('TIME_' + i) => new Ast.Value.Time(new Ast.Time.Absolute(Math.floor(i/4), [0, 15, 30, 45][i % 4], 0));
-    }
-} else {
-    constant_String                    = const(QUOTED_STRING, Type.String);
+constant_Number = const(NUMBER, Type.Number);
+constant_Currency = const(CURRENCY, Type.Currency);
+constant_Time = const(TIME, Type.Time);
+constant_Date = const(DATE, Type.Date);
+constant_Location = const(LOCATION, Type.Location);
 
-    constant_Entity__tt__url           = const(URL, Type.Entity('tt:url'));
-
-    constant_Entity__tt__username      = const(USERNAME, Type.Entity('tt:username'));
-    constant_Entity__tt__hashtag       = const(HASHTAG, Type.Entity('tt:hashtag'));
-    constant_Entity__tt__phone_number  = const(PHONE_NUMBER, Type.Entity('tt:phone_number'));
-    constant_Entity__tt__email_address = const(EMAIL_ADDRESS, Type.Entity('tt:email_address'));
-    constant_Entity__tt__path_name     = const(PATH_NAME, Type.Entity('tt:path_name'));
-
-    constant_Number = const(NUMBER, Type.Number);
-    constant_Currency = const(CURRENCY, Type.Currency);
-    constant_Time = const(TIME, Type.Time);
-    constant_Date = const(DATE, Type.Date);
-    constant_Location = const(LOCATION, Type.Location);
-
-    constant_Measure_ms = const(DURATION, Type.Measure('ms'));
-}
+constant_Measure_ms = const(DURATION, Type.Measure('ms'));
 
 constant_Entity__tt__picture  = {}
 constant_Entity__tt__function = {}

--- a/languages/thingtalk/common.genie
+++ b/languages/thingtalk/common.genie
@@ -30,6 +30,7 @@ thingpedia_search_question = {}
 thingpedia_slot_fill_question = {}
 
 thingpedia_result = {}
+thingpedia_action_past = {}
 
 out_param_Numeric = {
     out_param_Number;
@@ -174,6 +175,15 @@ for (let [pname, [typestr,]] of _tpLoader.params.in.values()) {
         a:thingpedia_action v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replacePlaceholderWithConstant(a, pname, v);
     }
 
+    thingpedia_action_past = {
+        a:thingpedia_action v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replacePlaceholderWithConstant(a, pname, v);
+    }
+    if (typestr.startsWith('Entity')) {
+        thingpedia_action_past = {
+            a:thingpedia_action v:constant_name [-> pname { isConstant: true }] => C.replacePlaceholderWithConstant(a, pname, v);
+        }
+    }
+
     thingpedia_program = {
         p:thingpedia_program v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replacePlaceholderWithConstant(p, pname, v);
     }
@@ -203,8 +213,10 @@ for (let [pname, [typestr,]] of _tpLoader.params.in.values()) {
 }
 
 for (let [pname, typestr] of _tpLoader.params.out.values()) {
-    thingpedia_result = {
-        bag:thingpedia_result v:$('constant_name') [-> pname { isConstant: true }] => C.replaceSlotBagPlaceholder(bag, pname, v);
-        bag:thingpedia_result v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replaceSlotBagPlaceholder(bag, pname, v);
+    if (typestr !== null) {
+        thingpedia_result = {
+            bag:thingpedia_result v:$('constant_name') [-> pname { isConstant: true }] => C.replaceSlotBagPlaceholder(bag, pname, v);
+            bag:thingpedia_result v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replaceSlotBagPlaceholder(bag, pname, v);
+        }
     }
 }

--- a/languages/thingtalk/common.genie
+++ b/languages/thingtalk/common.genie
@@ -31,6 +31,7 @@ thingpedia_slot_fill_question = {}
 
 thingpedia_result = {}
 thingpedia_action_past = {}
+thingpedia_error_message = {}
 
 out_param_Numeric = {
     out_param_Number;
@@ -178,9 +179,18 @@ for (let [pname, [typestr,]] of _tpLoader.params.in.values()) {
     thingpedia_action_past = {
         a:thingpedia_action v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replacePlaceholderWithConstant(a, pname, v);
     }
+
+    thingpedia_error_message = {
+        msg:thingpedia_error_message v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replaceErrorMessagePlaceholder(msg, pname, v);
+    }
+
     if (typestr.startsWith('Entity')) {
         thingpedia_action_past = {
             a:thingpedia_action v:constant_name [-> pname { isConstant: true }] => C.replacePlaceholderWithConstant(a, pname, v);
+        }
+
+        thingpedia_error_message = {
+            msg:thingpedia_error_message v:constant_name [-> pname { isConstant: true }] => C.replaceErrorMessagePlaceholder(msg, pname, v);
         }
     }
 

--- a/languages/thingtalk/common.genie
+++ b/languages/thingtalk/common.genie
@@ -29,6 +29,8 @@ thingpedia_who_question = {}
 thingpedia_search_question = {}
 thingpedia_slot_fill_question = {}
 
+thingpedia_result = {}
+
 out_param_Numeric = {
     out_param_Number;
     out_param_Currency;
@@ -197,5 +199,12 @@ for (let [pname, [typestr,]] of _tpLoader.params.in.values()) {
                     C.replacePlaceholderWithUndefined(p, pname, typestr);
             }
         }
+    }
+}
+
+for (let [pname, typestr] of _tpLoader.params.out.values()) {
+    thingpedia_result = {
+        bag:thingpedia_result v:$('constant_name') [-> pname { isConstant: true }] => C.replaceSlotBagPlaceholder(bag, pname, v);
+        bag:thingpedia_result v:$('constant_' + typestr) [-> pname { isConstant: true }] => C.replaceSlotBagPlaceholder(bag, pname, v);
     }
 }

--- a/languages/thingtalk/dialogue_utils.js
+++ b/languages/thingtalk/dialogue_utils.js
@@ -292,7 +292,7 @@ function makeRefinementProposal(ctx, proposal) {
     if (!(proposal.isFilter && proposal.table.isInvocation))
         return null;
 
-    const ctxFilterTable = findFilterTable(ctx.current.stmt.table);
+    const ctxFilterTable = C.findFilterTable(ctx.current.stmt.table);
     if (ctxFilterTable === null)
         return null;
 
@@ -419,51 +419,6 @@ function isSlotFillAnswerValidForQuestion(action, questions) {
         }
         return false;
     });
-}
-
-/**
- * Find the filter table in the context.
- *
- * Returns filterTable
- */
-function findFilterTable(root) {
-    let table = root;
-    while (!table.isFilter) {
-        if (table.isSequence ||
-            table.isHistory ||
-            table.isWindow ||
-            table.isTimeSeries)
-            throw new Error('NOT IMPLEMENTED');
-
-        // do not touch these with filters
-        if (table.isAggregation ||
-            table.isVarRef ||
-            table.isResultRef)
-            return null;
-
-        // go inside these
-        if (table.isSort ||
-            table.isIndex ||
-            table.isSlice ||
-            table.isProjection ||
-            table.isCompute ||
-            table.isAlias) {
-            table = table.table;
-            continue;
-        }
-
-        if (table.isJoin) {
-            // go right on join, always
-            table = table.rhs;
-            continue;
-        }
-
-        assert(table.isInvocation);
-        // if we get here, there is no filter table at all
-        return null;
-    }
-
-    return table;
 }
 
 
@@ -818,7 +773,7 @@ function isGoodSearchQuestion(ctx, questions) {
     if (!isValidSearchQuestion(ctx.current.stmt.table, questions))
         return false;
 
-    const ctxFilterTable = findFilterTable(ctx.current.stmt.table);
+    const ctxFilterTable = C.findFilterTable(ctx.current.stmt.table);
     if (!ctxFilterTable)
         return false;
     for (let q of questions) {
@@ -1224,7 +1179,7 @@ function isGoodEmptySearchQuestion(ctx, question) {
     if (!currentTable.schema.out[question])
         return false;
 
-    const ctxFilterTable = findFilterTable(ctx.current.stmt.table);
+    const ctxFilterTable = C.findFilterTable(ctx.current.stmt.table);
     if (!ctxFilterTable || !C.filterUsesParam(ctxFilterTable.filter, question))
         return false;
 
@@ -1348,7 +1303,7 @@ function relatedQuestion(ctx, stmt) {
     if (newFilterTable === null)
         return null;
 
-    ctxFilterTable = findFilterTable(currentTable);
+    ctxFilterTable = C.findFilterTable(currentTable);
 
     if (ctxFilterTable) {
         const newFilter = refineFilterToAnswerQuestion(ctxFilterTable.filter, newFilterTable.filter);

--- a/languages/thingtalk/dialogue_utils.js
+++ b/languages/thingtalk/dialogue_utils.js
@@ -274,7 +274,9 @@ function checkActionForRecommendation({ topResult, info, action: nextAction }, a
 }
 
 function makeRefinementProposal(ctx, proposal) {
-    assert(proposal.isFilter && proposal.table.isInvocation);
+    // this if() can be false only with weird primitive templates
+    if (!(proposal.isFilter && proposal.table.isInvocation))
+        return null;
 
     const ctxFilterTable = findFilterTable(ctx.current.stmt.table);
     if (ctxFilterTable === null)
@@ -1203,6 +1205,7 @@ function impreciseSlotFillQuestionAnswerPair(questions, answer) {
 }
 
 function isGoodEmptySearchQuestion(ctx, question) {
+    assert(typeof question === 'string');
     const currentTable = ctx.current.stmt.table;
     if (!currentTable.schema.out[question])
         return false;
@@ -1215,7 +1218,7 @@ function isGoodEmptySearchQuestion(ctx, question) {
 }
 
 function emptySearchChangePair(ctx, [question, phrase]) {
-    if (question !== null  && !isGoodEmptySearchQuestion(ctx, question))
+    if (question !== null  && !isGoodEmptySearchQuestion(ctx, question.name))
         return null;
 
     const currentTable = ctx.current.stmt.table;

--- a/languages/thingtalk/dialogue_utils.js
+++ b/languages/thingtalk/dialogue_utils.js
@@ -716,8 +716,7 @@ function queryRefinement(ctxTable, newFilter, refineFilter, newProjection) {
     //if (ctxFilterTable === null)
     //    return null;
     assert(filterTable.isFilter);
-    if (!filterTable.table.isInvocation)
-        return null;
+    assert(filterTable.isFilter && ((filterTable.table.isCompute && filterTable.table.table.isInvocation) || filterTable.table.isInvocation));
     //assert(filterTable.isFilter && filterTable.table.isInvocation);
 
     const refinedFilter = refineFilter(filterTable.filter, newFilter);
@@ -823,7 +822,7 @@ function preciseSearchQuestionAnswer(ctx, [questions, answer]) {
     const currentTable = ctx.current.stmt.table;
     if (!isValidSearchQuestion(currentTable, questions))
         return null;
-    assert(answer.isFilter && answer.table.isInvocation);
+    assert(answer.isFilter && ((answer.table.isCompute && answer.table.table.isInvocation) || answer.table.isInvocation));
 
     const newTable = queryRefinement(currentTable, answer.filter, refineFilterToAnswerQuestion);
     if (newTable === null)
@@ -939,7 +938,7 @@ function proposalReplyPair(ctx, [proposal, request]) {
     assert(requestFunctions.length === 1);
     if (requestFunctions[0] !== ctx.currentFunction)
         return null;
-    assert(request.isFilter && request.table.isInvocation);
+    assert(request.isFilter && ((request.table.isCompute && request.table.table.isInvocation) || request.table.isInvocation));
 
     const currentTable = ctx.current.stmt.table;
     const newTable = queryRefinement(currentTable, request.filter, refineFilterToAnswerQuestion);
@@ -970,7 +969,7 @@ function negativeRecommendationReplyPair(ctx, [topResult, action, request]) {
     assert(requestFunctions.length === 1);
     if (requestFunctions[0] !== ctx.currentFunction)
         return null;
-    assert(request.isFilter && request.table.isInvocation);
+    assert(request.isFilter && ((request.table.isCompute && request.table.table.isInvocation) || request.table.isInvocation));
 
     const currentTable = ctx.current.stmt.table;
     const newTable = queryRefinement(currentTable, request.filter, refineFilterToAnswerQuestionOrChangeFilter);
@@ -1098,7 +1097,7 @@ function negativeListProposalReplyPair(ctx, [results, action, request]) {
     assert(requestFunctions.length === 1);
     if (requestFunctions[0] !== ctx.currentFunction)
         return null;
-    assert(request.isFilter && request.table.isInvocation);
+    assert(request.isFilter && ((request.table.isCompute && request.table.table.isInvocation) || request.table.isInvocation));
 
     const currentTable = ctx.current.stmt.table;
     const newTable = queryRefinement(currentTable, request.filter, refineFilterToAnswerQuestionOrChangeFilter);

--- a/languages/thingtalk/dialogue_utils.js
+++ b/languages/thingtalk/dialogue_utils.js
@@ -1453,6 +1453,12 @@ function actionSuccessTerminalPair(ctx) {
     return checkStateIsValid(ctx, sysState, userState);
 }
 
+function actionSuccessQuestionPair(ctx, questions) {
+    const sysState = makeSimpleState(ctx, 'sys_action_success', null);
+    const userState = makeSimpleState(ctx, 'action_question', questions);
+    return checkStateIsValid(ctx, sysState, userState);
+}
+
 function actionErrorTerminalPair(ctx, error) {
     const [, questions] = error;
     assert(Array.isArray(questions));
@@ -1557,6 +1563,7 @@ module.exports = {
     listProposalRelatedQuestionPair,
     emptySearchChangePair,
     actionSuccessTerminalPair,
+    actionSuccessQuestionPair,
     actionErrorTerminalPair,
     actionErrorChangeParamPair,
 };

--- a/languages/thingtalk/dialogue_utils.js
+++ b/languages/thingtalk/dialogue_utils.js
@@ -715,7 +715,10 @@ function queryRefinement(ctxTable, newFilter, refineFilter, newProjection) {
     [cloneTable, filterTable] = findOrMakeFilterTable(cloneTable);
     //if (ctxFilterTable === null)
     //    return null;
-    assert(filterTable.isFilter && filterTable.table.isInvocation);
+    assert(filterTable.isFilter);
+    if (!filterTable.table.isInvocation)
+        return null;
+    //assert(filterTable.isFilter && filterTable.table.isInvocation);
 
     const refinedFilter = refineFilter(filterTable.filter, newFilter);
     if (refinedFilter === null)
@@ -1225,6 +1228,9 @@ function addDontCare(stmt, dontcare) {
 
     let clone = stmt.clone();
     let [cloneTable, filterTable] = findOrMakeFilterTable(clone.table);
+    assert(filterTable.isFilter);
+    if (!filterTable.table.isInvocation)
+        return null;
     clone.table = cloneTable;
 
     if (C.filterUsesParam(filterTable.filter, dontcare.name))
@@ -1315,6 +1321,9 @@ function relatedQuestion(ctx, stmt) {
     let ctxFilterTable, newFilterTable;
     [newTable, newFilterTable] = findOrMakeFilterTable(newTable.clone());
     if (newFilterTable === null)
+        return null;
+    assert(newFilterTable.isFilter);
+    if (!newFilterTable.table.isInvocation)
         return null;
 
     ctxFilterTable = C.findFilterTable(currentTable);

--- a/languages/thingtalk/dialogue_utils.js
+++ b/languages/thingtalk/dialogue_utils.js
@@ -816,6 +816,8 @@ function isGoodSlotFillQuestion(ctx, questions) {
     const action = getActionInvocation(ctx.next);
     assert(action instanceof Ast.Invocation);
     for (let q of questions) {
+        if (q === ctx.nextInfo.chainParameter)
+            return null;
         const arg = action.schema.getArgument(q);
         if (!arg || !arg.is_input)
             return false;

--- a/languages/thingtalk/dialogue_utils.js
+++ b/languages/thingtalk/dialogue_utils.js
@@ -1240,7 +1240,7 @@ function emptySearchChangePair(ctx, [question, phrase]) {
     if (newTable === null)
         return null;
     const userState = addQuery(ctx, 'execute', newTable, 'accepted');
-    const sysState = makeSimpleState(ctx, question ? 'sys_empty_search_question' : 'sys_empty_search', question);
+    const sysState = makeSimpleState(ctx, question ? 'sys_empty_search_question' : 'sys_empty_search', question ? question.name : null);
     return checkStateIsValid(ctx, sysState, userState);
 }
 

--- a/languages/thingtalk/en/computation.genie
+++ b/languages/thingtalk/en/computation.genie
@@ -168,6 +168,7 @@ compute_question = {
         ( 'how many' p:out_param_ArrayCount ('does' | 'do') table:with_filtered_table 'have ?'
         | 'how many' p:out_param_ArrayCount ('in a' | 'in' | 'in the') table:with_filtered_table '?'
         | 'how many' p:out_param_ArrayCount 'are there' ('in a' | 'in' | 'in the') table:with_filtered_table '?'
+
         | 'how many' p:out_param_ArrayCount ('does' | 'do') 'the' table:with_arg_min_max_table 'have ?'
         | 'how many' p:out_param_ArrayCount 'in the' table:with_arg_min_max_table '?'
         | 'how many' p:out_param_ArrayCount 'are there in the' table:with_arg_min_max_table '?'
@@ -180,6 +181,7 @@ compute_question = {
         ( 'how many' p:out_param_Array__Any ('does' | 'do') table:with_filtered_table 'have ?'
         | 'how many' p:out_param_Array__Any ('in a' | 'in' | 'in the') table:with_filtered_table '?'
         | 'how many' p:out_param_Array__Any 'are there' ('in a' | 'in' | 'in the') table:with_filtered_table '?'
+
         | 'how many' p:out_param_Array__Any ('does' | 'do') 'the' table:with_arg_min_max_table 'have ?'
         | 'how many' p:out_param_Array__Any 'in the' table:with_arg_min_max_table '?'
         | 'how many' p:out_param_Array__Any 'are there in the' table:with_arg_min_max_table '?'
@@ -192,9 +194,11 @@ compute_question = {
             return C.makeAggComputeProjExpression(table, 'count', null, p, Type.Number);
         };
 
+        !dialogues {
         ( 'how many' p:out_param_Array__Any 'with' filter:with_filter ('does' | 'do') table:with_filtered_table 'have ?'
         | 'how many' p:out_param_Array__Any 'with' filter:with_filter ('in a' | 'in' | 'in the') table:with_filtered_table '?'
         | 'how many' p:out_param_Array__Any 'with' filter:with_filter 'are there' ('in a' | 'in' | 'in the') table:with_filtered_table '?'
+
         | 'how many' p:out_param_Array__Any 'with' filter:with_filter ('does' | 'do') 'the'  table:with_arg_min_max_table 'have ?'
         | 'how many' p:out_param_Array__Any 'with' filter:with_filter 'in the' table:with_arg_min_max_table '?'
         | 'how many' p:out_param_Array__Any 'with' filter:with_filter 'are there in the' table:with_arg_min_max_table '?'
@@ -209,6 +213,7 @@ compute_question = {
                 return null;
             return C.makeAggComputeProjExpression(table, 'count', null, list, Type.Number);
         };
+        }
 
         // aggregation questions
         ?aggregation {

--- a/languages/thingtalk/en/constants.genie
+++ b/languages/thingtalk/en/constants.genie
@@ -37,25 +37,31 @@ constant_date_point = {
     'this week'           => C.makeDate(new Ast.DateEdge('start_of', 'week'), '+', null);
 
     !turking {
-    'tomorrow'            => C.makeDate(new Ast.DateEdge('end_of', 'day'), '+', null);
-    'the end of the day'  => C.makeDate(new Ast.DateEdge('end_of', 'day'), '+', null);
-    'the end of the week' => C.makeDate(new Ast.DateEdge('end_of', 'week'), '+', null);
-    'last week'           => C.makeDate(new Ast.DateEdge('start_of', 'week'), '-', new Ast.Value.Measure(1, 'week'));
-    'this month'          => C.makeDate(new Ast.DateEdge('start_of', 'mon'), '+', null);
-    'this year'           => C.makeDate(new Ast.DateEdge('start_of', 'year'), '+', null);
-    'next month'          => C.makeDate(new Ast.DateEdge('end_of', 'mon'), '+', null);
-    'next year'           => C.makeDate(new Ast.DateEdge('end_of', 'year'), '+', null);
-    'last month'          => C.makeDate(new Ast.DateEdge('end_of', 'mon'), '-', new Ast.Value.Measure(1, 'mon'));
-    'last year'           => C.makeDate(new Ast.DateEdge('end_of', 'year'), '-', new Ast.Value.Measure(1, 'year'));
+        'last week'           => C.makeDate(new Ast.DateEdge('start_of', 'week'), '-', new Ast.Value.Measure(1, 'week'));
+        'last month'          => C.makeDate(new Ast.DateEdge('end_of', 'mon'), '-', new Ast.Value.Measure(1, 'mon'));
+        'last year'           => C.makeDate(new Ast.DateEdge('end_of', 'year'), '-', new Ast.Value.Measure(1, 'year'));
+
+        ?future_dates {
+            'tomorrow'            => C.makeDate(new Ast.DateEdge('end_of', 'day'), '+', null);
+            'the end of the day'  => C.makeDate(new Ast.DateEdge('end_of', 'day'), '+', null);
+            'the end of the week' => C.makeDate(new Ast.DateEdge('end_of', 'week'), '+', null);
+            'this month'          => C.makeDate(new Ast.DateEdge('start_of', 'mon'), '+', null);
+            'this year'           => C.makeDate(new Ast.DateEdge('start_of', 'year'), '+', null);
+            'next month'          => C.makeDate(new Ast.DateEdge('end_of', 'mon'), '+', null);
+            'next year'           => C.makeDate(new Ast.DateEdge('end_of', 'year'), '+', null);
+        }
     }
 }
 
 constant_Date = {
     !turking {
-    duration:constant_Measure_ms 'from now' => C.makeDate(null, '+', duration);
-    duration:constant_Measure_ms 'ago'      => C.makeDate(null, '-', duration);
-    duration:constant_Measure_ms 'after' pt:constant_date_point  => C.makeDate(pt, '+', duration);
-    duration:constant_Measure_ms 'before' pt:constant_date_point => C.makeDate(pt, '-', duration);
+        duration:constant_Measure_ms 'ago'      => C.makeDate(null, '-', duration);
+        duration:constant_Measure_ms 'before' pt:constant_date_point => C.makeDate(pt, '-', duration);
+
+        ?future_dates {
+            duration:constant_Measure_ms 'from now' => C.makeDate(null, '+', duration);
+            duration:constant_Measure_ms 'after' pt:constant_date_point  => C.makeDate(pt, '+', duration);
+        }
     }
 }
 

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -269,7 +269,7 @@ $agent = {
         return D.makeSimpleState(ctx, 'sys_slot_fill', questions);
     };
 
-    ctx:ctx_search_command proposal:system_generic_proposal =>
+    ctx:ctx_search_command proposal:system_generic_proposal [weight=0.5] =>
         D.addQuery(ctx, 'sys_propose_refined_query', proposal, 'proposed');
 
     // action recommendation (through one or a list)

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -146,10 +146,16 @@ context function (state) {
                     tags.push('ctx_argminmax_question');
                 */
                 tags.push('ctx_single_result_search_command');
+
+                // we can recommend/show the result right away, even if many match
+                tags.push('ctx_complete_search_command');
             } else if (info.resultInfo.hasSingleResult) {
                 // "what is the rating of Terun?"
                 // FIXME if we want to answer differently, we need to change this one
                 tags.push('ctx_single_result_search_command');
+
+                // we can recommend/show the result right away, even if many match
+                tags.push('ctx_complete_search_command');
             } else {
                 // "what's the food and price range of restaurants nearby?"
                 // we treat these the same as "find restaurants nearby", but we make sure
@@ -232,10 +238,13 @@ $agent = {
         => D.makeSimpleState(ctx, 'sys_anything_else', null);
 
     // empty search error
-    ctx:ctx_empty_search_command question:empty_search_error => {
-        if (!D.isGoodEmptySearchQuestion(ctx, question))
+    ctx:ctx_empty_search_command error:empty_search_error => {
+        const [base, question] = error;
+        if (base !== null && !C.isSameFunction(base.schema, ctx.current.stmt.table.schema))
             return null;
-        return D.makeSimpleState(ctx, question ? 'sys_empty_search_question' : 'sys_empty_search', question);
+        if (question !== null && !D.isGoodEmptySearchQuestion(ctx, question.name))
+            return null;
+        return D.makeSimpleState(ctx, question ? 'sys_empty_search_question' : 'sys_empty_search', question.name);
     };
 
     // query refinement (through proposal or slot fill)

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -47,6 +47,7 @@ context ctx_init,
     ctx_end,
     ctx_with_result,
     ctx_with_action,
+    ctx_without_action,
     ctx_with_result_and_action,
     ctx_with_result_question,
     ctx_with_result_noquestion,
@@ -109,6 +110,8 @@ context function (state) {
 
             if (!info.nextInfo.isComplete)
                 tags.push('ctx_incomplete_action');
+        } else {
+            tags.push('ctx_without_action');
         }
 
         // we must have a result
@@ -349,9 +352,11 @@ $root = {
 
     // action recommendation (through one or a list)
 
-    ctx:ctx_complete_search_command pair:negative_recommendation_reply_pair [weight=0.3]
+    ctx:ctx_complete_search_command pair:negative_recommendation_reply_pair [weight=0.6]
         => D.negativeRecommendationReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:positive_recommendation_reply_pair [weight=0.7]
+        => D.positiveRecommendationReplyPair(ctx, pair);
+    ctx:ctx_complete_search_command pair:positive_recommendation_reply_by_name_pair [weight=0.7]
         => D.positiveRecommendationReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:recommendation_search_question_pair [weight=1]
         => D.recommendationSearchQuestionPair(ctx, pair);

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -39,7 +39,8 @@ import './dlg/recommendation';
 import './dlg/refinement';
 import './dlg/results';
 import './dlg/slot-fill';
-import './dlg/related-questions.genie';
+import './dlg/related-questions';
+import './dlg/action-results';
 
 context ctx_init,
     ctx_greet,
@@ -111,13 +112,18 @@ context function (state) {
             if (!info.nextInfo.isComplete)
                 tags.push('ctx_incomplete_action');
         } else {
-            tags.push('ctx_without_action');
+            if (info.resultInfo && info.resultInfo.isTable)
+                tags.push('ctx_without_action');
         }
 
         // we must have a result
         assert(info.resultInfo, `expected result info`);
-        if (!info.resultInfo.isTable)
-            return [['ctx_completed_action_success'], info];
+        if (!info.resultInfo.isTable) {
+            if (info.resultInfo.hasError)
+                return [['ctx_completed_action_error'], info];
+            else
+                return [['ctx_with_result', 'ctx_completed_action_success'], info];
+        }
 
         if (info.resultInfo.hasEmptyResult) {
             // note: aggregation cannot be empty (it would be zero)
@@ -330,6 +336,10 @@ $root = {
         return D.checkStateIsValid(ctx, sysState, userState);
     };
 
+    // action results
+    ctx:ctx_completed_action_success action_success_terminal_pair
+        => D.actionSuccessTerminalPair(ctx);
+
     // empty search error
     ctx:ctx_empty_search_command pair:empty_search_change_pair
         => D.emptySearchChangePair(ctx, pair);
@@ -352,10 +362,10 @@ $root = {
 
     // action recommendation (through one or a list)
 
-    ctx:ctx_complete_search_command pair:negative_recommendation_reply_pair [weight=0.6]
-        => D.negativeRecommendationReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:positive_recommendation_reply_pair [weight=0.7]
         => D.positiveRecommendationReplyPair(ctx, pair);
+    ctx:ctx_complete_search_command pair:negative_recommendation_reply_pair [weight=0.6]
+        => D.negativeRecommendationReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:positive_recommendation_reply_by_name_pair [weight=0.7]
         => D.positiveRecommendationReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:recommendation_search_question_pair [weight=1]
@@ -367,10 +377,10 @@ $root = {
     ctx:ctx_complete_search_command pair:recommendation_related_question_pair [weight=1]
         => D.recommendationRelatedQuestionPair(ctx, pair);
 
-    ctx:ctx_complete_search_command pair:negative_list_proposal_reply_pair [weight=10 * 0.3]
-        => D.negativeListProposalReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:positive_list_proposal_reply_pair [weight=10 * 0.7]
         => D.positiveListProposalReplyPair(ctx, pair);
+    ctx:ctx_complete_search_command pair:negative_list_proposal_reply_pair [weight=10 * 0.3]
+        => D.negativeListProposalReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:list_proposal_search_question_pair [weight=10]
         => D.listProposalSearchQuestionPair(ctx, pair);
     ctx:ctx_complete_search_command pair:list_proposal_related_question_pair [weight=1]

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -92,6 +92,9 @@ context function (state) {
     case 'cancel':
         return [['ctx_cancel'], info];
 
+    case 'action_question':
+        return [['ctx_with_result', 'ctx_completed_action_success'], info];
+
     case 'execute': {
         const tags = [];
 
@@ -339,6 +342,8 @@ $root = {
     // action results
     ctx:ctx_completed_action_success action_success_terminal_pair
         => D.actionSuccessTerminalPair(ctx);
+    ctx:ctx_completed_action_success question:action_success_question_pair
+        => D.actionSuccessQuestionPair(ctx, question);
 
     ctx:ctx_completed_action_error error:action_error_terminal_pair [weight=0.1]
         => D.actionErrorTerminalPair(ctx, error);

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -43,6 +43,7 @@ import './dlg/slot-fill';
 context ctx_init,
     ctx_greet,
     ctx_cancel,
+    ctx_end,
     ctx_with_result,
     ctx_with_action,
     ctx_with_result_and_action,
@@ -74,10 +75,11 @@ context function (state) {
         return null;
     const info = D.getContextInfo(state);
 
-    // no continuations possible after explicit "end" (which means the user said
+    // no continuations are possible after explicit "end" (which means the user said
     // "no thanks" after the agent asked "is there anything else I can do for you")
+    // but we still tag the context to generate something in inference mode
     if (state.dialogueAct === 'end')
-        return null;
+        return [['ctx_end'], info];
 
     switch (state.dialogueAct) {
     case 'greet':
@@ -236,6 +238,9 @@ $agent = {
 
     ctx:ctx_cancel anything_else_phrase
         => D.makeSimpleState(ctx, 'sys_anything_else', null);
+
+    ctx:ctx_end 'alright ,' ('bye !' | 'good bye !')
+        => D.makeSimpleState(ctx, 'sys_end', null);
 
     // empty search error
     ctx:ctx_empty_search_command error:empty_search_error => {

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -124,6 +124,8 @@ context function (state) {
         if (!info.resultInfo.isTable) {
             if (info.resultInfo.hasError)
                 return [['ctx_completed_action_error'], info];
+            else if (info.resultInfo.hasEmptyResult)
+                return [['ctx_completed_action_success'], info];
             else
                 return [['ctx_with_result', 'ctx_completed_action_success'], info];
         }

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -180,9 +180,14 @@ context function (state) {
     }
 }
 
+system_learn_more = {
+    'what would you like to know ?';
+    'what would you like to hear ?';
+}
+
 learn_more_search_question_pair = {
-    ( 'what would you like to' ('know' | 'hear') '?' '<sep>' questions:simple_user_search_question
-    | 'what would you like to' ('know' | 'hear') '?' '<sep>' questions:boolean_user_search_question
+    ( system_learn_more '<sep>' questions:simple_user_search_question
+    | system_learn_more '<sep>' questions:boolean_user_search_question
     ) => {
         return [null, null, questions];
     };
@@ -216,6 +221,64 @@ initial_command = {
         return prog.rules[0];
     };
 
+}
+
+$agent = {
+    ctx:ctx_greet ('hello' | 'hi') ('!' | ',') ('how can i help you' | 'what are you interested in' | 'what can i do for you') '?'
+        => D.makeSimpleState(ctx, 'sys_greet', null);
+
+    ctx:ctx_cancel anything_else_phrase
+        => D.makeSimpleState(ctx, 'sys_anything_else', null);
+
+    // empty search error
+    ctx:ctx_empty_search_command question:empty_search_error => {
+        if (!D.isGoodEmptySearchQuestion(ctx, question))
+            return null;
+        return D.makeSimpleState(ctx, question ? 'sys_empty_search_question' : 'sys_empty_search', question);
+    };
+
+    // query refinement (through proposal or slot fill)
+    ctx:ctx_search_command questions:search_question => {
+        if (!D.isGoodSearchQuestion(ctx, questions))
+            return null;
+        if (questions.length === 0)
+            return D.makeSimpleState(ctx, 'sys_generic_search_question', null);
+        else
+            return D.makeSimpleState(ctx, 'sys_search_question', questions);
+    };
+
+    ctx:ctx_incomplete_action questions:slot_fill_question => {
+        if (!D.isGoodSlotFillQuestion(ctx, questions))
+            return null;
+        return D.makeSimpleState(ctx, 'sys_slot_fill', questions);
+    };
+
+    ctx:ctx_search_command proposal:system_generic_proposal =>
+        D.addQuery(ctx, 'sys_propose_refined_query', proposal, 'proposed');
+
+    // action recommendation (through one or a list)
+
+    ctx:ctx_complete_search_command proposal:system_recommendation => {
+        const { topResult, action } = proposal;
+        if (action === null) {
+            return D.makeSimpleState(ctx, 'sys_recommend_one', null);
+        } else {
+            const chainParam = D.findChainParam(topResult, action);
+            return D.addActionParam(ctx, 'sys_recommend_one', action, chainParam, topResult.value.id, 'proposed');
+        }
+    };
+
+    ctx:ctx_complete_search_command proposal:system_list_proposal [weight=10] => {
+        const [results, /*info*/, action] = proposal;
+        const dialogueAct = results.length === 2 ? 'sys_recommend_two' : 'sys_recommend_three';
+        if (action === null)
+            return D.makeSimpleState(ctx, dialogueAct, null);
+        else
+            return D.addAction(ctx, dialogueAct, action, 'proposed');
+    };
+
+    ctx:ctx_learn_more system_learn_more
+        => D.makeSimpleState(ctx, 'sys_learn_more_what', null);
 }
 
 $root = {

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -39,6 +39,7 @@ import './dlg/recommendation';
 import './dlg/refinement';
 import './dlg/results';
 import './dlg/slot-fill';
+import './dlg/related-questions.genie';
 
 context ctx_init,
     ctx_greet,
@@ -173,8 +174,8 @@ context function (state) {
             else // we can refine
                 tags.push('ctx_search_command');
 
-            if (!info.resultInfo.hasLargeResult) // we can /show the result
-                tags.push('ctx_complete_search_command');
+            // we can /show the result
+            tags.push('ctx_complete_search_command');
         }
 
         return [tags, info];
@@ -358,6 +359,8 @@ $root = {
         => D.recommendationCancelPair(ctx, pair);
     ctx:ctx_learn_more pair:learn_more_search_question_pair [weight=1]
         => D.recommendationSearchQuestionPair(ctx, pair);
+    ctx:ctx_complete_search_command pair:recommendation_related_question_pair [weight=1]
+        => D.recommendationRelatedQuestionPair(ctx, pair);
 
     ctx:ctx_complete_search_command pair:negative_list_proposal_reply_pair [weight=10 * 0.3]
         => D.negativeListProposalReplyPair(ctx, pair);
@@ -365,4 +368,6 @@ $root = {
         => D.positiveListProposalReplyPair(ctx, pair);
     ctx:ctx_complete_search_command pair:list_proposal_search_question_pair [weight=10]
         => D.listProposalSearchQuestionPair(ctx, pair);
+    ctx:ctx_complete_search_command pair:list_proposal_related_question_pair [weight=1]
+        => D.listProposalRelatedQuestionPair(ctx, pair);
 }

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -63,6 +63,7 @@ context ctx_init,
     ctx_completed_action_error,
     ctx_confirm_action,
     ctx_incomplete_action,
+    ctx_incomplete_action_after_search,
     ctx_learn_more;
 
 context function (state) {
@@ -97,7 +98,7 @@ context function (state) {
                 if (info.nextInfo.isComplete) {
                     return [['ctx_confirm_action'], info];
                 } else {
-                    return [['ctx_incomplete_action'], info];
+                    return [['ctx_incomplete_action', 'ctx_incomplete_action_after_search'], info];
                 }
             }
 
@@ -247,7 +248,7 @@ $agent = {
             return D.makeSimpleState(ctx, 'sys_search_question', questions);
     };
 
-    ctx:ctx_incomplete_action questions:slot_fill_question => {
+    ctx:ctx_incomplete_action_after_search questions:slot_fill_question => {
         if (!D.isGoodSlotFillQuestion(ctx, questions))
             return null;
         return D.makeSimpleState(ctx, 'sys_slot_fill', questions);

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -340,6 +340,11 @@ $root = {
     ctx:ctx_completed_action_success action_success_terminal_pair
         => D.actionSuccessTerminalPair(ctx);
 
+    ctx:ctx_completed_action_error error:action_error_terminal_pair [weight=0.1]
+        => D.actionErrorTerminalPair(ctx, error);
+    ctx:ctx_completed_action_error pair:action_error_change_param_pair
+        => D.actionErrorChangeParamPair(ctx, pair);
+
     // empty search error
     ctx:ctx_empty_search_command pair:empty_search_change_pair
         => D.emptySearchChangePair(ctx, pair);

--- a/languages/thingtalk/en/dlg/action-results.genie
+++ b/languages/thingtalk/en/dlg/action-results.genie
@@ -73,3 +73,89 @@ action_success_phrase = {
 action_success_terminal_pair = {
     action:action_success_phrase anything_else_phrase '<sep>' thanks_phrase ('goodbye !' | '') => action;
 }
+
+short_action_error_message = {
+    ctx:ctx_completed_action_error msg:thingpedia_error_message if complete
+        => D.checkThingpediaErrorMessage(ctx, msg);
+
+    ctx:ctx_completed_action_error msg:constant_String => {
+        const error = ctx.error;
+        if (error.isString && error.equals(msg))
+            return ctx;
+        else
+            return null;
+    };
+}
+
+action_description_phrase = {
+    coref_action_phrase;
+
+    ( action:action_description_phrase param:preposition_input_param
+    | action:action_description_phrase ('with' | 'having') param:npp_input_param
+    ) => C.addInvocationInputParam(action, param);
+}
+
+long_action_error_message = {
+    ('i could not' | 'it was not possible to') action:action_description_phrase (':' | 'because') ctx:short_action_error_message
+        => D.checkActionErrorMessage(ctx, action);
+}
+
+one_param_try_different_param_question = {
+    ( 'would you like to try a different' p:input_param '?'
+    | 'would you like a different' p:input_param '?'
+    | 'shall i try another' p:input_param '?'
+    | 'how about for another' p:input_param '?'
+    ) => {
+        return [p.name];
+    };
+}
+
+two_param_try_different_param_question = {
+    ( 'would you like to try a different' p1:input_param 'or' p2:input_param '?'
+    | 'would you like a different' p1:input_param 'or' p2:input_param '?'
+    | 'shall i try another' p1:input_param 'or' p2:input_param '?'
+    | 'how about for another' p1:input_param 'or' p2:input_param '?'
+    ) => {
+        if (p1 === p2)
+            return null;
+        return [p1, p2];
+    };
+}
+
+action_error_phrase = {
+    sorry_preamble ctx:short_action_error_message '.' => [ctx.currentFunctionSchema, []];
+
+    ( sorry_preamble ctx:short_action_error_message '.' questions:one_param_try_different_param_question [weight=1]
+    | sorry_preamble ctx:short_action_error_message '.' questions:two_param_try_different_param_question [weight=0.5]
+    | sorry_preamble ctx:long_action_error_message '.' questions:one_param_try_different_param_question [weight=1]
+    | sorry_preamble ctx:long_action_error_message '.' questions:two_param_try_different_param_question [weight=0.5]
+    ) => {
+        const schema = ctx.currentFunctionSchema;
+        for (let q of questions) {
+            const arg = schema.getArgument(q);
+            if (!arg || !arg.is_input)
+                return null;
+        }
+        return [schema, questions];
+    };
+}
+
+action_error_terminal_pair = {
+    error:action_error_phrase '<sep>' no_thanks_phrase => error;
+    error:action_error_phrase '<sep>' nevermind_phrase => error;
+}
+
+action_error_change_param_pair = {
+    error:action_error_phrase '<sep>' ('i see ,' | 'okay' | 'okay ,' | 'yeah' | 'yeah ,') ('can you try' | 'how about') answer:imprecise_slot_fill_answer_phrase '?' => {
+        const [schema, questions] = error;
+        if (answer instanceof Ast.Value) {
+            if (questions.length !== 1)
+                return null;
+            answer = new Ast.InputParam(null, questions[0], answer);
+        }
+        const arg = schema.getArgument(answer.name);
+        if (!arg || !arg.is_input || !arg.type.equals(answer.value.getType()))
+            return null;
+        return [error, answer];
+    };
+}

--- a/languages/thingtalk/en/dlg/action-results.genie
+++ b/languages/thingtalk/en/dlg/action-results.genie
@@ -1,0 +1,75 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+
+// Action result templates: used after executing the action
+// Either the action was successful, and we're done, or
+// the action failed, and we give the user an option to try again
+
+{
+    const assert = require('assert');
+    const ThingTalk = require('thingtalk');
+    const Ast = ThingTalk.Ast;
+    const Type = ThingTalk.Type;
+
+    const C = require('../../ast_manip');
+    const D = require('../../dialogue_utils');
+
+    // import thingpedia info
+    const _tpLoader = require('../../load-thingpedia');
+}
+
+for (let [pname, [typestr,]] of _tpLoader.params.in.values()) {
+    thingpedia_action_past = {
+        ( action:thingpedia_action_past 'it'
+        | action:thingpedia_action_past 'this'
+        | action:thingpedia_action_past 'that'
+        ) [-> pname] => {
+            const type = action.schema.getArgType(pname);
+            if (!type || !type.isEntity)
+                return null;
+            return C.replacePlaceholderWithUndefined(action, pname, typestr);
+        };
+    }
+}
+
+complete_past_action_phrase = {
+    action:thingpedia_action_past 'for you' if complete => {
+        if (!(action instanceof Ast.Action.Invocation))
+            return null;
+        return action.invocation;
+    };
+
+    ( action:complete_past_action_phrase param:preposition_input_param
+    | action:complete_past_action_phrase ('with' | 'having') param:npp_input_param
+    ) => C.addInvocationInputParam(action, param);
+}
+
+generic_action_success_phrase = {
+    'your request was completed successfully';
+    'consider your request done !';
+}
+
+action_success_phrase = {
+    ctx:ctx_completed_action_success generic_excitement_phrase result:thingpedia_result if complete
+        => D.makeThingpediaActionSuccessPhrase(ctx, result);
+
+    ctx:ctx_completed_action_success generic_excitement_phrase generic_action_success_phrase result:direct_result_info_phrase
+        => D.makeThingpediaActionSuccessPhrase(ctx, result);
+
+    ctx:ctx_completed_action_success 'i' action:complete_past_action_phrase '.'
+        => D.makeCompleteActionSuccessPhrase(ctx, action, null);
+
+    ctx:ctx_completed_action_success 'i' action:complete_past_action_phrase '.' info:direct_result_info_phrase
+        => D.makeCompleteActionSuccessPhrase(ctx, action, info);
+}
+
+action_success_terminal_pair = {
+    action:action_success_phrase anything_else_phrase '<sep>' thanks_phrase ('goodbye !' | '') => action;
+}

--- a/languages/thingtalk/en/dlg/action-results.genie
+++ b/languages/thingtalk/en/dlg/action-results.genie
@@ -74,6 +74,19 @@ action_success_terminal_pair = {
     action:action_success_phrase anything_else_phrase '<sep>' thanks_phrase ('goodbye !' | '') => action;
 }
 
+action_success_question_pair = {
+    action:action_success_phrase anything_else_phrase '<sep>' questions:simple_user_search_question => {
+        for (let [qname, qtype] of questions) {
+            const arg = action.schema.getArgument(qname);
+            if (!arg || arg.is_input)
+                return null;
+            if (qtype !== null && !qtype.equals(arg.type))
+                return null;
+        }
+        return questions.map(([qname, qtype]) => qname);
+    };
+}
+
 short_action_error_message = {
     ctx:ctx_completed_action_error msg:thingpedia_error_message if complete
         => D.checkThingpediaErrorMessage(ctx, msg);

--- a/languages/thingtalk/en/dlg/coref-actions.genie
+++ b/languages/thingtalk/en/dlg/coref-actions.genie
@@ -116,11 +116,21 @@ action_coref_list_proposal = {
 // sentences from the user
 
 coref_action_command = {
-    ( ctx:ctx_with_action base:coref_action_phrase
-    | ctx:ctx_with_action base:contextual_action_phrase
-    ) if complete => D.contextualAction(ctx, base);
+    ctx:ctx_with_action base:coref_action_phrase if complete
+        => D.contextualAction(ctx, base);
+    ctx:ctx_without_action base:coref_action_phrase => base;
 
     ( action:coref_action_command param:preposition_input_param
     | action:coref_action_command ('with' | 'having') param:npp_input_param
+    ) => C.addInvocationInputParam(action, param);
+}
+
+action_by_name_command = {
+    ctx:ctx_with_action base:contextual_action_phrase if complete
+        => D.contextualAction(ctx, base);
+    ctx:ctx_without_action base:contextual_action_phrase => base;
+
+    ( action:contextual_action_phrase param:preposition_input_param
+    | action:contextual_action_phrase ('with' | 'having') param:npp_input_param
     ) => C.addInvocationInputParam(action, param);
 }

--- a/languages/thingtalk/en/dlg/coref-actions.genie
+++ b/languages/thingtalk/en/dlg/coref-actions.genie
@@ -23,6 +23,10 @@
     const _tpLoader = require('../../load-thingpedia');
 }
 
+coref_action_phrase = {}
+contextual_action_phrase = {}
+list_coref_action_phrase = {}
+
 for (let [pname, [typestr,]] of _tpLoader.params.in.values()) {
     // coref to one object (for recommendation)
     coref_action_phrase = {

--- a/languages/thingtalk/en/dlg/coref-questions.genie
+++ b/languages/thingtalk/en/dlg/coref-questions.genie
@@ -45,7 +45,7 @@ simple_user_search_question = {
     | 'i need' ('the' | 'its') p1:out_param_Any 'and' p2:out_param_Any ('first' | '') '.'
     | 'i just need' ('the' | 'its') p1:out_param_Any 'and' p2:out_param_Any '.'
     ) => {
-        if (p1.name === 'id' || p2.name === 'id')
+        if (p1.name === 'id' || p2.name === 'id' || p1.name === p2.name)
             return null;
         return [[p1.name, null], [p2.name, null]];
     };

--- a/languages/thingtalk/en/dlg/list-proposal.genie
+++ b/languages/thingtalk/en/dlg/list-proposal.genie
@@ -106,10 +106,32 @@ negative_list_proposal_reply_pair = {
         => D.mergePreambleAndRequest(pair, request);
 }
 
+generic_list_proposal_accept_phrase = {
+    ('ok' | 'yeah' | '') ('i like' | 'i am interested in' | 'i am intrigued by') name:constant_name '.' => name;
+    ('ok' | 'yeah' | '') name:constant_name 'sounds' ('good' | 'really good' | 'nice' | 'interesting') '.' => name;
+}
+
+list_proposal_accept_phrase_must_have_action = {
+    ('ok' | 'yeah' | '') ('i will go' | 'i will take' | 'i am good for') name:constant_name '.' => name;
+}
+
+list_proposal_accept_phrase_with_action = {
+    name:generic_list_proposal_accept_phrase generic_preamble_for_action action:coref_action_command => [name, action];
+    name:list_proposal_accept_phrase_must_have_action generic_preamble_for_action action:coref_action_command => [name, action];
+}
+
+list_proposal_accept_phrase_with_action_by_name = {
+    ('ok' | 'yeah' | '') generic_preamble_for_action action:action_by_name_command => action;
+}
+
+list_proposal_tell_me_more = {
+    ('ok' | 'yeah' | '') 'can you tell me more about' name:constant_name '?' => name;
+    ('ok' | 'yeah' | '') ('i like' | 'i am interested in' | 'i am intrigued by') name:constant_name '.' tell_me_more_phrase => name;
+    ('ok' | 'yeah' | '') name:constant_name 'sounds' ('good' | 'really good' | 'nice' | 'interesting') '.' tell_me_more_phrase => name;
+}
+
 positive_list_proposal_reply_pair = {
-    ( prop:system_list_proposal '<sep>' ('ok' | 'yeah' | '') ('i like' | 'i am interested in' | 'i am intrigued by') name:constant_name '.' [weight=0.5]
-    | prop:system_list_proposal '<sep>' ('ok' | 'yeah' | '') name:constant_name 'sounds' ('good' | 'really good' | 'nice' | 'interesting') '.' [weight=0.5]
-    ) => {
+    prop:system_list_proposal '<sep>' name:generic_list_proposal_accept_phrase => {
         const [results, info, actionProposal] = prop;
         let good = false;
         for (let result of results) {
@@ -124,7 +146,7 @@ positive_list_proposal_reply_pair = {
         return [results, actionProposal, name, actionProposal];
     };
 
-    prop:system_list_proposal '<sep>' ('ok' | 'yeah' | '') ('i will go' | 'i will take' | 'i am good for') name:constant_name '.' => {
+    prop:system_list_proposal '<sep>' name:list_proposal_accept_phrase_must_have_action => {
         const [results, info, actionProposal] = prop;
         if (actionProposal === null)
             return null;
@@ -141,10 +163,56 @@ positive_list_proposal_reply_pair = {
         return [results, actionProposal, name, actionProposal];
     };
 
-    ( prop:system_list_proposal '<sep>' ('ok' | 'yeah' | '') 'can you tell me more about' name:constant_name '?' [weight=0.33]
-    | prop:system_list_proposal '<sep>' ('ok' | 'yeah' | '') ('i like' | 'i am interested in' | 'i am intrigued by') name:constant_name '.' tell_me_more_phrase [weight=0.33]
-    | prop:system_list_proposal '<sep>' ('ok' | 'yeah' | '') name:constant_name 'sounds' ('good' | 'really good' | 'nice' | 'interesting') '.' tell_me_more_phrase [weight=0.33]
-    ) => {
+    prop:system_list_proposal '<sep>' accept:list_proposal_accept_phrase_with_action => {
+        const [results, info, actionProposal] = prop;
+        const [name, acceptedAction] = accept;
+        if (actionProposal !== null && !C.isSameFunction(actionProposal.schema, acceptedAction.schema))
+            return null;
+        let good = false;
+        for (let result of results) {
+            if (result.value.id.equals(name)) {
+                good = true;
+                break;
+            }
+        }
+        if (!good)
+            return false;
+
+        return [results, actionProposal, name, acceptedAction];
+    };
+
+    prop:system_list_proposal '<sep>' action:list_proposal_accept_phrase_with_action_by_name => {
+        const [results, info, actionProposal] = prop;
+        if (actionProposal !== null && !C.isSameFunction(actionProposal.schema, action.schema))
+            return null;
+
+        const idType = results[0].value.id.getType();
+        let name = null;
+        const acceptedAction = action.clone();
+        // find the chain parameter for the action, extract the name, and set the param to undefined
+        // as the rest of the code expects
+        for (let in_param of acceptedAction.in_params) {
+            const arg = action.schema.getArgument(in_param.name);
+            assert(arg);
+            if (arg.type.equals(idType)) {
+                name = in_param.value;
+                in_param.value = new Ast.Value.Undefined(true);
+                break;
+            }
+        }
+        if (!name)
+            return null;
+        let good = false;
+        for (let result of results) {
+            if (result.value.id.equals(name)) {
+                good = true;
+                break;
+            }
+        }
+        return [results, actionProposal, name, acceptedAction];
+    };
+
+    prop:system_list_proposal '<sep>' name:list_proposal_tell_me_more => {
         const [results, info, actionProposal] = prop;
         let good = false;
         for (let result of results) {

--- a/languages/thingtalk/en/dlg/list-proposal.genie
+++ b/languages/thingtalk/en/dlg/list-proposal.genie
@@ -190,3 +190,8 @@ list_proposal_search_question_pair = {
         return [results, name, action, [pname, type]];
     };
 }
+
+
+list_proposal_related_question_pair = {
+    prop:system_list_proposal '<sep>' question:related_question => [prop, question];
+}

--- a/languages/thingtalk/en/dlg/list-proposal.genie
+++ b/languages/thingtalk/en/dlg/list-proposal.genie
@@ -187,7 +187,7 @@ list_proposal_search_question_pair = {
             if (type !== null && !info.schema.getArgType(pname).equals(type))
                 return null;
         }
-        return [results, name, action, [pname, type]];
+        return [results, name, action, [[pname, type]]];
     };
 }
 

--- a/languages/thingtalk/en/dlg/recommendation.genie
+++ b/languages/thingtalk/en/dlg/recommendation.genie
@@ -177,6 +177,10 @@ negative_recommendation_reply_pair = {
         => D.mergePreambleAndRequest(pair, request);
 }
 
+recommendation_accept_phrase_with_action = {
+    accept_phrase generic_preamble_for_action action:coref_action_command => action;
+}
+
 positive_recommendation_reply_pair = {
     prop:system_recommendation '<sep>' accept_phrase [repeat=true] => {
         const { topResult, action: actionProposal } = prop;
@@ -190,14 +194,67 @@ positive_recommendation_reply_pair = {
         // this doesn't make much sense, so we don't want this flow
         if (actionProposal === null)
             return null;
-
         return [topResult, actionProposal, actionProposal];
+    };
+
+    prop:system_recommendation '<sep>' acceptedAction:recommendation_accept_phrase_with_action => {
+        const { topResult, action: actionProposal } = prop;
+        if (actionProposal !== null && !C.isSameFunction(actionProposal.schema, acceptedAction.schema))
+            return null;
+        return [topResult, actionProposal, acceptedAction];
     };
 
     ( prop:system_recommendation '<sep>' tell_me_more_phrase [weight=0.5]
     | prop:system_recommendation '<sep>' accept_phrase tell_me_more_phrase [weight=0.5]
     ) => {
         const { topResult, action: actionProposal } = prop;
+        // set the action to null, which will hit the "tell me more" path
+        return [topResult, actionProposal, null];
+    };
+}
+
+positive_recommendation_reply_by_name_pair = {
+    prop:system_recommendation '<sep>' name:generic_list_proposal_accept_phrase => {
+        const { topResult, action: actionProposal } = prop;
+        // if the user did not give an action earlier, and no action
+        // was proposed by the agent right now, the flow is roughly
+        //
+        // U: hello i am looking for a restaurant
+        // A: how about the ... ?
+        // U: sure I like that
+        //
+        // this doesn't make much sense, so we don't want this flow
+        if (actionProposal === null)
+            return null;
+        if (!topResult.value.id.equals(name))
+            return null;
+        return [topResult, actionProposal, actionProposal];
+    };
+
+    prop:system_recommendation '<sep>' name:list_proposal_accept_phrase_must_have_action => {
+        const { topResult, action: actionProposal } = prop;
+        if (actionProposal === null)
+            return null;
+        if (!topResult.value.id.equals(name))
+            return null;
+        return [topResult, actionProposal, actionProposal];
+    };
+
+    prop:system_recommendation '<sep>' accept:list_proposal_accept_phrase_with_action => {
+        const { topResult, action: actionProposal } = prop;
+        const [name, acceptedAction] = accept;
+        if (actionProposal !== null && !C.isSameFunction(actionProposal.schema, acceptedAction.schema))
+            return null;
+        if (!topResult.value.id.equals(name))
+            return null;
+
+        return [topResult, actionProposal, acceptedAction];
+    };
+
+    prop:system_recommendation '<sep>' name:list_proposal_tell_me_more => {
+        const { topResult, action: actionProposal } = prop;
+        if (!topResult.value.id.equals(name))
+            return null;
         // set the action to null, which will hit the "tell me more" path
         return [topResult, actionProposal, null];
     };

--- a/languages/thingtalk/en/dlg/recommendation.genie
+++ b/languages/thingtalk/en/dlg/recommendation.genie
@@ -41,6 +41,11 @@ action_recommendation = {
 }
 
 actionable_system_recommendation_short = {
+    ctx:ctx_with_result_noquestion proposal:thingpedia_result if complete
+        => D.makeThingpediaRecommendation(ctx, proposal);
+    ctx:ctx_with_result_noquestion proposal:thingpedia_result if complete
+        => D.makeThingpediaRecommendation(ctx, proposal);
+
     ( ctx:ctx_with_result_and_action 'i' ('recommend' | 'suggest') proposal:constant_name
     | ctx:ctx_with_result_noquestion ('i see' | 'i have' | 'i have found' | 'i have one , it is') proposal:constant_name
     ) => D.makeRecommendation(ctx, proposal);
@@ -236,4 +241,9 @@ recommendation_cancel_pair = {
             return null;
         return prop;
     };
+}
+
+
+recommendation_related_question_pair = {
+    prop:system_recommendation '<sep>' question:related_question => [prop, question];
 }

--- a/languages/thingtalk/en/dlg/recommendation.genie
+++ b/languages/thingtalk/en/dlg/recommendation.genie
@@ -70,6 +70,11 @@ user_question_answer_begin = {
         => D.makeRecommendation(ctx, proposal);
 }
 
+direct_user_question_answer = {
+    ctx:ctx_with_result_question info:direct_result_info_phrase
+        => D.makeThingpediaRecommendation(ctx, info);
+}
+
 proposal_info_action_pair = {
     'is a' info:result_info_phrase '.' action:action_coref_recommendation [weight=0.8] => {
         const resultType = info.schema.getArgType('id');
@@ -124,6 +129,9 @@ system_recommendation = {
     | proposal:user_question_answer_begin 'is' filter:apv_filter '.'
     | proposal:user_question_answer_begin 'has' filter:npp_filter '.'
     ) => D.makeShortUserQuestionAnswer(proposal, filter);
+
+    // even shorter answers to single questions
+    direct_user_question_answer;
 
     // recommendations after a search, followed by an offer to make an action
     ( proposal:actionable_system_recommendation_short '. it' pair:proposal_info_action_pair

--- a/languages/thingtalk/en/dlg/refinement.genie
+++ b/languages/thingtalk/en/dlg/refinement.genie
@@ -91,17 +91,17 @@ positive_proposal_reply_pair = {
 
 
 empty_search_error = {
-    !inference ('sorry ,' | 'i am sorry ,' | '') ('there are no' | 'i cannot find any') base:base_table ('matching your request' | 'with those characteristics' | 'like that')
+    !inference sorry_preamble ('there are no' | 'i cannot find any') base:base_table ('matching your request' | 'with those characteristics' | 'like that')
     '.' => [base, null];
 
-    ('sorry ,' | 'i am sorry ,' | '') ('there are no' | 'i cannot find any') base:base_table ('matching your request' | 'with those characteristics' | 'like that')
+    sorry_preamble ('there are no' | 'i cannot find any') base:base_table ('matching your request' | 'with those characteristics' | 'like that')
     '.' 'would you like' ('a different' | 'another') p:out_param_Any '?' => {
         if (!base.schema.hasArgument(p))
             return null;
         return [base, p];
     };
 
-    ('sorry ,' | 'i am sorry ,' | '') 'i cannot find any result for your search . would you like' ('a different' | 'another') p:out_param_Any '?'
+    sorry_preamble 'i cannot find any result for your search . would you like' ('a different' | 'another') p:out_param_Any '?'
         => [null, p];
 }
 

--- a/languages/thingtalk/en/dlg/refinement.genie
+++ b/languages/thingtalk/en/dlg/refinement.genie
@@ -91,7 +91,7 @@ positive_proposal_reply_pair = {
 
 
 empty_search_error = {
-    ('sorry ,' | 'i am sorry ,' | '') ('there are no' | 'i cannot find any') base:base_table ('matching your request' | 'with those characteristics' | 'like that')
+    !inference ('sorry ,' | 'i am sorry ,' | '') ('there are no' | 'i cannot find any') base:base_table ('matching your request' | 'with those characteristics' | 'like that')
     '.' => [base, null];
 
     ('sorry ,' | 'i am sorry ,' | '') ('there are no' | 'i cannot find any') base:base_table ('matching your request' | 'with those characteristics' | 'like that')

--- a/languages/thingtalk/en/dlg/related-questions.genie
+++ b/languages/thingtalk/en/dlg/related-questions.genie
@@ -1,0 +1,37 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+
+// Recommendation templates: the agent reads out or describe the top result from the search,
+// optionally proposing an action to do on it
+
+// A recommendation from the system is followed by:
+// - yes (= "positive_recommendation_reply_pair")
+// - some form of search refinement (= "negative_recommendation_reply_pair")
+// - a question (= "recommendation_search_question_pair")
+// - closing the dialogue (= "recommendation_cancel_pair")
+
+{
+    const assert = require('assert');
+    const ThingTalk = require('thingtalk');
+    const Ast = ThingTalk.Ast;
+    const Type = ThingTalk.Type;
+
+    const C = require('../../ast_manip');
+    const D = require('../../dialogue_utils');
+
+    // import thingpedia info
+    const _tpLoader = require('../../load-thingpedia');
+}
+
+related_question = {
+    ctx:ctx_with_result stmt:search_command [weight=0.1] => D.relatedQuestion(ctx, stmt);
+    ctx:ctx_with_result stmt:complete_question => D.relatedQuestion(ctx, stmt);
+    ctx:ctx_with_result stmt:projection_question [weight=0.1] => D.relatedQuestion(ctx, stmt);
+}

--- a/languages/thingtalk/en/dlg/results.genie
+++ b/languages/thingtalk/en/dlg/results.genie
@@ -74,7 +74,37 @@ result_name_list = {
     };
 }
 
+// a noun phrase of the form "the X is ... and the Y is ..."
+// used to answer questions, and to add extra information after recommendations & action results
+direct_result_info_phrase = {
+    ( ctx:ctx_with_result phrase:one_param_direct_result_info_phrase
+    | ctx:ctx_with_result phrase:two_param_direct_result_info_phrase
+    | ctx:ctx_with_result phrase:three_param_direct_result_info_phrase
+    ) => D.checkInfoPhrase(ctx, phrase);
+}
 
+one_param_direct_result_info_phrase = {
+    ('the' | 'its') param:out_param_Any 'is' v:constant_Any => {
+        const vtype = v.getType();
+        if (!_tpLoader.params.out.has(param.name + '+' + vtype))
+            return null;
+        const bag = new SlotBag(null);
+        bag.set(param.name, v);
+        return bag;
+    };
+}
+
+two_param_direct_result_info_phrase = {
+    b1:one_param_direct_result_info_phrase 'and' b2:one_param_direct_result_info_phrase => SlotBag.merge(b1, b2);
+}
+
+three_param_direct_result_info_phrase = {
+    b1:one_param_direct_result_info_phrase ',' b2:two_param_direct_result_info_phrase => SlotBag.merge(b1, b2);
+}
+
+// a noun phrase of the form "a restaurant in Cambridge that serves X"
+// structurally similar to a with_filter_table, but used to describe a result
+// so either filters & comparisons are not allowed, and the AST is different (it's a SlotBag)
 result_info_phrase = {
     // one, two or three slots, without any "or", "not" or "comparison" filters
     // only "and" and "contains"

--- a/languages/thingtalk/en/dlg/shared.genie
+++ b/languages/thingtalk/en/dlg/shared.genie
@@ -123,3 +123,16 @@ anything_else_phrase = {
     'do you need anything else ?';
     'anything else for you today ?';
 }
+
+sorry_preamble = {
+    'sorry ,';
+    'i am sorry ,';
+    '';
+}
+
+nevermind_phrase = {
+    'ok , never mind';
+    'never mind then';
+    'alright , never mind';
+    'too bad , alright';
+}

--- a/languages/thingtalk/en/dlg/shared.genie
+++ b/languages/thingtalk/en/dlg/shared.genie
@@ -45,6 +45,15 @@ the_base_noun_phrase = {
     ) => noun;
 }
 
+generic_excitement_phrase = {
+    'great !';
+    'awesome !';
+    'sounds good !';
+    'alright ,';
+    'sounds good ,';
+    'perfect !';
+}
+
 greeting = {
     'hello !';
     'hi !';
@@ -107,7 +116,6 @@ no_thanks_phrase = {
     'no thanks this will do for now .';
     'no thank you that will be all .';
 }
-
 
 anything_else_phrase = {
     'is there anything else i can help you with ?';

--- a/languages/thingtalk/en/dlg/slot-fill.genie
+++ b/languages/thingtalk/en/dlg/slot-fill.genie
@@ -182,7 +182,7 @@ direct_search_question = {
 yesno_search_question = {
     one_param_yesno_direct_search_question;
     two_param_yesno_direct_search_question;
-    generic_question;
+    !inference generic_question;
 }
 
 direct_search_question_with_preamble = {
@@ -194,7 +194,7 @@ direct_search_question_with_preamble = {
 yesno_search_question_with_preamble = {
     search_result_preamble question:one_param_yesno_direct_search_question => question;
     search_result_preamble question:two_param_yesno_direct_search_question => question;
-    search_result_preamble question:generic_question => question;
+    !inference search_result_preamble question:generic_question => question;
 }
 
 precise_search_question_answer_pair = {

--- a/languages/thingtalk/en/dlg/slot-fill.genie
+++ b/languages/thingtalk/en/dlg/slot-fill.genie
@@ -317,6 +317,7 @@ imprecise_slot_fill_question_answer_pair = {
 verbose_slot_fill_answer = {
     // complete answer, like "I am looking to book it for ... at ..."
     generic_preamble_for_action action:coref_action_command => action;
+    generic_preamble_for_action action:action_by_name_command => action;
 }
 
 imprecise_slot_fill_question_answer_pair = {

--- a/languages/thingtalk/en/dlg/slot-fill.genie
+++ b/languages/thingtalk/en/dlg/slot-fill.genie
@@ -215,6 +215,13 @@ precise_search_question_answer_pair = {
     };
 }
 
+search_question = {
+    direct_search_question;
+    yesno_search_question;
+    direct_search_question_with_preamble [weight=0.1];
+    yesno_search_question_with_preamble [weight=0.1];
+}
+
 generic_dontcare_phrase = {
     'it does not matter .';
     'it does not matter . can you suggest one ?';
@@ -280,6 +287,11 @@ two_param_slot_fill_question = {
             return null;
         return [p1, p2];
     };
+}
+
+slot_fill_question = {
+    one_param_slot_fill_question;
+    two_param_slot_fill_question;
 }
 
 imprecise_slot_fill_answer_phrase = {

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -297,6 +297,8 @@ class ThingpediaLoader {
         if (ptype.isArray) {
             vtype = ptype.elem;
             op = 'contains';
+        } else if (pname === 'id') {
+            vtype = Type.String;
         }
         const vtypestr = this._recordType(vtype);
         if (vtypestr === null)

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -20,6 +20,7 @@ const SchemaRetriever = ThingTalk.SchemaRetriever;
 const Units = ThingTalk.Units;
 
 const { clean, typeToStringSafe, makeFilter, makeAndFilter } = require('./utils');
+const { SlotBag } = require('./slot_bag');
 
 function identity(x) {
     return x;
@@ -59,7 +60,7 @@ class ThingpediaLoader {
         };
         this.params = {
             in: new Map,
-            out: new Set,
+            out: new Map,
         };
         this.idQueries = new Map;
         this.compoundArrays = {};
@@ -244,12 +245,12 @@ class ThingpediaLoader {
         const pname = arg.name;
         const ptype = arg.type;
         const key = pname + '+' + ptype;
+        const typestr = this._recordType(ptype);
         // FIXME match functionName
         //if (this.params.out.has(key))
         //    return;
-        this.params.out.add(key);
+        this.params.out.set(key, [pname, typestr]);
 
-        const typestr = this._recordType(ptype);
         const pvar = new Ast.Value.VarRef(pname);
 
         if (ptype.isCompound)
@@ -515,7 +516,11 @@ class ThingpediaLoader {
 
         const functionName = q.class.name + ':' + q.name;
         const table = new Ast.Table.Invocation(null, invocation, q);
-        for (let form of canonical) {
+
+        let shortCanonical = q.metadata.canonical_short || canonical;
+        if (!Array.isArray(shortCanonical))
+            shortCanonical = [shortCanonical];
+        for (let form of shortCanonical) {
             this._grammar.addRule('base_table', [form], this._runtime.simpleCombine(() => table));
             this._grammar.addRule('base_noun_phrase', [form], this._runtime.simpleCombine(() => functionName));
         }
@@ -589,8 +594,31 @@ class ThingpediaLoader {
                 this._recordOutputParam(functionName, arg);
         }
 
-        if (functionDef.functionType === 'query')
+        if (functionDef.functionType === 'query') {
             await this._makeExampleFromQuery(functionDef);
+            if (functionDef.metadata.result)
+                await this._loadCustomResultString(functionDef);
+        }
+    }
+
+    async _loadCustomResultString(functionDef) {
+        let chunks = functionDef.metadata.result.trim().split(' ');
+        let expansion = [];
+
+        for (let chunk of chunks) {
+            if (chunk === '')
+                continue;
+            if (chunk.startsWith('$') && chunk !== '$$') {
+                const [, param1, param2, opt] = /^\$(?:\$|([a-zA-Z0-9_]+(?![a-zA-Z0-9_]))|{([a-zA-Z0-9_]+)(?::([a-zA-Z0-9_-]+))?})$/.exec(chunk);
+                let param = param1 || param2;
+                assert(param);
+                expansion.push(new this._runtime.Placeholder(param, opt));
+            } else {
+                expansion.push(chunk);
+            }
+        }
+
+        this._grammar.addRule('thingpedia_result', expansion, this._runtime.simpleCombine(() => new SlotBag(functionDef)));
     }
 
     async _loadDevice(device) {

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -129,18 +129,8 @@ class ThingpediaLoader {
                         this._runtime.simpleCombine(() => value));
                 }
             } else if (type.isEntity) {
-                if (!this._nonConstantTypes.has(typestr) && !this._idTypes.has(typestr)) {
-                    if (this._options.flags.dialogues) {
-                        for (let i = 0; i < 20; i++) {
-                            const string = `str:ENTITY_${type.type}::${i}:`;
-                            const value = new Ast.Value.Entity(string, type.type, string);
-                            this._grammar.addRule('constant_' + typestr, ['GENERIC_ENTITY_' + type.type + '_' + i],
-                                this._runtime.simpleCombine(() => value));
-                        }
-                    } else {
-                        this._grammar.addConstants('constant_' + typestr, 'GENERIC_ENTITY_' + type.type, type);
-                    }
-                }
+                if (!this._nonConstantTypes.has(typestr) && !this._idTypes.has(typestr))
+                    this._grammar.addConstants('constant_' + typestr, 'GENERIC_ENTITY_' + type.type, type);
             }
         }
         return typestr;
@@ -561,16 +551,7 @@ class ThingpediaLoader {
         const schemaClone = table.schema.clone();
         schemaClone.is_list = false;
         schemaClone.no_filter = true;
-        if (this._options.flags.dialogues) {
-            for (let i = 0; i < 5; i ++) {
-                this._grammar.addRule('constant_name', ['GENERIC_ENTITY_' + idType.type + '_' + i], this._runtime.simpleCombine(() => {
-                    const value = new Ast.Value.Entity('str:ENTITY_' + idType.type + '::' + i + ':', idType.type, null);
-                    /*const idfilter = new Ast.BooleanExpression.Atom(null, 'id', '==', value);
-                    return [value, new Ast.Table.Filter(null, table, idfilter, schemaClone)];*/
-                    return value;
-                }));
-            }
-        }
+        this._grammar.addConstants('constant_name', 'GENERIC_ENTITY_' + idType.type, idType);
 
         const idfilter = new Ast.BooleanExpression.Atom(null, 'id', '==', new Ast.Value.VarRef('p_id'));
         await this._loadTemplate(new Ast.Example(

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -565,8 +565,8 @@ class ThingpediaLoader {
             'query',
             { p_id: id.type },
             new Ast.Table.Filter(null, table, idfilter, schemaClone),
-            [`\${p_id}`],
-            [`\${p_id}`],
+            [`\${p_id:no-undefined}`],
+            [`\${p_id:no-undefined}`],
             {}
         ));
         const namefilter = new Ast.BooleanExpression.Atom(null, 'id', '=~', new Ast.Value.VarRef('p_name'));
@@ -576,8 +576,8 @@ class ThingpediaLoader {
             'query',
             { p_name: Type.String },
             new Ast.Table.Filter(null, table, namefilter, table.schema),
-            [`\${p_name}`, ...canonical.map((c) => `\${p_name} ${c}`)],
-            [`\${p_name}`, ...canonical.map((c) => `\${p_name} ${c}`)],
+            [`\${p_name:no-undefined}`, ...canonical.map((c) => `\${p_name} ${c}`)],
+            [`\${p_name:no-undefined}`, ...canonical.map((c) => `\${p_name} ${c}`)],
             {}
         ));
     }

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -478,26 +478,37 @@ class ThingpediaLoader {
             if (this._options.debug && preprocessed[0].startsWith(','))
                 console.log(`WARNING: template ${ex.id} starts with , but is not a query`);
 
-            let chunks = preprocessed.trim().split(' ');
-            let expansion = [];
-
-            for (let chunk of chunks) {
-                if (chunk === '')
-                    continue;
-                if (chunk.startsWith('$') && chunk !== '$$') {
-                    const [, param1, param2, opt] = /^\$(?:\$|([a-zA-Z0-9_]+(?![a-zA-Z0-9_]))|{([a-zA-Z0-9_]+)(?::([a-zA-Z0-9_-]+))?})$/.exec(chunk);
-                    let param = param1 || param2;
-                    assert(param);
-                    expansion.push(new this._runtime.Placeholder(param, opt));
-                } else {
-                    expansion.push(chunk);
-                }
-            }
-
-            this._grammar.addRule(grammarCat, expansion, this._runtime.simpleCombine(() => ex.value));
+            const chunks = this._addPrimitiveTemplate(grammarCat, preprocessed, ex.value);
             rules.push({ category: grammarCat, expansion: chunks, example: ex });
+
+            if (grammarCat === 'thingpedia_action') {
+                const pastform = this._langPack.toVerbPast(preprocessed);
+                if (pastform)
+                    this._addPrimitiveTemplate('thingpedia_action_past', pastform, ex.value);
+            }
         }
         return rules;
+    }
+
+    _addPrimitiveTemplate(grammarCat, preprocessed, value) {
+        let chunks = preprocessed.trim().split(' ');
+        let expansion = [];
+
+        for (let chunk of chunks) {
+            if (chunk === '')
+                continue;
+            if (chunk.startsWith('$') && chunk !== '$$') {
+                const [, param1, param2, opt] = /^\$(?:\$|([a-zA-Z0-9_]+(?![a-zA-Z0-9_]))|{([a-zA-Z0-9_]+)(?::([a-zA-Z0-9_-]+))?})$/.exec(chunk);
+                let param = param1 || param2;
+                assert(param);
+                expansion.push(new this._runtime.Placeholder(param, opt));
+            } else {
+                expansion.push(chunk);
+            }
+        }
+
+        this._grammar.addRule(grammarCat, expansion, this._runtime.simpleCombine(() => value));
+        return chunks;
     }
 
     async _makeExampleFromQuery(q) {
@@ -594,11 +605,10 @@ class ThingpediaLoader {
                 this._recordOutputParam(functionName, arg);
         }
 
-        if (functionDef.functionType === 'query') {
+        if (functionDef.functionType === 'query')
             await this._makeExampleFromQuery(functionDef);
-            if (functionDef.metadata.result)
-                await this._loadCustomResultString(functionDef);
-        }
+        if (functionDef.metadata.result)
+            await this._loadCustomResultString(functionDef);
     }
 
     async _loadCustomResultString(functionDef) {

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -847,12 +847,16 @@ class ThingpediaLoader {
             console.log('Loaded ' + countTemplates + ' templates');
         }
 
-        idTypes.forEach((entity) => this._entities[entity.type] = entity);
-        await Promise.all(idTypes.map(this._loadIdType, this));
-        await Promise.all([
-            Promise.all(devices.map(this._loadDevice, this)),
-            Promise.all(datasets.map(this._loadDataset, this))
-        ]);
+        for (let entity of idTypes) {
+            this._entities[entity.type] = entity;
+            await this._loadIdType(entity);
+        }
+
+        for (let device of devices)
+            await this._loadDevice(device);
+
+        for (let dataset of datasets)
+            await this._loadDataset(dataset);
     }
 }
 

--- a/languages/thingtalk/slot_bag.js
+++ b/languages/thingtalk/slot_bag.js
@@ -20,6 +20,21 @@ class SlotBag {
         this.schema = schema;
         this.store = new Map;
     }
+
+    static merge(b1, b2) {
+        if (b1.schema !== null && b2.schema !== null && b1.schema !== b2.schema)
+            return null;
+        const newbag = new SlotBag(b1.schema || b2.schema);
+        for (let [key, value] of b1.entries())
+            newbag.set(key, value.clone());
+        for (let [key, value] of b2.entries()) {
+            if (newbag.has(key))
+                return null;
+            newbag.set(key, value.clone());
+        }
+        return newbag;
+    }
+
     clone() {
         let newbag = new SlotBag(this.schema);
         for (let [key, value] of this.entries())
@@ -64,7 +79,10 @@ function checkAndAddSlot(bag, filter) {
     assert(bag instanceof SlotBag);
     if (!filter.isAtom)
         return null;
-    const ptype = bag.schema.getArgType(filter.name);
+    const arg = bag.schema.getArgument(filter.name);
+    if (!arg || arg.is_input)
+        return null;
+    const ptype = arg.type;
     if (!ptype)
         return null;
     const vtype = filter.value.getType();

--- a/languages/thingtalk/state_manip.js
+++ b/languages/thingtalk/state_manip.js
@@ -180,6 +180,7 @@ class ResultInfo {
             this.argMinMaxField = null;
             this.projection = null;
         }
+        this.hasError = item.results.error !== null;
         this.hasEmptyResult = item.results.results.length === 0;
         this.hasSingleResult = item.results.results.length === 1;
         this.hasLargeResult = isLargeResultSet(item.results);

--- a/languages/thingtalk/state_manip.js
+++ b/languages/thingtalk/state_manip.js
@@ -438,8 +438,10 @@ function addActionParam(ctx, dialogueAct, action, pname, value, confirm) {
         const setparams = new Set;
         setparams.add(pname);
         for (let param of action.in_params) {
+            if (param.value.isUndefined)
+                continue;
             if (param.name !== pname)
-                in_params.push(param);
+                in_params.push(param.clone());
             setparams.add(param.name);
         }
 
@@ -475,8 +477,7 @@ function replaceAction(ctx, dialogueAct, action, confirm) {
 
 function addAction(ctx, dialogueAct, action, confirm) {
     assert(action instanceof Ast.Invocation);
-    // the action must have no parameter set!
-    assert(action.in_params.every((in_param) => in_param.value.isUndefined));
+    // note: parameters from the action are ignored altogether!
 
     let newHistoryItem;
     if (ctx.nextInfo) {

--- a/languages/thingtalk/state_manip.js
+++ b/languages/thingtalk/state_manip.js
@@ -96,7 +96,8 @@ const SYSTEM_DIALOGUE_ACTS = new Set([
     // agent executed the action successfully (and shows the result of the action)
     'sys_action_success',
 
-    // agent had an error in executing the action
+    // agent had an error in executing the action (with and without a slot-fill question)
+    'sys_action_error_question',
     'sys_action_error',
 
     // agent asks if anything else is needed
@@ -108,8 +109,9 @@ const SYSTEM_DIALOGUE_ACTS = new Set([
 
 const SYSTEM_STATE_MUST_HAVE_PARAM = new Set([
     'sys_search_question',
+    'sys_slot_fill',
     'sys_empty_search_question',
-    'sys_slot_fill'
+    'sys_action_error_question',
 ]);
 
 const INITIAL_CONTEXT_INFO = {};
@@ -264,6 +266,12 @@ class ContextInfo {
     get results() {
         if (this.currentIdx !== null)
             return this.state.history[this.currentIdx].results.results;
+        return null;
+    }
+
+    get error() {
+        if (this.currentIdx !== null)
+            return this.state.history[this.currentIdx].results.error;
         return null;
     }
 
@@ -550,4 +558,5 @@ module.exports = {
     addAction,
     addQuery,
     replaceAction,
+    setOrAddInvocationParam,
 };

--- a/languages/thingtalk/state_manip.js
+++ b/languages/thingtalk/state_manip.js
@@ -308,12 +308,20 @@ function getContextInfo(state) {
 }
 
 function isUserAskingResultQuestion(ctx) {
-    // is the user asking a question about the result, or refining a search?
+    // is the user asking a question about the result (or a specific element), or refining a search?
     // we say it's a question if the user is asking a projection question, and it's not the first turn,
     // and the projection was different at the previous turn
 
-    if (ctx.currentIdx === null || ctx.currentIdx === 0)
+    if (ctx.currentIdx === null)
         return false;
+    if (ctx.currentIdx === 0) {
+        if (!ctx.current.stmt.table)
+            return false;
+        const filterTable = C.findFilterTable(ctx.current.stmt.table);
+        if (!filterTable)
+            return false;
+        return C.filterUsesParam(filterTable.filter, 'id');
+    }
 
     let currentProjection = ctx.resultInfo.projection;
     if (!currentProjection)

--- a/languages/thingtalk/utils.js
+++ b/languages/thingtalk/utils.js
@@ -49,7 +49,7 @@ function makeFilter(loader, pname, op, value, negate = false) {
     } else if (op === '==' && vtype.isString) {
         op = '=~';
     }
-    if (!loader.params.out.has(pname.name + '+' + ptype))
+    if (!loader.params.out.has(pname.name + '+' + ptype) && pname.name !== 'id')
         return null;
     if (loader.flags.turking && value.isEnum)
         return null;

--- a/lib/genie-compiler/grammar.pegjs
+++ b/lib/genie-compiler/grammar.pegjs
@@ -65,7 +65,7 @@ StatementOrCodeBlock = Statement / CodeBlock
 
 NonTerminalRef
   = name:Identifier { return new Ast.NonTerminalRef.Identifier(name); }
-  / '$root' !IdentifierPart { return new Ast.NonTerminalRef.Identifier('$root'); }
+  / name:('$root' / '$user' / '$agent') !IdentifierPart { return new Ast.NonTerminalRef.Identifier(name); }
   / '$' __ '(' __ nameCode:Code __ ')' { return new Ast.NonTerminalRef.Computed(nameCode); }
 
 NonTerminalDeclaration

--- a/lib/genie-compiler/meta_ast.js
+++ b/lib/genie-compiler/meta_ast.js
@@ -86,6 +86,10 @@ class NonTerminalStmt extends Statement {
         super();
 
         this.isNonTerminal = true;
+
+        // $user is the same as $root, and it's introduced for symmetry with $agent
+        if (name === '$user')
+            name = '$root';
         this.name = name;
         this.rules = rules;
     }

--- a/lib/i18n/american-english.js
+++ b/lib/i18n/american-english.js
@@ -38,14 +38,14 @@ function replaceMeMy(sentence) {
 // This function should correct coreferences, conjugations and other
 // grammar/readability issues that are too inconvenient to prevent
 // using the templates 
-function postprocessSynthetic(sentence, program, rng) {
+function postprocessSynthetic(sentence, program, rng, forTarget = 'user') {
     assert(rng);
     if (program.isProgram && program.principal !== null)
         sentence = replaceMeMy(sentence);
 
     if (!sentence.endsWith(' ?') && !sentence.endsWith(' !') && !sentence.endsWith(' .') && coin(0.5, rng))
         sentence = sentence.trim() + ' .';
-    if (sentence.endsWith(' ?') && coin(0.5, rng))
+    if (forTarget === 'user' && sentence.endsWith(' ?') && coin(0.5, rng))
         sentence = sentence.substring(0, sentence.length-2);
 
     sentence = sentence.replace(/ (1|one|a) ([a-z]+)s /g, ' $1 $2 ');
@@ -159,6 +159,7 @@ const SPECIAL_TOKENS = {
     'n\'t': 'n\'t',
     '\'s': '\'s',
     '?': '?',
+    '!': '!',
 
     // right/left round/curly/square bracket
     '-rrb-': ')',

--- a/lib/i18n/american-english.js
+++ b/lib/i18n/american-english.js
@@ -324,6 +324,17 @@ function pluralize(name) {
     }
 }
 
+function toVerbPast(phrase) {
+    const words = phrase.split(' ');
+    const tags = new Tag(words).initial().tags;
+
+    if (!['VB', 'VBP', 'VBZ', 'VBD'].includes(tags[0]))
+        return undefined;
+
+    const inflected = new Inflectors(words[0]).toPast();
+    return [inflected, ...words.slice(1)].join(' ');
+}
+
 function isGoodWord(word) {
     // filter out words that cannot be in the dataset,
     // because they would be either tokenized/preprocessed out or
@@ -353,6 +364,7 @@ module.exports = {
     postprocessNLG,
 
     pluralize,
+    toVerbPast,
 
     ARGUMENT_NAME_OVERRIDES,
 

--- a/lib/i18n/default.js
+++ b/lib/i18n/default.js
@@ -105,8 +105,13 @@ const CHANGE_SUBJECT_TEMPLATES = [];
 
 const SINGLE_DEVICE_TEMPLATES = [];
 
-function pluralize(noun) {
+function pluralize(phrase) {
     // no plural form
+    return undefined;
+}
+
+function toVerbPast(phrase) {
+    // no past
     return undefined;
 }
 
@@ -129,7 +134,9 @@ module.exports = {
     postprocessSynthetic,
     detokenize,
 
+    // inflections
     pluralize,
+    toVerbPast,
 
     ARGUMENT_NAME_OVERRIDES,
 

--- a/lib/i18n/italian.js
+++ b/lib/i18n/italian.js
@@ -123,6 +123,12 @@ function pluralize(noun) {
     return undefined;
 }
 
+function toVerbPast(phrase) {
+    // rules for past simple (passato remoto) are positively insane
+    // no way in hell this is implementable
+    return undefined;
+}
+
 function isGoodWord(word) {
     // filter out words that cannot be in the dataset,
     // because they would be either tokenized/preprocessed out or
@@ -151,6 +157,7 @@ module.exports = {
     detokenize,
 
     pluralize,
+    toVerbPast,
 
     ARGUMENT_NAME_OVERRIDES,
 

--- a/lib/i18n/persian.js
+++ b/lib/i18n/persian.js
@@ -69,6 +69,10 @@ function pluralize(noun) {
     return undefined;
 }
 
+function toVerbPast(noun) {
+    // no past tense
+    return undefined;
+}
 
 function isGoodWord(word) {
     // filter out words that cannot be in the dataset,
@@ -102,6 +106,7 @@ module.exports = {
     detokenize,
 
     pluralize,
+    toVerbPast,
 
     ARGUMENT_NAME_OVERRIDES,
 

--- a/lib/i18n/simplified-chinese.js
+++ b/lib/i18n/simplified-chinese.js
@@ -86,6 +86,10 @@ function pluralize(noun) {
     return undefined;
 }
 
+function toVerbPast(phrase) {
+    return phrase + '了';
+}
+
 function isGoodWord(word) {
     // filter out words that cannot be in the dataset,
     // because they would be either tokenized/preprocessed out or
@@ -120,6 +124,7 @@ module.exports = {
     detokenize,
 
     pluralize,
+    toVerbPast,
 
     ARGUMENT_NAME_OVERRIDES,
 

--- a/lib/i18n/traditional-chinese.js
+++ b/lib/i18n/traditional-chinese.js
@@ -85,11 +85,16 @@ function pluralize(noun) {
     return undefined;
 }
 
+function toVerbPast(phrase) {
+    return phrase + '了';
+}
+
 module.exports = {
     postprocessSynthetic,
     detokenize,
 
     pluralize,
+    toVerbPast,
 
     ARGUMENT_NAME_OVERRIDES,
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@
 // See COPYING for details
 "use strict";
 
-const { BasicSentenceGenerator, ContextualSentenceGenerator } = require('./sentence-generator');
+const { SentenceGenerator, BasicSentenceGenerator, ContextualSentenceGenerator, DialogueGenerator } = require('./sentence-generator');
 const SentenceSampler = require('./sampler');
 const { ParaphraseValidator, ParaphraseValidatorFilter } = require('./validator');
 const ValidationHITCreator = require('./validation');
@@ -34,11 +34,14 @@ const BinaryPPDB = require('./binary_ppdb');
 const Training = require('./training');
 
 const Utils = require('./utils');
+const I18n = require('./i18n');
 const parallelize = require('./parallelize');
 
 module.exports = {
+    SentenceGenerator,
     BasicSentenceGenerator,
     ContextualSentenceGenerator,
+    DialogueGenerator,
     SentenceSampler,
     ParaphraseValidator,
     ParaphraseValidatorFilter,
@@ -66,5 +69,6 @@ module.exports = {
 
     // semi-unstable API
     Utils,
+    I18n,
     parallelize
 };

--- a/lib/languages/dlgthingtalk/index.js
+++ b/lib/languages/dlgthingtalk/index.js
@@ -19,6 +19,9 @@ const ThingTalkSimulator = require('./simulator');
 const DialogueAgent = require('./agent');
 const { computeNewState, computePrediction, prepareContextForPrediction } = require('./state_utils');
 
+const MAX_CONSTANTS = 20;
+const MAX_SMALL_INTEGER = 12;
+
 module.exports = {
     async parse(code, options) {
         const tpClient = options.thingpediaClient;
@@ -29,6 +32,180 @@ module.exports = {
         const state = await ThingTalk.Grammar.parseAndTypecheck(code, options.schemaRetriever, false);
         assert(state instanceof Ast.DialogueState);
         return state;
+    },
+
+    extractConstants(ast) {
+        const constants = {};
+        function addConstant(token, display, value) {
+            if (constants[token])
+                constants[token].push({ display, value });
+            else
+                constants[token] = [{ display, value }];
+        }
+
+        ast.visit(new class extends Ast.NodeVisitor {
+            visitStringValue(value) {
+                addConstant('QUOTED_STRING', value.value, value);
+            }
+
+            visitEntityValue(value) {
+                switch (value.type) {
+                case 'tt:url':
+                    addConstant('URL', value.value, value);
+                    break;
+
+                case 'tt:username':
+                    addConstant('USERNAME', value.value, value);
+                    break;
+
+                case 'tt:hashtag':
+                    addConstant('HASHTAG', value.value, value);
+                    break;
+
+                case 'tt:phone_number':
+                    addConstant('PHONE_NUMBER', value.value, value);
+                    break;
+
+                case 'tt:email_address':
+                    addConstant('EMAIL_ADDRESS', value.value, value);
+                    break;
+
+                case 'tt:path_name':
+                    addConstant('PATH_NAME', value.value, value);
+                    break;
+
+                default:
+                    addConstant('GENERIC_ENTITY_' + value.type, value.display, value);
+                    break;
+                }
+            }
+
+            visitNumberValue(value) {
+                addConstant('NUMBER', String(value.value), value);
+            }
+
+            visitCurrencyValue(value) {
+                addConstant('CURRENCY', String(value.value) + ' ' + value.unit, value);
+            }
+
+            visitLocationValue(value) {
+                if (value.value instanceof Ast.Location.Absolute && value.value.display)
+                    addConstant('LOCATION', value.value.display, value);
+                else if (value.value instanceof Ast.Location.Unresolved && value.value.name)
+                    addConstant('LOCATION', value.value.name, value);
+            }
+
+            visitTimeValue(value) {
+                if (!(value.value instanceof Ast.Time.Absolute))
+                    return;
+                const time = value.value;
+                addConstant('TIME', `${time.hour}:${time.minute < 10 ? '0' : ''}${time.minute}:${time.second < 10 ? '0' : ''}${time.second}`, value);
+            }
+
+            visitDateValue(value) {
+                if (!(value.value instanceof Date))
+                    return;
+                addConstant('DATE', value.date.toISOString(), value);
+            }
+        });
+
+        return constants;
+    },
+    createConstants(token, type, maxConstants) {
+        // ignore maxConstants, because it's too low (5) and there is no way to set it differently
+
+        const constants = [];
+        for (let i = 0; i < MAX_CONSTANTS; i++) {
+            switch (token) {
+            case 'NUMBER':
+                constants.push({
+                    display: 'NUMBER_' + i,
+                    value: new Ast.Value.Number(MAX_SMALL_INTEGER + 1 + i)
+                });
+                break;
+            case 'QUOTED_STRING':
+                constants.push({
+                    display: 'QUOTED_STRING_' + i,
+                    value: new Ast.Value.String('str:QUOTED_STRING::' + i + ':')
+                });
+                break;
+            case 'URL':
+                constants.push({
+                    display: 'URL_' + i,
+                    value: new Ast.Value.Entity('str:URL::' + i + ':', 'tt:url')
+                });
+                break;
+            case 'USERNAME':
+                constants.push({
+                    display: 'USERNAME_' + i,
+                    value: new Ast.Value.Entity('str:USERNAME::' + i + ':', 'tt:username')
+                });
+                break;
+            case 'HASHTAG':
+                constants.push({
+                    display: 'HASHTAG_' + i,
+                    value: new Ast.Value.Entity('str:HASHTAG::' + i + ':', 'tt:hashtag')
+                });
+                break;
+            case 'PHONE_NUMBER':
+                constants.push({
+                    display: 'PHONE_NUMBER_' + i,
+                    value: new Ast.Value.Entity('str:PHONE_NUMBER::' + i + ':', 'tt:phone_number')
+                });
+                break;
+            case 'EMAIL_ADDRESS':
+                constants.push({
+                    display: 'EMAIL_ADDRESS_' + i,
+                    value: new Ast.Value.Entity('str:EMAIL_ADDRESS::' + i + ':', 'tt:email_address')
+                });
+                break;
+            case 'PATH_NAME':
+                constants.push({
+                    display: 'PATH_NAME_' + i,
+                    value: new Ast.Value.Entity('str:PATH_NAME::' + i + ':', 'tt:path_name')
+                });
+                break;
+            case 'CURRENCY':
+                constants.push({
+                    display: 'CURRENCY_' + i,
+                    value: new Ast.Value.Currency(2 + i, 'usd')
+                });
+                break;
+            case 'DURATION':
+                constants.push({
+                    display: 'DURATION_' + i,
+                    value: new Ast.Value.Measure(2 + i, 'ms')
+                });
+                break;
+            case 'LOCATION':
+                constants.push({
+                    display: 'LOCATION_' + i,
+                    value: new Ast.Value.Location(new Ast.Location.Absolute(2 + i, 2 + i, null))
+                });
+                break;
+            case 'DATE':
+                constants.push({
+                    display: 'DATE_' + i,
+                    value: new Ast.Value.Date(new Date(2018, 0, 2 + i))
+                });
+                break;
+            case 'TIME':
+                constants.push({
+                    display: 'TIME_' + i,
+                    value: new Ast.Value.Time(new Ast.Time.Absolute(Math.floor(i/4), [0, 15, 30, 45][i % 4], 0))
+                });
+                break;
+            default: {
+                assert(token.startsWith('GENERIC_ENTITY_'));
+                const string = `str:ENTITY_${type.type}::${i}:`;
+                constants.push({
+                    display: token + '_' + i,
+                    value: new Ast.Value.Entity(string, type.type, string)
+                });
+            }
+            }
+        }
+        return constants;
     },
 
     async parsePrediction(code, entities, options) {

--- a/lib/languages/dlgthingtalk/simulator.js
+++ b/lib/languages/dlgthingtalk/simulator.js
@@ -190,6 +190,10 @@ class ResultGenerator {
         return newString;
     }
 
+    generateString() {
+        return this._generateString('QUOTED_STRING', false);
+    }
+
     _reuseConstant(key, repeatable) {
         // first check if we have something in the program already
         let candidates = this._candidates.get(key);
@@ -207,6 +211,13 @@ class ResultGenerator {
             return uniform(previous, this._rng);
 
         return undefined;
+    }
+}
+
+class SimulatedError extends Error {
+    constructor(message, code) {
+        super(message);
+        this.code = code;
     }
 }
 
@@ -254,12 +265,23 @@ class SimulationExecEnvironment extends ThingTalk.ExecEnvironment {
         throw new Error(`Invalid readResult, no result for ${functionKey}[${index}]`);
     }
 
+    _failAction(schema) {
+        const errors = Object.keys(schema.metadata.on_error || {});
+        if (errors.length === 0)
+            throw new SimulatedError(this.generator.generateString());
+        else
+            throw new SimulatedError(this.generator.generateString(), uniform(errors, this._rng));
+    }
+
     async invokeAction(kind, attrs, fname, params) {
         const outputType = kind + ':action/' + fname;
-        const schema = await this._schemas.getSchemaAndNames(kind, 'action', fname);
+        const schema = await this._schemas.getMeta(kind, 'action', fname);
 
-        // XXX for now, assume the action is always successful (on error, I'll modify the annotated.txt by hand)
-
+        // with some probability, fail the action
+        if (coin(0.1, this._rng)) {
+            await this._failAction(schema);
+            return undefined;
+        }
 
         let anyOutArgument = false;
         for (let arg of schema.iterateArguments()) {
@@ -271,11 +293,13 @@ class SimulationExecEnvironment extends ThingTalk.ExecEnvironment {
 
         if (anyOutArgument)
             return [[outputType, this.generator.generate(schema, params, 0)]];
+
+        return undefined;
     }
 
     async _doInvokeQuery(kind, fname, params) {
         const outputType = kind + ':' + fname;
-        const schema = await this._schemas.getSchemaAndNames(kind, 'query', fname);
+        const schema = await this._schemas.getMeta(kind, 'query', fname);
         if (this._database && this._database.has(outputType)) {
             const data = this._database.get(outputType);
             return [data.map((item) => {
@@ -293,7 +317,6 @@ class SimulationExecEnvironment extends ThingTalk.ExecEnvironment {
                 return [outputType, mapped];
             }), true];
         }
-
 
         let numResults, cacheable;
         if (schema.is_list) {
@@ -327,11 +350,6 @@ class SimulationExecEnvironment extends ThingTalk.ExecEnvironment {
         if (cacheable)
             this._execCache.push([functionKey, params, list]);
         return list;
-    }
-
-    async reportError(msg, error) {
-        console.error(msg, error);
-        process.exit(1);
     }
 }
 
@@ -490,6 +508,7 @@ class ThingTalkSimulator extends AbstractThingTalkExecutor {
             execState = new SimulationExecEnvironment(this._locale, this._schemas, this._database, this._rng);
 
         const results = [];
+        let error = null;
         const generator = new ResultGenerator(this._rng);
         for (let slot of stmt.iterateSlots2()) {
             if (slot instanceof Ast.Selector)
@@ -501,12 +520,23 @@ class ThingTalkSimulator extends AbstractThingTalkExecutor {
             const mapped = await this._mapResult(outputType, outputValue);
             results.push(new Ast.DialogueHistoryResultItem(null, mapped));
         };
+        execState.reportError = async (msg, err) => {
+            if (!(err instanceof SimulatedError)) {
+                console.error(msg, err);
+                process.exit(1);
+                return;
+            }
+            if (err.code)
+                error = new Ast.Value.Enum(err.code);
+            else
+                error = new Ast.Value.String(err.message);
+        };
 
         await compiled.command(execState);
 
         const numResults = results.length;
         const resultList = new Ast.DialogueHistoryResultList(null, results.slice(0, PAGE_SIZE),
-            new Ast.Value.Number(Math.min(MORE_SIZE, numResults)), numResults > MORE_SIZE);
+            new Ast.Value.Number(Math.min(MORE_SIZE, numResults)), numResults > MORE_SIZE, error);
 
         return [resultList, execState];
     }

--- a/lib/languages/dlgthingtalk/simulator.js
+++ b/lib/languages/dlgthingtalk/simulator.js
@@ -68,9 +68,9 @@ class ResultGenerator {
         let result = {};
         Object.assign(result, params);
         for (let arg of schema.iterateArguments()) {
-            if (arg.type.isCompound)
-                continue;
             if (arg.direction !== Ast.ArgDirection.OUT)
+                continue;
+            if (arg.name.indexOf('.') >= 0)
                 continue;
 
             if (arg.name === 'id')
@@ -82,6 +82,16 @@ class ResultGenerator {
     }
 
     _generateValue(type, repeatable = true, arg) {
+        if (type.isCompound) {
+            let result = {};
+            for (let field in type.fields) {
+                const arg = type.fields[field];
+                assert(arg instanceof Ast.ArgumentDef);
+                result[field] = this._generateValue(arg.type, true, arg);
+            }
+            return result;
+        }
+
         if (type.isArray) {
             let length = randint(1, 3, this._rng);
             let buffer = [];
@@ -487,10 +497,26 @@ class ThingTalkSimulator extends AbstractThingTalkExecutor {
             for (let key in outputValue) {
                 const value = outputValue[key];
                 const type = schema.getArgType(key) || this._inferType(value);
-                mappedResult[key] = Ast.Value.fromJS(type, value);
+                if (type.isCompound)
+                    mappedResult[key] = this._mapCompound(key + '.', schema, value);
+                else
+                    mappedResult[key] = Ast.Value.fromJS(type, value);
             }
         }
         return mappedResult;
+    }
+
+    _mapCompound(prefix, schema, object) {
+        let result = {};
+        for (let key in object) {
+            const value = object[key];
+            const type = schema.getArgType(prefix + key) || this._inferType(value);
+            if (type.isCompound)
+                result[key] = this._mapCompound(prefix + key + '.', type, object);
+            else
+                result[key] = Ast.Value.fromJS(type, value);
+        }
+        return new Ast.Value.Object(result);
     }
 
     async executeStatement(stmt, execState) {
@@ -532,7 +558,13 @@ class ThingTalkSimulator extends AbstractThingTalkExecutor {
                 error = new Ast.Value.String(err.message);
         };
 
-        await compiled.command(execState);
+        try {
+            await compiled.command(execState);
+        } catch(e) {
+            console.error(`Failed to execute program: ` + e.message);
+            console.error(new Ast.Program(null, [], [], [stmt]).prettyprint());
+            throw e;
+        }
 
         const numResults = results.length;
         const resultList = new Ast.DialogueHistoryResultList(null, results.slice(0, PAGE_SIZE),

--- a/lib/languages/dlgthingtalk/simulator.js
+++ b/lib/languages/dlgthingtalk/simulator.js
@@ -269,10 +269,8 @@ class SimulationExecEnvironment extends ThingTalk.ExecEnvironment {
             }
         }
 
-        if (anyOutArgument) {
-            const result = this.generator.generate(schema, params, 0);
-            await this.output(outputType, result);
-        }
+        if (anyOutArgument)
+            return [[outputType, this.generator.generate(schema, params, 0)]];
     }
 
     async _doInvokeQuery(kind, fname, params) {

--- a/lib/languages/dlgthingtalk/simulator.js
+++ b/lib/languages/dlgthingtalk/simulator.js
@@ -548,7 +548,9 @@ class ThingTalkSimulator extends AbstractThingTalkExecutor {
         };
         execState.reportError = async (msg, err) => {
             if (!(err instanceof SimulatedError)) {
+                console.error(`Failed to execute program`);
                 console.error(msg, err);
+                console.error(new Ast.Program(null, [], [], [stmt]).prettyprint());
                 process.exit(1);
                 return;
             }

--- a/lib/languages/dlgthingtalk/simulator.js
+++ b/lib/languages/dlgthingtalk/simulator.js
@@ -45,6 +45,7 @@ class ResultGenerator {
             return;
 
         const jsValue = value.toJS();
+
         if (value.isString)
             this._doAddCandidate('QUOTED_STRING', jsValue);
         else if (value.isNumber)
@@ -125,7 +126,15 @@ class ResultGenerator {
     }
 
     _generateDate(repeatable) {
-        return new Date(2018, 0, this._generateNumber('DATE', repeatable));
+        const reused = this._reuseConstant('DATE', repeatable);
+        if (reused !== undefined)
+            return reused;
+
+        const num = this._generateNumber('DATE::number', repeatable);
+        assert(Number.isFinite(num));
+        const date = new Date(2018, 0, num);
+        assert(Number.isFinite(date.getTime()));
+        return date;
     }
 
     _generateLocation(repeatable) {
@@ -166,6 +175,7 @@ class ResultGenerator {
         }
 
         let newNumber = randint(min, max, this._rng);
+        assert(Number.isFinite(newNumber));
         this._constants.get(key).push(newNumber);
         return newNumber;
     }

--- a/lib/languages/multidst/index.js
+++ b/lib/languages/multidst/index.js
@@ -149,6 +149,14 @@ module.exports = {
         return [ast.prettyprint().split(' '), {}];
     },
 
+    // multidst does not use constants
+    extractConstants(ast) {
+        return {};
+    },
+    createConstants(type) {
+        return [];
+    },
+
     async normalize(code, options) {
         try {
             return (await parse(code)).prettyprint();

--- a/lib/languages/thingtalk.js
+++ b/lib/languages/thingtalk.js
@@ -12,7 +12,9 @@
 const ThingTalk = require('thingtalk');
 const SchemaRetriever = ThingTalk.SchemaRetriever;
 const NNSyntax = ThingTalk.NNSyntax;
+const Ast = ThingTalk.Ast;
 
+const { Constant } = require('../sentence-generator/runtime');
 const { makeDummyEntity } = require('../utils');
 
 module.exports = {
@@ -25,6 +27,27 @@ module.exports = {
         const schemas = options.schemaRetriever;
         await program.typecheck(schemas, false);
         return program;
+    },
+
+    extractConstants(ast) {
+        // TODO
+        // (not needed because this is only used in contextual mode)
+        return {};
+    },
+    createConstants(token, type, maxConstants) {
+        const escapedToken = token.replace(/[:._]/g, (match) => {
+            if (match === '_')
+                return '__';
+            let code = match.charCodeAt(0);
+            return code < 16 ? '_0' + code.toString(16) : '_' + code.toString(16);
+        });
+        const constants = [];
+        for (let i = 0; i < maxConstants; i++) {
+            const value = new Ast.Value.VarRef(`__const_${escapedToken}_${i}`, type);
+            value.constNumber = i;
+            constants.push(new Constant(token, i, value));
+        }
+        return constants;
     },
 
     serialize(ast, sentence, entities) {

--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -25,9 +25,9 @@ const BASIC_TARGET_GEN_SIZE = 100000;
 const CONTEXTUAL_TARGET_GEN_SIZE = 10000;
 
 class SentenceGenerator extends events.EventEmitter {
-    constructor(targetLanguage, options) {
+    constructor(options) {
         super();
-        this._target = targetLanguage;
+        this._target = require('../languages/' + options.targetLanguage);
         this._templateFiles = options.templateFiles;
         this._options = options;
         this._langPack = i18n.get(options.locale);
@@ -75,7 +75,7 @@ class ContextualSentenceGenerator extends stream.Transform {
         this._idPrefix = options.idPrefix;
         this._debug = options.debug;
         this._target = require('../languages/' + options.targetLanguage);
-        this._generator = new SentenceGenerator(this._target, options);
+        this._generator = new SentenceGenerator(options);
 
         this._minibatch = [];
         this._processed = 0;
@@ -169,7 +169,7 @@ class BasicSentenceGenerator extends stream.Readable {
         if (options.targetPruningSize === undefined)
             options.targetPruningSize = BASIC_TARGET_GEN_SIZE;
         this._target = require('../languages/' + options.targetLanguage);
-        this._generator = new SentenceGenerator(this._target, options);
+        this._generator = new SentenceGenerator(options);
         this._generator.on('progress', (value) => {
             this.emit('progress', value);
         });
@@ -416,7 +416,7 @@ class DialogueGenerator extends stream.Readable {
         if (options.maxConstants === undefined)
             options.maxConstants = 5;
         this._target = require('../languages/' + options.targetLanguage);
-        this._generator = new SentenceGenerator(this._target, options);
+        this._generator = new SentenceGenerator(options);
 
         this._initialized = false;
         this._dialogueAgent = this._target.createSimulator(options);

--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -336,6 +336,16 @@ class MinibatchDialogueGenerator {
         });
     }
 
+    _tryAddTurn(continuations, derivation) {
+        try {
+            this._addTurn(continuations, derivation);
+        } catch(e) {
+            console.error(derivation.toString());
+            console.error(derivation.value);
+            throw e;
+        }
+    }
+
     async nextTurn() {
         this._turnIdx++;
         const start = Date.now();
@@ -351,11 +361,11 @@ class MinibatchDialogueGenerator {
             if (partials.length > 0) {
                 const derivation = this._sentenceGenerator.generateOne(partials[0]);
                 if (derivation !== undefined)
-                    this._addTurn(continuations, derivation);
+                    this._tryAddTurn(continuations, derivation);
             }
         } else {
             this._sentenceGenerator.generate(partials, (depth, derivation) => {
-                this._addTurn(continuations, derivation);
+                this._tryAddTurn(continuations, derivation);
             });
         }
 

--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -46,6 +46,9 @@ class SentenceGenerator extends events.EventEmitter {
     generate(contexts, callback) {
         this._grammar.generate(contexts, callback);
     }
+    generateOne(context) {
+        return this._grammar.generateOne(context);
+    }
 
     async initialize() {
         this._grammar = new $runtime.Grammar(this._options);
@@ -258,7 +261,7 @@ class MinibatchDialogueGenerator {
 
         this._debug = true;
 
-        this._partialDialogs = new ReservoirSampler(this._minibatchSize * 0.1, this._rng);
+        this._partialDialogs = new ReservoirSampler(Math.ceil(this._minibatchSize * 0.1), this._rng);
         this._emptyDialogue = new PartialDialogue();
         this._maybeAddPartialDialog(this._emptyDialogue);
         this._completeDialogs = new ReservoirSampler(this._minibatchSize, this._rng);
@@ -276,6 +279,62 @@ class MinibatchDialogueGenerator {
         return discarded !== dlg;
     }
 
+    _addTurn(continuations, derivation) {
+        const dlg = derivation.context.dlg;
+
+        let [agentState, userState] = derivation.value;
+        let agent, agent_target, user, user_target;
+        let newConstants = {};
+        Object.assign(newConstants, dlg.constants);
+        if (dlg.context === null) {
+            // first turn in the dialogue
+            assert(dlg === this._emptyDialogue);
+            assert(agentState === null);
+            userState = userState.optimize();
+            assert(userState !== null); // not-null even after optimize
+            let turnString = derivation.toString();
+            turnString = turnString.replace(/ +/g, ' ');
+            turnString = this._sentenceGenerator.postprocess(turnString, userState);
+            mergeConstants(newConstants, turnString);
+
+            agent = '';
+            agent_target = null;
+            user = turnString;
+            user_target = userState.prettyprint();
+        } else {
+            agentState = agentState.optimize();
+            userState = userState.optimize();
+            assert(agentState !== null); // not-null even after optimize
+            assert(userState !== null); // not-null even after optimize
+            let turnString = derivation.toString();
+            turnString = turnString.replace(/ +/g, ' ');
+            turnString = this._sentenceGenerator.postprocess(turnString, userState);
+            mergeConstants(newConstants, turnString);
+
+            [agent, user] = turnString.split(' <sep> ');
+            assert(agent);
+            assert(user);
+
+            const agentPrediction = this._target.computePrediction(dlg.context, agentState, 'agent');
+            agent_target = agentPrediction.prettyprint();
+
+            const userPrediction = this._target.computePrediction(agentState, userState, 'user');
+            user_target = userPrediction.prettyprint();
+        }
+
+        continuations.put(dlg, {
+            userState,
+            newTurn: {
+                context: dlg.context !== null ? dlg.context.prettyprint() : null,
+                agent,
+                agent_target,
+                user,
+                user_target
+            },
+            newConstants: {}
+        });
+    }
+
     async nextTurn() {
         this._turnIdx++;
         const start = Date.now();
@@ -286,61 +345,18 @@ class MinibatchDialogueGenerator {
         this._partialDialogs.reset();
 
         const continuations = new MultiMap;
-        this._sentenceGenerator.generate(partials, (depth, derivation) => {
-            const dlg = derivation.context.dlg;
-
-            let [agentState, userState] = derivation.value;
-            let agent, agent_target, user, user_target;
-            let newConstants = {};
-            Object.assign(newConstants, dlg.constants);
-            if (dlg.context === null) {
-                // first turn in the dialogue
-                assert(dlg === this._emptyDialogue);
-                assert(agentState === null);
-                userState = userState.optimize();
-                assert(userState !== null); // not-null even after optimize
-                let turnString = derivation.toString();
-                turnString = turnString.replace(/ +/g, ' ');
-                turnString = this._sentenceGenerator.postprocess(turnString, userState);
-                mergeConstants(newConstants, turnString);
-
-                agent = '';
-                agent_target = null;
-                user = turnString;
-                user_target = userState.prettyprint();
-            } else {
-                agentState = agentState.optimize();
-                userState = userState.optimize();
-                assert(agentState !== null); // not-null even after optimize
-                assert(userState !== null); // not-null even after optimize
-                let turnString = derivation.toString();
-                turnString = turnString.replace(/ +/g, ' ');
-                turnString = this._sentenceGenerator.postprocess(turnString, userState);
-                mergeConstants(newConstants, turnString);
-
-                [agent, user] = turnString.split(' <sep> ');
-                assert(agent);
-                assert(user);
-
-                const agentPrediction = this._target.computePrediction(dlg.context, agentState, 'agent');
-                agent_target = agentPrediction.prettyprint();
-
-                const userPrediction = this._target.computePrediction(agentState, userState, 'user');
-                user_target = userPrediction.prettyprint();
+        if (this._minibatchSize === 1) {
+            assert(partials.length <= 1);
+            if (partials.length > 0) {
+                const derivation = this._sentenceGenerator.generateOne(partials[0]);
+                if (derivation !== undefined)
+                    this._addTurn(continuations, derivation);
             }
-
-            continuations.put(dlg, {
-                userState,
-                newTurn: {
-                    context: dlg.context !== null ? dlg.context.prettyprint() : null,
-                    agent,
-                    agent_target,
-                    user,
-                    user_target
-                },
-                newConstants: {}
+        } else {
+            this._sentenceGenerator.generate(partials, (depth, derivation) => {
+                this._addTurn(continuations, derivation);
             });
-        });
+        }
 
         for (let i = 0; i < partials.length; i++) {
             const dlg = partials[i];

--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -469,6 +469,10 @@ class DialogueGenerator extends stream.Readable {
 }
 
 module.exports = {
+    // low-level interface
+    SentenceGenerator,
+
+    // stream interface for batch generation
     BasicSentenceGenerator,
     ContextualSentenceGenerator,
     DialogueGenerator

--- a/lib/sentence-generator/index.js
+++ b/lib/sentence-generator/index.js
@@ -25,8 +25,9 @@ const BASIC_TARGET_GEN_SIZE = 100000;
 const CONTEXTUAL_TARGET_GEN_SIZE = 10000;
 
 class SentenceGenerator extends events.EventEmitter {
-    constructor(options) {
+    constructor(targetLanguage, options) {
         super();
+        this._target = targetLanguage;
         this._templateFiles = options.templateFiles;
         this._options = options;
         this._langPack = i18n.get(options.locale);
@@ -51,7 +52,7 @@ class SentenceGenerator extends events.EventEmitter {
     }
 
     async initialize() {
-        this._grammar = new $runtime.Grammar(this._options);
+        this._grammar = new $runtime.Grammar(this._target, this._options);
         for (let file of this._templateFiles) {
             const compiledTemplate = await importGenie(file);
             this._grammar = await compiledTemplate(this._options, this._langPack, this._grammar);
@@ -73,8 +74,8 @@ class ContextualSentenceGenerator extends stream.Transform {
         this._options = options;
         this._idPrefix = options.idPrefix;
         this._debug = options.debug;
-        this._generator = new SentenceGenerator(options);
         this._target = require('../languages/' + options.targetLanguage);
+        this._generator = new SentenceGenerator(this._target, options);
 
         this._minibatch = [];
         this._processed = 0;
@@ -167,11 +168,11 @@ class BasicSentenceGenerator extends stream.Readable {
         options.contextual = false;
         if (options.targetPruningSize === undefined)
             options.targetPruningSize = BASIC_TARGET_GEN_SIZE;
-        this._generator = new SentenceGenerator(options);
+        this._target = require('../languages/' + options.targetLanguage);
+        this._generator = new SentenceGenerator(this._target, options);
         this._generator.on('progress', (value) => {
             this.emit('progress', value);
         });
-        this._target = require('../languages/' + options.targetLanguage);
         this._iterator = null;
 
         this._initialization = null;
@@ -414,10 +415,10 @@ class DialogueGenerator extends stream.Readable {
             options.targetPruningSize = CONTEXTUAL_TARGET_GEN_SIZE;
         if (options.maxConstants === undefined)
             options.maxConstants = 5;
-        this._generator = new SentenceGenerator(options);
+        this._target = require('../languages/' + options.targetLanguage);
+        this._generator = new SentenceGenerator(this._target, options);
 
         this._initialized = false;
-        this._target = require('../languages/' + options.targetLanguage);
         this._dialogueAgent = this._target.createSimulator(options);
         this._minibatchIdx = 0;
     }

--- a/lib/sentence-generator/runtime.js
+++ b/lib/sentence-generator/runtime.js
@@ -945,8 +945,8 @@ class Grammar extends events.EventEmitter {
             if (this._charts === undefined) {
                 this._charts = [];
                 for (let depth = 0; depth <= this._options.maxDepth; depth++) {
-                    // multiply non-contextual non-terminals by a factor of 5
-                    const targetPruningSize = 5 * this._options.targetPruningSize * POWERS[depth];
+                    // multiply non-contextual non-terminals by a factor of 10
+                    const targetPruningSize = 10 * this._options.targetPruningSize * POWERS[depth];
 
                     this._charts[depth] = [];
                     for (let index = 0; index < this._nonTermList.length; index++) {

--- a/lib/sentence-generator/runtime.js
+++ b/lib/sentence-generator/runtime.js
@@ -339,10 +339,12 @@ class Rule {
     constructor(number, expansion, combiner, weight = 1, repeat = false) {
         this.number = number;
         this.expansion = expansion;
+        assert(this.expansion.length > 0);
         this.combiner = combiner;
         this.weight = weight;
         this.repeat = repeat;
         this.hasContext = false;
+        this.enabled = true;
         assert(this.weight > 0);
     }
 }
@@ -540,9 +542,6 @@ class Grammar extends events.EventEmitter {
                         break;
                     }
 
-                    if (!rule.expansion.length)
-                        continue;
-
                     let first = rule.expansion[0];
                     if (first instanceof NonTerminal && this.hasContext(first.symbol)) {
                         rule.hasContext = true;
@@ -715,8 +714,185 @@ class Grammar extends events.EventEmitter {
         }
     }
 
+    _enableAllRules() {
+        for (let index = 0; index < this._nonTermList.length; index++) {
+            for (let rule of this._rules[index])
+                rule.enabled = true;
+        }
+    }
+
+    _disableUnreachableRules(charts) {
+        // disable all rules that use contexts that are empty
+
+        // iteratively propagate disabling the rules
+
+        // initially, all non-terminals are disabled, except the root, and all rules are disabled
+        let nonTermEnabled = [];
+        for (let index = 0; index < this._nonTermList.length; index++) {
+            nonTermEnabled[index] = false;
+
+            for (let rule of this._rules[index])
+                rule.enabled = false;
+        }
+        nonTermEnabled[this._rootIndex] = true;
+
+        let anyChange = true;
+
+        while (anyChange) {
+            anyChange = false;
+
+            // for all enabled non-terminals:
+            //   for all rules:
+            //     if the rule has a context non-terminal that is not empty, enable the rule and all the non-terminals it uses
+            //     if the rule has a context non-terminal that is empty, do nothing
+            //     if the rule does not have a context non-terminals, enable the rule and all the non-terminals it uses
+
+            for (let index = 0; index < this._nonTermList.length; index++) {
+                if (!nonTermEnabled[index])
+                    continue;
+
+                for (let rule of this._rules[index]) {
+                    // if this rule was already enabled, do nothing
+                    if (rule.enabled)
+                        continue;
+
+                    const first = rule.expansion[0];
+                    if (first instanceof NonTerminal && this.hasContext(first.symbol)) {
+                        // first terminal is a context
+
+                        if (charts[0][first.index].length > 0) {
+                            // we have at least one element: enable this rule
+                            if (this._options.debug)
+                                console.log(`enabling rule NT[${this._nonTermList[index]}] -> ${rule.expansion.join(' ')}`);
+                            rule.enabled = true;
+                            anyChange = true;
+
+                            for (let expansion of rule.expansion) {
+                                if (expansion instanceof NonTerminal)
+                                    nonTermEnabled[expansion.index] = true;
+                            }
+                        } else {
+                            // else do nothing, rule stays disabled
+                        }
+                    } else {
+                        // enable this rule unconditionally
+                        if (this._options.debug)
+                            console.log(`enabling rule NT[${this._nonTermList[index]}] -> ${rule.expansion.join(' ')}`);
+                        rule.enabled = true;
+                        anyChange = true;
+                        for (let expansion of rule.expansion) {
+                            if (expansion instanceof NonTerminal)
+                                nonTermEnabled[expansion.index] = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Generate a single sentence or dialogue turn, given the single context.
+     *
+     * This method will expand the grammar then sample exactly one derivation out of the root non-terminal.
+     *
+     * This method is optimized for individual generation, and prune the set of enabled rules
+     * based on the context. It cannot be called for non-contextual grammars. No `progress` events will
+     * be emitted during this method.
+     *
+     * @param context {any} - the current context
+     * @return {Derivation} - the sampled derivation
+     */
+    generateOne(context) {
+        this.finalize();
+        assert(this._contextual);
+
+        const rootSampler = new ReservoirSampler(1);
+
+        const charts = [];
+
+        for (let depth = 0; depth <= this._options.maxDepth; depth++) {
+            if (this._options.debug)
+                console.log(`--- DEPTH ${depth}`);
+            const depthbegin = Date.now();
+
+            const targetPruningSize = this._options.targetPruningSize * POWERS[depth];
+            charts[depth] = [];
+            for (let index = 0; index < this._nonTermList.length; index++)
+                charts[depth][index] = new ReservoirSampler(Math.ceil(targetPruningSize), this._options.rng);
+            assert(charts[depth].length === this._nonTermList.length);
+
+            if (this._contextual && depth === 0) {
+                this._initializeContexts([context], charts, depth);
+                this._disableUnreachableRules(charts);
+            }
+
+            for (let index = 0; index < this._nonTermList.length; index++) {
+                const minDistance = this._minDistanceFromRoot[index];
+                if (minDistance === undefined || minDistance > this._options.maxDepth - depth)
+                    continue;
+                const isRoot = index === this._rootIndex;
+
+                let nonTermSize = 0;
+                for (const rule of this._rules[index]) {
+                    if (!rule.enabled)
+                        continue;
+
+                    let ruleTarget = Math.min(10 * Math.ceil(targetPruningSize * rule.weight), MAX_SAMPLE_SIZE);
+                    let sampler = new ReservoirSampler(ruleTarget, this._options.rng);
+                    try {
+                        expandRule(charts, depth, index, rule, this._averagePruningFactor, this._options, this._nonTermList, (derivation) => {
+                            if (derivation === null)
+                                return;
+                            sampler.add(derivation);
+                        });
+                    } catch(e) {
+                        console.error(`Error expanding rule NT[${this._nonTermList[index]}] -> ${rule.expansion.join(' ')}`);
+                        throw e;
+                    }
+                    // if this rule hasn't hit the target, duplicate all the outputs until we hit exactly the target
+                    if (rule.repeat && sampler.length > 0 && sampler.length < ruleTarget) {
+                        const lengthbefore = sampler.length;
+                        sampler = Array.from(sampler);
+                        const lengthafter = sampler.length;
+                        assert(lengthbefore === lengthafter);
+                        for (let i = sampler.length; i < ruleTarget; i++)
+                            sampler.push(uniform(sampler, this._options.rng));
+                    }
+
+                    for (let derivation of sampler)
+                        charts[depth][index].add(derivation);
+                }
+                nonTermSize = charts[depth][index].length;
+                if (isRoot) {
+                    for (let derivation of charts[depth][index])
+                        rootSampler.add(derivation);
+                    charts[depth][index].reset();
+                }
+
+                if (this._options.debug && nonTermSize > 0)
+                    console.log(`stats: size(charts[${depth}][${this._nonTermList[index]}]) = ${nonTermSize}`);
+            }
+
+            if (this._options.debug) {
+                console.log(`depth ${depth} took ${((Date.now() - depthbegin)/1000).toFixed(2)} seconds`);
+                console.log();
+            }
+        }
+
+        return rootSampler.sampled[0];
+    }
+
+    /**
+     * Generate a batch of sentences (or dialogue turns), given the batch of contexts.
+     *
+     * This method is optimized for batch generation, and will cache intermediate generations
+     * that do not depend on the context between subsequent calls.
+     */
     generate(contexts, callback) {
         this.finalize();
+
+        // enable all rules (in case we called generateOne before)
+        this._enableAllRules();
 
         // reset progress counter for this round (only if contextual)
         this._progress = 0;
@@ -799,6 +975,9 @@ class Grammar extends events.EventEmitter {
 
                 let nonTermSize = 0;
                 for (const rule of this._rules[index]) {
+                    if (!rule.enabled)
+                        continue;
+
                     let ruleProductivity = 0;
                     let ruleTarget = Math.min(10 * Math.ceil(targetPruningSize * rule.weight), MAX_SAMPLE_SIZE);
                     let sampler = new ReservoirSampler(ruleTarget, this._options.rng);

--- a/lib/sentence-generator/runtime.js
+++ b/lib/sentence-generator/runtime.js
@@ -11,31 +11,19 @@
 
 const assert = require('assert');
 const events = require('events');
-const ThingTalk = require('thingtalk');
-const Ast = ThingTalk.Ast;
 
 const List = require('./list');
 const { ReservoirSampler, coin, uniform } = require('../random');
+const MultiMap = require('../multimap');
 
 // A numbered constant, eg. QUOTED_STRING_0 or NUMBER_1 or HASHTAG_3
 // During generation, this constant is put in the program as a VarRef
 // with an unique variable name.
 class Constant {
-    constructor(symbol, number, type) {
+    constructor(symbol, number, value) {
         this.symbol = symbol;
         this.number = number;
-        this.type = type;
-
-        const escapedSymbol = symbol.replace(/[:._]/g, (match) => {
-            if (match === '_')
-                return '__';
-            let code = match.charCodeAt(0);
-            return code < 16 ? '_0' + code.toString(16) : '_' + code.toString(16);
-        });
-        this.value = new Ast.Value.VarRef(`__const_${escapedSymbol}_${number}`);
-        // HACK: VarRefs don't know their own types normally, but these ones do
-        this.value.getType = () => type;
-        this.value.constNumber = number;
+        this.value = value;
     }
 
     toString() {
@@ -336,13 +324,15 @@ class Choice {
 }
 
 class Rule {
-    constructor(number, expansion, combiner, weight = 1, repeat = false) {
+    constructor(number, expansion, combiner, weight = 1, repeat = false, forConstant = false, temporary = false) {
         this.number = number;
         this.expansion = expansion;
         assert(this.expansion.length > 0);
         this.combiner = combiner;
         this.weight = weight;
         this.repeat = repeat;
+        this.forConstant = forConstant;
+        this.temporary = temporary;
         this.hasContext = false;
         this.enabled = true;
         assert(this.weight > 0);
@@ -361,9 +351,10 @@ const DEPTH_PROGRESS_MULTIPLIERS = [
 ];
 
 class Grammar extends events.EventEmitter {
-    constructor(options) {
+    constructor(targetLang, options) {
         super();
 
+        this._target = targetLang;
         this._options = options || {};
         this._contextual = options.contextual;
 
@@ -377,6 +368,9 @@ class Grammar extends events.EventEmitter {
         this._rootSymbol = options.rootSymbol || '$root';
         this._rootIndex = this._internalDeclareSymbol(this._rootSymbol);
         assert(this._rootIndex === 0);
+
+        // map constant tokens (QUOTED_STRING, NUMBER, ...) to the non-terms where they are used (constant_String, ...)
+        this._constantMap = new MultiMap;
 
         this._finalized = false;
         this._averagePruningFactor = [];
@@ -454,17 +448,20 @@ class Grammar extends events.EventEmitter {
 
     _addRuleInternal(symbolId, expansion, combiner, attributes = {}) {
         const rulenumber = this._rules[symbolId].length;
-        this._rules[symbolId].push(new Rule(rulenumber, expansion, combiner, attributes.weight, attributes.repeat));
+        this._rules[symbolId].push(new Rule(rulenumber, expansion, combiner, attributes.weight, attributes.repeat, attributes.forConstant, attributes.temporary));
     }
 
-    addConstants(symbol, token, type, attributes) {
+    addConstants(symbol, token, type, attributes = {}) {
         if (this._finalized)
             throw new GenieTypeError(`Grammar was finalized, cannot add more rules`);
 
         const symbolId = this._lookupNonTerminal(symbol);
-        for (let i = 0; i < (this._options.maxConstants || DEFAULT_MAX_CONSTANTS); i++) {
-            let constant = new Constant(token, i, type);
-            this._addRuleInternal(symbolId, [constant], (() => new Derivation(constant.value, List.singleton(constant))), attributes);
+        this._constantMap.put(token, symbolId);
+
+        attributes.forConstant = true;
+        for (let constant of this._target.createConstants(token, type, this._options.maxConstants || DEFAULT_MAX_CONSTANTS)) {
+            const sentencepiece = constant instanceof Constant ? constant : constant.display;
+            this._addRuleInternal(symbolId, [sentencepiece], (() => new Derivation(constant.value, List.singleton(sentencepiece))), attributes);
         }
     }
 
@@ -791,6 +788,38 @@ class Grammar extends events.EventEmitter {
         }
     }
 
+    _addConstantsFromContext(context) {
+        // disable all rules that generate constants
+        for (let index = 0; index < this._nonTermList.length; index++) {
+            for (let rule of this._rules[index]) {
+                if (rule.forConstant)
+                    rule.enabled = false;
+            }
+        }
+
+        // ask the target language to extract the constants from the context
+        const constants = this._target.extractConstants(context.context);
+
+        // create temporary rules generating these constants
+        // these rules are added to all the non-terminals where we saw a `const()` declaration
+        const attributes = { forConstant: true, temporary: true };
+
+        for (let token in constants) {
+            for (let symbolId of this._constantMap.get(token)) {
+                for (let constant of constants[token]) {
+                    this._addRuleInternal(symbolId, [constant.display], (() => new Derivation(constant.value, List.singleton(constant.display))), attributes);
+                    if (this._options.debug)
+                        console.log(`added temporary rule NT[${this._nonTermList[symbolId]}] -> ${constant.display}`);
+                }
+            }
+        }
+    }
+
+    _removeTemporaryRules() {
+        for (let index = 0; index < this._nonTermList.length; index++)
+            this._rules[index] = this._rules[index].filter((r) => !r.temporary);
+    }
+
     /**
      * Generate a single sentence or dialogue turn, given the single context.
      *
@@ -825,6 +854,7 @@ class Grammar extends events.EventEmitter {
             if (this._contextual && depth === 0) {
                 this._initializeContexts([context], charts, depth);
                 this._disableUnreachableRules(charts);
+                this._addConstantsFromContext(context);
             }
 
             for (let index = 0; index < this._nonTermList.length; index++) {
@@ -879,6 +909,8 @@ class Grammar extends events.EventEmitter {
                 console.log();
             }
         }
+
+        this._removeTemporaryRules();
 
         return rootSampler.sampled[0];
     }

--- a/lib/sentence-generator/runtime.js
+++ b/lib/sentence-generator/runtime.js
@@ -374,7 +374,8 @@ class Grammar extends events.EventEmitter {
         this._contextTable = new Map;
         this._contextTagger = null;
 
-        this._rootIndex = this._internalDeclareSymbol('$root');
+        this._rootSymbol = options.rootSymbol || '$root';
+        this._rootIndex = this._internalDeclareSymbol(this._rootSymbol);
         assert(this._rootIndex === 0);
 
         this._finalized = false;

--- a/lib/sentence-generator/runtime.js
+++ b/lib/sentence-generator/runtime.js
@@ -836,7 +836,7 @@ class Grammar extends events.EventEmitter {
         this.finalize();
         assert(this._contextual);
 
-        const rootSampler = new ReservoirSampler(1);
+        const rootSampler = new ReservoirSampler(1, this._options.rng);
 
         const charts = [];
 

--- a/tool/demo-dialog.js
+++ b/tool/demo-dialog.js
@@ -63,7 +63,7 @@ class DialogAgent extends events.EventEmitter {
         this._simulatorState = undefined;
 
         if (!USE_NEURAL_POLICY) {
-            this._sentenceGenerator = new SentenceGenerator(this._target, {
+            this._sentenceGenerator = new SentenceGenerator({
                 contextual: true,
                 rootSymbol: '$agent',
                 flags: {

--- a/tool/demo-dialog.js
+++ b/tool/demo-dialog.js
@@ -63,7 +63,7 @@ class DialogAgent extends events.EventEmitter {
         this._simulatorState = undefined;
 
         if (!USE_NEURAL_POLICY) {
-            this._sentenceGenerator = new SentenceGenerator({
+            this._sentenceGenerator = new SentenceGenerator(this._target, {
                 contextual: true,
                 rootSymbol: '$agent',
                 flags: {

--- a/tool/lib/multi_json_database.js
+++ b/tool/lib/multi_json_database.js
@@ -1,0 +1,52 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const util = require('util');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Parse a TSV file in a format similar to shared-parameter-datasets.tsv
+ * with one line per Thingpedia query, pointing to a JSON file for each.
+ */
+class MultiJSONDatabase {
+    constructor(filename) {
+        this._filename = filename;
+        this._dirname = path.dirname(filename);
+
+        this._store = new Map;
+    }
+
+    async load() {
+        const lines = (await util.promisify(fs.readFile)(this._filename, { encoding: 'utf8' })).split(/\r?\n/g);
+        await Promise.all(lines.map(async (line) => {
+            if (!line.trim() || line.startsWith('#'))
+                return;
+
+            let [functionKey, filepath] = line.trim().split('\t');
+            filepath = path.resolve(this._dirname, filepath);
+
+            const file = JSON.parse(await util.promisify(fs.readFile)(filepath, { encoding: 'utf8' }));
+            this._store.set(functionKey, file);
+        }));
+    }
+
+    get size() {
+        return this._store.size;
+    }
+    has(key) {
+        return this._store.has(key);
+    }
+    get(key) {
+        return this._store.get(key);
+    }
+}
+module.exports = MultiJSONDatabase;

--- a/tool/manual-annotate-dialog.js
+++ b/tool/manual-annotate-dialog.js
@@ -9,12 +9,10 @@
 // See COPYING for details
 "use strict";
 
-const util = require('util');
 const fs = require('fs');
 const readline = require('readline');
 const events = require('events');
 const seedrandom = require('seedrandom');
-const path = require('path');
 const Tp = require('thingpedia');
 const ThingTalk = require('thingtalk');
 
@@ -23,43 +21,7 @@ const ParserClient = require('./lib/parserclient');
 const { DialogueParser, DialogueSerializer } = require('./lib/dialog_parser');
 const StreamUtils = require('../lib/stream-utils');
 const { readAllLines } = require('./lib/argutils');
-
-/**
- * Parse a TSV file in a format similar to shared-parameter-datasets.tsv
- * with one line per Thingpedia query, pointing to a JSON file for each.
- */
-class MultiJSONDatabase {
-    constructor(filename) {
-        this._filename = filename;
-        this._dirname = path.dirname(filename);
-
-        this._store = new Map;
-    }
-
-    async load() {
-        const lines = (await util.promisify(fs.readFile)(this._filename, { encoding: 'utf8' })).split(/\r?\n/g);
-        await Promise.all(lines.map(async (line) => {
-            if (!line.trim() || line.startsWith('#'))
-                return;
-
-            let [functionKey, filepath] = line.trim().split('\t');
-            filepath = path.resolve(this._dirname, filepath);
-
-            const file = JSON.parse(await util.promisify(fs.readFile)(filepath, { encoding: 'utf8' }));
-            this._store.set(functionKey, file);
-        }));
-    }
-
-    get size() {
-        return this._store.size;
-    }
-    has(key) {
-        return this._store.has(key);
-    }
-    get(key) {
-        return this._store.get(key);
-    }
-}
+const MultiJSONDatabase = require('./lib/multi_json_database');
 
 class Annotator extends events.EventEmitter {
     constructor(rl, dialogues, options) {

--- a/tool/requote.js
+++ b/tool/requote.js
@@ -405,7 +405,7 @@ module.exports = {
 
     async execute(args) {
         readAllLines(args.input_file)
-            .pipe(new DatasetParser({ contextual: args.contextual }))
+            .pipe(new DatasetParser({ contextual: args.contextual, preserveId: true }))
             .pipe(new Stream.Transform({
                 objectMode: true,
 

--- a/tool/server.js
+++ b/tool/server.js
@@ -223,7 +223,7 @@ module.exports = {
             help: "Path to the NLU model, pointing to a model directory.",
         });
         parser.addArgument('--nlg-model', {
-            required: true,
+            required: false,
             help: "Path to the NLU model, pointing to a model directory.",
         });
         parser.addArgument('--thingpedia', {


### PR DESCRIPTION
_This is not 1.8 material_

This PR introduces a new way to run the dialogue templates, in "inference mode". In this mode, we take exactly one context, and generate exactly one possible continuation. If this continuation contains only the agent sentence and agent dialogue state, it is suitable to choose as the policy and utterance in a real interactive agent.