### PR TITLE
webqa-make-string-dataset: chunk long strings before passing them to …

### DIFF
--- a/tool/webqa-make-string-datasets.js
+++ b/tool/webqa-make-string-datasets.js
@@ -123,12 +123,34 @@ class ParamDatasetGenerator {
         }
     }
 
+    async _tokenizeOne(str) {
+        // chunk long sentences into chunks of at most 1000 characters
+
+        if (str.length < 500)
+            return this._tokenizer.tokenize(this._locale, str);
+
+        // very crude chunking, might break a word in the middle
+        // this is mostly ok anyway cause we'll pick a substring anyway
+        const output = [];
+        for (let i = 0; i < str.length; i += 500) {
+            const chunk = str.substring(i, i+500);
+            const { tokens } = await this._tokenizer.tokenize(this._locale, chunk);
+            // refuse to do anything if we have any entity (we'll drop this string later anyway)
+            if (tokens.some((tok) => /^[A-Z]/.test(tok)))
+                return { tokens: [], entities: {} };
+
+            output.push(...tokens);
+        }
+
+        return { tokens: output, entities: {} };
+    }
+
     async _tokenizeAll(strings) {
         let output = [];
         for (let i = 0; i < strings.length; i += 100) {
             console.log(`${i}/${strings.length}`);
             const slice = strings.slice(i, i+100);
-            const tokenized = await Promise.all(slice.map((str) => this._tokenizer.tokenize(this._locale, str)));
+            const tokenized = await Promise.all(slice.map((str) => this._tokenizeOne(str)));
             output.push(...tokenized);
         }
         return output;
@@ -186,7 +208,7 @@ class ParamDatasetGenerator {
 
                     // if some tokens are uppercase, they are entities, like NUMBER_0,
                     // in which case we ignore this value
-                    if (tokens.some((tok) => /^[A-Z]/.test(tok)))
+                    if (tokens.length === 0 || tokens.some((tok) => /^[A-Z]/.test(tok)))
                         continue;
 
                     output.write([value, tokens.join(' '), weight]);

--- a/tool/webqa-make-string-datasets.js
+++ b/tool/webqa-make-string-datasets.js
@@ -20,6 +20,8 @@ const Tokenizer = require('../lib/tokenizer');
 const StreamUtils = require('../lib/stream-utils');
 const { makeMetadata } = require('./lib/webqa-metadata');
 
+const MAX_CHARS = 200;
+
 class ParamDatasetGenerator {
     constructor(locale, debug, className) {
         this._locale = locale;
@@ -126,14 +128,14 @@ class ParamDatasetGenerator {
     async _tokenizeOne(str) {
         // chunk long sentences into chunks of at most 1000 characters
 
-        if (str.length < 500)
+        if (str.length < MAX_CHARS)
             return this._tokenizer.tokenize(this._locale, str);
 
         // very crude chunking, might break a word in the middle
         // this is mostly ok anyway cause we'll pick a substring anyway
         const output = [];
-        for (let i = 0; i < str.length; i += 500) {
-            const chunk = str.substring(i, i+500);
+        for (let i = 0; i < str.length; i += MAX_CHARS) {
+            const chunk = str.substring(i, i+MAX_CHARS);
             const { tokens } = await this._tokenizer.tokenize(this._locale, chunk);
             // refuse to do anything if we have any entity (we'll drop this string later anyway)
             if (tokens.some((tok) => /^[A-Z]/.test(tok)))


### PR DESCRIPTION
…the tokenizer

Otherwise the tokenizer will run out of memory and crash, especially
on memory-limited machine where the Java VM is configured to use
too much memory.