### PR TITLE
Disable id filters when it is set to be non-filterable

### DIFF
--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -670,6 +670,8 @@ class ThingpediaLoader {
         const id = q.getArgument('id');
         if (!id.type.isEntity)
             return;
+        if (id.getImplementationAnnotation('filterable') === false)
+            return;
 
         const idType = id.type;
         const entity = this._entities[idType.type];


### PR DESCRIPTION
@ryachen01 discovered this issue: we still generate id filters even it's annotated as `filterable=false`