### PR TITLE
Add simple action rejection templates

### DIFF
--- a/languages/thingtalk/dialogue_acts/action-confirm.js
+++ b/languages/thingtalk/dialogue_acts/action-confirm.js
@@ -22,6 +22,7 @@
 const assert = require('assert');
 
 const ThingTalk = require('thingtalk');
+const Ast = ThingTalk.Ast;
 const Type = ThingTalk.Type;
 
 const C = require('../ast_manip');
@@ -30,6 +31,8 @@ const {
     makeAgentReply,
     makeSimpleState,
     sortByName,
+    setOrAddInvocationParam,
+    replaceAction,
 } = require('../state_manip');
 
 
@@ -68,7 +71,38 @@ function actionConfirmAcceptPhrase(ctx) {
     return clone.state;
 }
 
+function actionConfirmRejectPhrase(ctx) {
+    // remove last action in history so it's not carried over into the cancel state
+    return makeSimpleState(ctx, 'cancel', null, true);
+}
+
+// function actionConfirmChangeParam(ctx, answer) {
+//     // console.log(ctx);
+//     // console.log(answer);
+//     const schema = ctx.nextFunctionSchema;
+//     const questions = ctx.dialogueActParam || [];
+//     if (answer instanceof Ast.Value) {
+//         if (questions.length !== 1)
+//             return null;
+//         answer = new Ast.InputParam(null, questions[0], answer);
+//     }
+//     const arg = schema.getArgument(answer.name);
+//     if (!arg || !arg.is_input || !arg.type.equals(answer.value.getType()))
+//         return null;
+
+//     // console.log(ctx.state.history[0]);
+//     const action = C.getInvocation(ctx.state.history[0]);
+//     // console.log(action);
+//     if (!action)
+//         return null;
+//     const clone = action.clone();
+//     setOrAddInvocationParam(clone, answer.name, answer.value);
+//     return replaceAction(ctx, 'execute', clone, 'accepted');
+// }
+
 module.exports = {
     makeActionConfirmationPhrase,
-    actionConfirmAcceptPhrase
+    actionConfirmAcceptPhrase,
+    actionConfirmRejectPhrase
+    // actionConfirmChangeParam
 };

