### PR TITLE
Fix bert annotation and improve speed

### DIFF
--- a/tool/autoqa/lib/bert-canonical-annotator.py
+++ b/tool/autoqa/lib/bert-canonical-annotator.py
@@ -153,7 +153,7 @@ class BertLM:
         self.tokenizer = BertTokenizer.from_pretrained(model_name_or_path)
 
         # Load pre-trained model (weights)
-        self.model = BertForMaskedLM.from_pretrained(model_name_or_path).to('cuda')
+        self.model = BertForMaskedLM.from_pretrained(model_name_or_path).to(device)
         self.model.eval()
 
         self.gpt2_ordering = gpt2_ordering

--- a/tool/autoqa/lib/canonical-generator.js
+++ b/tool/autoqa/lib/canonical-generator.js
@@ -192,6 +192,7 @@ class AutoCanonicalGenerator {
             const child = child_process.spawn(`python3`, args, {stdio: ['pipe', 'pipe', 'inherit']});
 
             const output = util.promisify(fs.writeFile);
+            const startTime = new Date();
             if (this.options.debug)
                 await output(`./bert-canonical-annotator-in.json`, JSON.stringify(functions, null, 2));
 
@@ -211,6 +212,8 @@ class AutoCanonicalGenerator {
             if (this.options.debug) {
                 try {
                     await output(`./bert-canonical-annotator-out.json`, JSON.stringify(JSON.parse(stdout), null, 2));
+                    const time = Math.round((new Date() - startTime) / 1000);
+                    console.log(`Bert annotator took ${time} seconds to run.`);
                 } catch (e) {
                      await output(`./bert-canonical-annotator-out.json`, stdout);
                 }
@@ -220,8 +223,13 @@ class AutoCanonicalGenerator {
             if (this.algorithm.includes('bert') || this.algorithm.includes('adj'))
                 this._updateCanonicals(synonyms, adjectives);
             if (this.algorithm.includes('bart')) {
+                const startTime = new Date();
                 const extractor = new CanonicalExtractor(this.class, this.functions, this.paraphraser_model, this.options);
                 await extractor.run(synonyms, functions);
+                if (this.options.debug) {
+                    const time = Math.round((new Date() - startTime) / 1000);
+                    console.log(`Bart annotator took ${time} seconds to run.`);
+                }
             }
         }
 

--- a/tool/autoqa/lib/canonical-generator.js
+++ b/tool/autoqa/lib/canonical-generator.js
@@ -62,11 +62,12 @@ class AutoCanonicalGenerator {
 
         this.options = options;
 
-        if (options.dataset !== 'custom' && fs.existsSync(`../${options.dataset}/manual-annotations`)) {
-            this.manualAnnotations = require(`../${options.dataset}/manual-annotations`);
-            this.annotatedProperties = Object.keys(this.manualAnnotations.MANUAL_PROPERTY_CANONICAL_OVERRIDE);
-        } else {
-            this.annotatedProperties = [];
+        this.annotatedProperties = [];
+        const file = path.resolve(path.dirname(module.filename), `../${options.dataset}/manual-annotations.js`);
+        if (options.dataset !== 'custom' && fs.existsSync(file)) {
+            const manualAnnotations = require(`../${options.dataset}/manual-annotations`);
+            if (manualAnnotations.PROPERTY_CANONICAL_OVERRIDE)
+                this.annotatedProperties = Object.keys(manualAnnotations.PROPERTY_CANONICAL_OVERRIDE);
         }
         this._langPack = new EnglishLanguagePack();
     }
@@ -215,7 +216,7 @@ class AutoCanonicalGenerator {
                 }
             }
 
-            const {synonyms, adjectives } = JSON.parse(stdout);
+            const { synonyms, adjectives } = JSON.parse(stdout);
             if (this.algorithm.includes('bert') || this.algorithm.includes('adj'))
                 this._updateCanonicals(synonyms, adjectives);
             if (this.algorithm.includes('bart')) {

--- a/tool/autoqa/make-string-datasets.js
+++ b/tool/autoqa/make-string-datasets.js
@@ -46,11 +46,12 @@ class ParamDatasetGenerator {
         this._tokenizer = I18N.get(locale).getTokenizer();
 
 
-        if (dataset !== 'custom' && fs.existsSync(`../${dataset}/manual-annotations`)) {
-            let manualAnnotations = require(`../${dataset}/manual-annotations`);
-            this._propertiesNoFilter = manualAnnotations.PROPERTIES_NO_FILTER;
-        } else {
-            this._propertiesNoFilter = [];
+        this._propertiesNoFilter = [];
+        const file = path.resolve(path.dirname(module.filename), `../${dataset}/manual-annotations.js`);
+        if (dataset !== 'custom' && fs.existsSync(file)) {
+            const manualAnnotations = require(`../${dataset}/manual-annotations`);
+            if (manualAnnotations.PROPERTIES_NO_FILTER)
+                this._propertiesNoFilter = manualAnnotations.PROPERTIES_NO_FILTER;
         }
     }
 


### PR DESCRIPTION
I introduced a bug which makes both bert and bart to run on all values instead of sampled examples.
This PR makes the test run in a not too crazy long time at least. 
Future improvement on Bart will be in a separate PR