--- a/languages/thingtalk/dialogue_acts/action-confirm.js
+++ b/languages/thingtalk/dialogue_acts/action-confirm.js
@@ -87,7 +87,7 @@ function actionConfirmChangeParam(ctx, answer) {
     
     const clone = action.clone();
     setOrAddInvocationParam(clone, answer.name, answer.value);
-    return replaceAction(ctx, 'execute', clone, 'accepted');
+    return replaceAction(ctx, 'execute', clone, 'confirmed');
 }
 
 module.exports = {

--- a/languages/thingtalk/dialogue_acts/action-confirm.js
+++ b/languages/thingtalk/dialogue_acts/action-confirm.js
@@ -73,7 +73,9 @@ function actionConfirmAcceptPhrase(ctx) {
 }
 
 function actionConfirmRejectPhrase(ctx) {
-    return new Ast.DialogueState(null, POLICY_NAME, 'cancel', null, []);
+    const clone = ctx.clone();
+    clone.next.confirm = 'proposed';
+    return makeSimpleState(clone, 'cancel', null);
 }
 
 function actionConfirmChangeParam(ctx, answer) {

--- a/languages/thingtalk/dialogue_acts/action-confirm.js
+++ b/languages/thingtalk/dialogue_acts/action-confirm.js
@@ -83,8 +83,9 @@ function actionConfirmChangeParam(ctx, answer) {
 
     // don't accept in params that don't apply to this specific action
     const arg = ctx.nextFunctionSchema.getArgument(answer.name);
-    if (!arg || !arg.is_input) return null;
-    
+    if (!arg || !arg.is_input || !arg.type.equals(answer.value.getType()))
+        return null;
+
     const clone = action.clone();
     setOrAddInvocationParam(clone, answer.name, answer.value);
     return replaceAction(ctx, 'execute', clone, 'confirmed');

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -224,8 +224,10 @@ $user = {
     ) => D.startNewRequest(ctx, stmt);
 
     // action confirmations
-    ctx:ctx_sys_confirm_action accept_phrase
+    ctx:ctx_sys_confirm_action accept_phrase [weight=0.9]
         => D.actionConfirmAcceptPhrase(ctx);
+    ctx:ctx_sys_confirm_action reject_phrase [weight=0.1]
+        => S.makeSimpleState(ctx, 'cancel', null);
 
     // action and non-list query results
     ( ctx:ctx_sys_action_success thanks_phrase ('goodbye !' | '')

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -228,8 +228,8 @@ $user = {
         => D.actionConfirmAcceptPhrase(ctx);
     ctx:ctx_sys_confirm_action reject_phrase [weight=0.1]
         => D.actionConfirmRejectPhrase(ctx);
-    // ctx:ctx_sys_confirm_action reject_phrase ('can you try' | 'how about') answer:imprecise_slot_fill_answer_phrase [weight=0.1]
-    //     => D.actionConfirmChangeParam(ctx, answer);
+    ctx:ctx_sys_confirm_action reject_phrase ('can you try' | 'how about') answer:imprecise_slot_fill_answer_phrase [weight=0.1]
+        => D.actionConfirmChangeParam(ctx, answer);
 
     // action and non-list query results
     ( ctx:ctx_sys_action_success thanks_phrase ('goodbye !' | '')

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -227,7 +227,9 @@ $user = {
     ctx:ctx_sys_confirm_action accept_phrase [weight=0.9]
         => D.actionConfirmAcceptPhrase(ctx);
     ctx:ctx_sys_confirm_action reject_phrase [weight=0.1]
-        => S.makeSimpleState(ctx, 'cancel', null);
+        => D.actionConfirmRejectPhrase(ctx);
+    // ctx:ctx_sys_confirm_action reject_phrase ('can you try' | 'how about') answer:imprecise_slot_fill_answer_phrase [weight=0.1]
+    //     => D.actionConfirmChangeParam(ctx, answer);
 
     // action and non-list query results
     ( ctx:ctx_sys_action_success thanks_phrase ('goodbye !' | '')

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -228,7 +228,7 @@ $user = {
         => D.actionConfirmAcceptPhrase(ctx);
     ctx:ctx_sys_confirm_action reject_phrase [weight=0.1]
         => D.actionConfirmRejectPhrase(ctx);
-    ctx:ctx_sys_confirm_action reject_phrase ('can you try' | 'how about') answer:imprecise_slot_fill_answer_phrase [weight=0.1]
+    ctx:ctx_sys_confirm_action reject_phrase ('can you try' | 'how about') answer:imprecise_slot_fill_answer_phrase ('instead ?' | '') [weight=0.1]
         => D.actionConfirmChangeParam(ctx, answer);
 
     // action and non-list query results

--- a/languages/thingtalk/en/dlg/shared.genie
+++ b/languages/thingtalk/en/dlg/shared.genie
@@ -63,6 +63,15 @@ accept_phrase = {
     'sounds good';
 }
 
+reject_phrase = {
+    'no';
+    'actually , no';
+    'that will not work';
+    'no , thank you';
+    'not yet';
+    'actually , not yet';
+}
+
 tell_me_more_phrase = {
     'can you tell me more ?';
     'can you tell me more about it ?';

--- a/languages/thingtalk/state_manip.js
+++ b/languages/thingtalk/state_manip.js
@@ -323,7 +323,7 @@ function addNewItem(ctx, dialogueAct, dialogueActParam, confirm, ...newHistoryIt
     return newState;
 }
 
-function makeSimpleState(ctx, dialogueAct, dialogueActParam) {
+function makeSimpleState(ctx, dialogueAct, dialogueActParam, dropActions = false) {
     // a "simple state" carries the current executed/confirmed/accepted items, but not the
     // proposed ones
 
@@ -331,11 +331,14 @@ function makeSimpleState(ctx, dialogueAct, dialogueActParam) {
     if (ctx === INITIAL_CONTEXT_INFO)
         return newState;
 
-    for (let i = 0; i < ctx.state.history.length; i++) {
-        if (ctx.state.history[i].confirm === 'proposed')
-            break;
-        newState.history.push(ctx.state.history[i]);
+    if (!dropActions) {
+        for (let i = 0; i < ctx.state.history.length; i++) {
+            if (ctx.state.history[i].confirm === 'proposed')
+                break;
+            newState.history.push(ctx.state.history[i]);
+        }
     }
+
     return newState;
 }
 

--- a/languages/thingtalk/state_manip.js
+++ b/languages/thingtalk/state_manip.js
@@ -323,7 +323,7 @@ function addNewItem(ctx, dialogueAct, dialogueActParam, confirm, ...newHistoryIt
     return newState;
 }
 
-function makeSimpleState(ctx, dialogueAct, dialogueActParam, dropActions = false) {
+function makeSimpleState(ctx, dialogueAct, dialogueActParam) {
     // a "simple state" carries the current executed/confirmed/accepted items, but not the
     // proposed ones
 
@@ -331,12 +331,10 @@ function makeSimpleState(ctx, dialogueAct, dialogueActParam, dropActions = false
     if (ctx === INITIAL_CONTEXT_INFO)
         return newState;
 
-    if (!dropActions) {
-        for (let i = 0; i < ctx.state.history.length; i++) {
-            if (ctx.state.history[i].confirm === 'proposed')
-                break;
-            newState.history.push(ctx.state.history[i]);
-        }
+    for (let i = 0; i < ctx.state.history.length; i++) {
+        if (ctx.state.history[i].confirm === 'proposed')
+            break;
+        newState.history.push(ctx.state.history[i]);
     }
 
     return newState;


### PR DESCRIPTION
Currently, `sys_confirm_action` states are only followed by the user accepting the action. This PR adds two additional transitions:
1. Action cancellations, of the utterance form "No, thank you." or "Actually, not yet.". These are annotated as `cancel` states.
2. Action modifications, of the utterance form "Actually, could you do [X] instead?". These are annotated with the new action.