### PR TITLE
Prototype for evaluate-by-device

### DIFF
--- a/lib/dataset-tools/evaluation/sentence_evaluator.js
+++ b/lib/dataset-tools/evaluation/sentence_evaluator.js
@@ -108,6 +108,7 @@ class SentenceEvaluator {
             id: this._id,
             preprocessed: this._preprocessed,
             target_code: this._targetPrograms,
+            target_devices: [],
             ok: [],
             ok_without_param: [],
             ok_function: [],
@@ -186,6 +187,7 @@ class SentenceEvaluator {
         const goldFunctions = untypedTargetCode.map((code) => Array.from(getFunctions(code)));
         const goldDevices = untypedTargetCode.map((code) => Array.from(getDevices(code)));
         result.is_primitive = goldFunctions[0].length === 1;
+        result.target_devices = goldDevices;
 
         let first = true;
         let ok = false, ok_without_param = false, ok_function = false,
@@ -330,128 +332,141 @@ class CollectSentenceStatistics extends Stream.Writable {
         super({ objectMode: true });
 
         this._maxComplexity = options.maxComplexity;
+        this._splitByDevice = options.splitByDevice;
 
-        this._buffer = {
-            total: 0,
-            primitives: 0,
-            compounds: 0,
-            ok: [],
-            ok_without_param: [],
-            ok_function: [],
-            ok_device: [],
-            ok_num_function: [],
-            ok_syntax: [],
-            'prim/ok': [],
-            'prim/ok_without_param': [],
-            'prim/ok_function': [],
-            'prim/ok_device': [],
-            'prim/ok_num_function': [],
-            'prim/ok_syntax': [],
-            'comp/ok': [],
-            'comp/ok_without_param': [],
-            'comp/ok_function': [],
-            'comp/ok_device': [],
-            'comp/ok_num_function': [],
-            'comp/ok_syntax': [],
-        };
+        // _buffer will map devices to individual buffers. If splitByDevice is
+        // false, there will only be a single buffer. Othersie, these individual
+        // buffers will be created ad-hoc, as new devices come up.
+        this._buffer = {};
     }
 
     _write(ex, encoding, callback) {
-        this._buffer.total ++;
+        const uniqueDevices = ex.target_devices.filter((val, ix) => ex.target_devices.indexOf(val) === ix);
+        assert(uniqueDevices.length === 1);
+        const device = this._splitbyDevice ? 'all' : uniqueDevices[0];
+        if (!(device in this._buffer)) {
+            this._buffer[device] = {
+                total: 0,
+                primitives: 0,
+                compounds: 0,
+                ok: [],
+                ok_without_param: [],
+                ok_function: [],
+                ok_device: [],
+                ok_num_function: [],
+                ok_syntax: [],
+                'prim/ok': [],
+                'prim/ok_without_param': [],
+                'prim/ok_function': [],
+                'prim/ok_device': [],
+                'prim/ok_num_function': [],
+                'prim/ok_syntax': [],
+                'comp/ok': [],
+                'comp/ok_without_param': [],
+                'comp/ok_function': [],
+                'comp/ok_device': [],
+                'comp/ok_num_function': [],
+                'comp/ok_syntax': [],
+            };
+        }
+        this._buffer[device].total ++;
         if (ex.is_primitive)
-            this._buffer.primitives ++;
+            this._buffer[device].primitives ++;
         else
-            this._buffer.compounds ++;
+            this._buffer[device].compounds ++;
 
         let compkey;
         if (this._maxComplexity && ex.complexity >= this._maxComplexity)
             compkey = 'complexity_>=' + this._maxComplexity + '/';
         else
             compkey = 'complexity_' + ex.complexity + '/';
-        if (!this._buffer[compkey + 'total']) {
-            this._buffer[compkey + 'total'] = 0;
+        if (!this._buffer[device][compkey + 'total']) {
+            this._buffer[device][compkey + 'total'] = 0;
             for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax'])
-                this._buffer[compkey + key] = [];
+                this._buffer[device][compkey + key] = [];
         }
 
 
         let numericKey = ex.has_numeric ? 'with_numeric_' : 'without_numeric_';
-        if (!this._buffer[numericKey + 'total']) {
-            this._buffer[numericKey + 'total'] = 0;
+        if (!this._buffer[device][numericKey + 'total']) {
+            this._buffer[device][numericKey + 'total'] = 0;
             for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax'])
-                this._buffer[numericKey + key] = [];
+                this._buffer[device][numericKey + key] = [];
         }
 
-        this._buffer[compkey + 'total'] += 1;
-        this._buffer[numericKey + 'total'] += 1;
+        this._buffer[device][compkey + 'total'] += 1;
+        this._buffer[device][numericKey + 'total'] += 1;
 
         for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax']) {
             for (let beampos = 0; beampos < ex[key].length; beampos++) {
-                while (this._buffer[key].length <= beampos)
-                    this._buffer[key].push(0);
+                while (this._buffer[device][key].length <= beampos)
+                    this._buffer[device][key].push(0);
                 if (ex[key][beampos])
-                    this._buffer[key][beampos] ++;
+                    this._buffer[device][key][beampos] ++;
 
                 let subkey = ex.is_primitive ? 'prim/' + key : 'comp/' + key;
-                while (this._buffer[subkey].length <= beampos)
-                    this._buffer[subkey].push(0);
+                while (this._buffer[device][subkey].length <= beampos)
+                    this._buffer[device][subkey].push(0);
                 if (ex[key][beampos])
-                    this._buffer[subkey][beampos] ++;
+                    this._buffer[device][subkey][beampos] ++;
 
                 subkey = compkey + key;
-                while (this._buffer[subkey].length <= beampos)
-                    this._buffer[subkey].push(0);
+                while (this._buffer[device][subkey].length <= beampos)
+                    this._buffer[device][subkey].push(0);
                 if (ex[key][beampos])
-                    this._buffer[subkey][beampos] ++;
-                assert(!isNaN(this._buffer[subkey][beampos]));
+                    this._buffer[device][subkey][beampos] ++;
+                assert(!isNaN(this._buffer[device][subkey][beampos]));
 
                 subkey = numericKey + key;
-                while (this._buffer[subkey].length <= beampos)
-                    this._buffer[subkey].push(0);
+                while (this._buffer[device][subkey].length <= beampos)
+                    this._buffer[device][subkey].push(0);
                 if (ex[key][beampos])
-                    this._buffer[subkey][beampos] ++;
+                    this._buffer[device][subkey][beampos] ++;
             }
         }
         callback();
     }
 
     _final(callback) {
-        // convert to percentages
-        for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax']) {
-            for (let beampos = 0; beampos < this._buffer[key].length; beampos++) {
-                //this._buffer[key][beampos] = (this._buffer[key][beampos] * 100 / this._buffer.total).toFixed(2);
-                //this._buffer['prim/' + key][beampos] = (this._buffer['prim/' + key][beampos] * 100 / this._buffer.primitives).toFixed(2);
-                //this._buffer['comp/' + key][beampos] = (this._buffer['comp/' + key][beampos] * 100 / this._buffer.compounds).toFixed(2);
+        for (let device in this._buffer) {
+            // convert to percentages
+            console.error(device + '\t' + this._buffer[device].total);
+            for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax']) {
+                for (let beampos = 0; beampos < this._buffer[device][key].length; beampos++) {
+                    //this._buffer[device][key][beampos] = (this._buffer[device][key][beampos] * 100 / this._buffer[device].total).toFixed(2);
+                    //this._buffer[device]['prim/' + key][beampos] = (this._buffer[device]['prim/' + key][beampos] * 100 / this._buffer[device].primitives).toFixed(2);
+                    //this._buffer[device]['comp/' + key][beampos] = (this._buffer[device]['comp/' + key][beampos] * 100 / this._buffer[device].compounds).toFixed(2);
 
-                this._buffer[key][beampos] /= this._buffer.total;
-                this._buffer['prim/' + key][beampos] /= this._buffer.primitives;
-                this._buffer['comp/' + key][beampos] /= this._buffer.compounds;
+                    this._buffer[device][key][beampos] /= this._buffer[device].total;
+                    this._buffer[device]['prim/' + key][beampos] /= this._buffer[device].primitives;
+                    this._buffer[device]['comp/' + key][beampos] /= this._buffer[device].compounds;
 
-                for (let i = 0; i < 20; i++) {
-                    const compkey = 'complexity_' + i + '/';
-                    if (this._buffer[compkey + 'total']) {
-                        this._buffer[compkey + key][beampos] /= this._buffer[compkey + 'total'];
-                        assert(!isNaN(this._buffer[compkey + key][beampos]), this._buffer[compkey + key]);
+                    for (let i = 0; i < 20; i++) {
+                        const compkey = 'complexity_' + i + '/';
+                        if (this._buffer[device][compkey + 'total']) {
+                            this._buffer[device][compkey + key][beampos] /= this._buffer[device][compkey + 'total'];
+                            assert(!isNaN(this._buffer[device][compkey + key][beampos]), this._buffer[device][compkey + key]);
+                        }
                     }
-                }
-                if (this._maxComplexity) {
-                    const compkey = 'complexity_>=' + this._maxComplexity + '/';
-                    if (this._buffer[compkey + 'total']) {
-                        this._buffer[compkey + key][beampos] /= this._buffer[compkey + 'total'];
-                        assert(!isNaN(this._buffer[compkey + key][beampos]), this._buffer[compkey + key]);
+                    if (this._maxComplexity) {
+                        const compkey = 'complexity_>=' + this._maxComplexity + '/';
+                        if (this._buffer[device][compkey + 'total']) {
+                            this._buffer[device][compkey + key][beampos] /= this._buffer[device][compkey + 'total'];
+                            assert(!isNaN(this._buffer[device][compkey + key][beampos]), this._buffer[device][compkey + key]);
+                        }
                     }
-                }
 
-                let numerickey = 'with_numeric_';
-                if (this._buffer[numerickey + 'total']) {
-                    this._buffer[numerickey + key][beampos] /= this._buffer[numerickey + 'total'];
-                    assert(!isNaN(this._buffer[numerickey + key][beampos]), this._buffer[numerickey + key]);
-                }
+                    let numerickey = 'with_numeric_';
+                    if (this._buffer[device][numerickey + 'total']) {
+                        this._buffer[device][numerickey + key][beampos] /= this._buffer[device][numerickey + 'total'];
+                        assert(!isNaN(this._buffer[device][numerickey + key][beampos]), this._buffer[device][numerickey + key]);
+                    }
 
-                numerickey = 'without_numeric_';
-                if (this._buffer[numerickey + 'total']) {
-                    this._buffer[numerickey + key][beampos] /= this._buffer[numerickey + 'total'];
-                    assert(!isNaN(this._buffer[numerickey + key][beampos]), this._buffer[numerickey + key]);
+                    numerickey = 'without_numeric_';
+                    if (this._buffer[device][numerickey + 'total']) {
+                        this._buffer[device][numerickey + key][beampos] /= this._buffer[device][numerickey + 'total'];
+                        assert(!isNaN(this._buffer[device][numerickey + key][beampos]), this._buffer[device][numerickey + key]);
+                    }
                 }
             }
         }

--- a/lib/dataset-tools/evaluation/sentence_evaluator.js
+++ b/lib/dataset-tools/evaluation/sentence_evaluator.js
@@ -187,7 +187,7 @@ class SentenceEvaluator {
         const goldFunctions = untypedTargetCode.map((code) => Array.from(getFunctions(code)));
         const goldDevices = untypedTargetCode.map((code) => Array.from(getDevices(code)));
         result.is_primitive = goldFunctions[0].length === 1;
-        result.target_devices = goldDevices;
+        result.target_devices = goldDevices[0];
 
         let first = true;
         let ok = false, ok_without_param = false, ok_function = false,
@@ -335,93 +335,100 @@ class CollectSentenceStatistics extends Stream.Writable {
         this._splitByDevice = options.splitByDevice;
 
         // _buffer will map devices to individual buffers. If splitByDevice is
-        // false, there will only be a single buffer. Othersie, these individual
+        // false, there will only be a single buffer. Otherwise, these individual
         // buffers will be created ad-hoc, as new devices come up.
         this._buffer = {};
     }
 
     _write(ex, encoding, callback) {
-        const uniqueDevices = ex.target_devices.filter((val, ix) => ex.target_devices.indexOf(val) === ix);
-        assert(uniqueDevices.length === 1);
-        const device = this._splitbyDevice ? 'all' : uniqueDevices[0];
-        if (!(device in this._buffer)) {
-            this._buffer[device] = {
-                total: 0,
-                primitives: 0,
-                compounds: 0,
-                ok: [],
-                ok_without_param: [],
-                ok_function: [],
-                ok_device: [],
-                ok_num_function: [],
-                ok_syntax: [],
-                'prim/ok': [],
-                'prim/ok_without_param': [],
-                'prim/ok_function': [],
-                'prim/ok_device': [],
-                'prim/ok_num_function': [],
-                'prim/ok_syntax': [],
-                'comp/ok': [],
-                'comp/ok_without_param': [],
-                'comp/ok_function': [],
-                'comp/ok_device': [],
-                'comp/ok_num_function': [],
-                'comp/ok_syntax': [],
-            };
-        }
-        this._buffer[device].total ++;
-        if (ex.is_primitive)
-            this._buffer[device].primitives ++;
-        else
-            this._buffer[device].compounds ++;
+        let uniqueDevices;
+        if (this._splitByDevice) {
+            uniqueDevices = Array.from(new Set(ex.target_devices));
+            uniqueDevices = uniqueDevices.filter(val => !val.includes('dialogue.transaction'));
+            if (uniqueDevices.length === 0)
+                uniqueDevices.push('generic'); // generic device, for deviceless acts
+        } else
+            uniqueDevices = ['all'];
+        for (let device of uniqueDevices) {
+            if (!(device in this._buffer)) {
+                this._buffer[device] = {
+                    total: 0,
+                    primitives: 0,
+                    compounds: 0,
+                    ok: [],
+                    ok_without_param: [],
+                    ok_function: [],
+                    ok_device: [],
+                    ok_num_function: [],
+                    ok_syntax: [],
+                    'prim/ok': [],
+                    'prim/ok_without_param': [],
+                    'prim/ok_function': [],
+                    'prim/ok_device': [],
+                    'prim/ok_num_function': [],
+                    'prim/ok_syntax': [],
+                    'comp/ok': [],
+                    'comp/ok_without_param': [],
+                    'comp/ok_function': [],
+                    'comp/ok_device': [],
+                    'comp/ok_num_function': [],
+                    'comp/ok_syntax': [],
+                };
+            }
+            this._buffer[device].total ++;
+            if (ex.is_primitive)
+                this._buffer[device].primitives ++;
+            else
+                this._buffer[device].compounds ++;
 
-        let compkey;
-        if (this._maxComplexity && ex.complexity >= this._maxComplexity)
-            compkey = 'complexity_>=' + this._maxComplexity + '/';
-        else
-            compkey = 'complexity_' + ex.complexity + '/';
-        if (!this._buffer[device][compkey + 'total']) {
-            this._buffer[device][compkey + 'total'] = 0;
-            for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax'])
-                this._buffer[device][compkey + key] = [];
-        }
+            let compkey;
+            if (this._maxComplexity && ex.complexity >= this._maxComplexity)
+                compkey = 'complexity_>=' + this._maxComplexity + '/';
+            else
+                compkey = 'complexity_' + ex.complexity + '/';
+            if (!this._buffer[device][compkey + 'total']) {
+                this._buffer[device][compkey + 'total'] = 0;
+                for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax'])
+                    this._buffer[device][compkey + key] = [];
+            }
 
 
-        let numericKey = ex.has_numeric ? 'with_numeric_' : 'without_numeric_';
-        if (!this._buffer[device][numericKey + 'total']) {
-            this._buffer[device][numericKey + 'total'] = 0;
-            for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax'])
-                this._buffer[device][numericKey + key] = [];
-        }
+            let numericKey = ex.has_numeric ? 'with_numeric_' : 'without_numeric_';
+            if (!this._buffer[device][numericKey + 'total']) {
+                this._buffer[device][numericKey + 'total'] = 0;
+                for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax'])
+                    this._buffer[device][numericKey + key] = [];
+            }
 
-        this._buffer[device][compkey + 'total'] += 1;
-        this._buffer[device][numericKey + 'total'] += 1;
+            this._buffer[device][compkey + 'total'] += 1;
+            this._buffer[device][numericKey + 'total'] += 1;
 
-        for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax']) {
-            for (let beampos = 0; beampos < ex[key].length; beampos++) {
-                while (this._buffer[device][key].length <= beampos)
-                    this._buffer[device][key].push(0);
-                if (ex[key][beampos])
-                    this._buffer[device][key][beampos] ++;
+            for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax']) {
+                for (let beampos = 0; beampos < ex[key].length; beampos++) {
+                    while (this._buffer[device][key].length <= beampos)
+                        this._buffer[device][key].push(0);
+                    if (ex[key][beampos])
+                        this._buffer[device][key][beampos] ++;
 
-                let subkey = ex.is_primitive ? 'prim/' + key : 'comp/' + key;
-                while (this._buffer[device][subkey].length <= beampos)
-                    this._buffer[device][subkey].push(0);
-                if (ex[key][beampos])
-                    this._buffer[device][subkey][beampos] ++;
+                    let subkey = ex.is_primitive ? 'prim/' + key : 'comp/' + key;
+                    while (this._buffer[device][subkey].length <= beampos)
+                        this._buffer[device][subkey].push(0);
+                    if (ex[key][beampos])
+                        this._buffer[device][subkey][beampos] ++;
 
-                subkey = compkey + key;
-                while (this._buffer[device][subkey].length <= beampos)
-                    this._buffer[device][subkey].push(0);
-                if (ex[key][beampos])
-                    this._buffer[device][subkey][beampos] ++;
-                assert(!isNaN(this._buffer[device][subkey][beampos]));
+                    subkey = compkey + key;
+                    while (this._buffer[device][subkey].length <= beampos)
+                        this._buffer[device][subkey].push(0);
+                    if (ex[key][beampos])
+                        this._buffer[device][subkey][beampos] ++;
+                    assert(!isNaN(this._buffer[device][subkey][beampos]));
 
-                subkey = numericKey + key;
-                while (this._buffer[device][subkey].length <= beampos)
-                    this._buffer[device][subkey].push(0);
-                if (ex[key][beampos])
-                    this._buffer[device][subkey][beampos] ++;
+                    subkey = numericKey + key;
+                    while (this._buffer[device][subkey].length <= beampos)
+                        this._buffer[device][subkey].push(0);
+                    if (ex[key][beampos])
+                        this._buffer[device][subkey][beampos] ++;
+                }
             }
         }
         callback();

--- a/lib/dataset-tools/evaluation/sentence_evaluator.js
+++ b/lib/dataset-tools/evaluation/sentence_evaluator.js
@@ -437,7 +437,6 @@ class CollectSentenceStatistics extends Stream.Writable {
     _final(callback) {
         for (let device in this._buffer) {
             // convert to percentages
-            console.error(device + '\t' + this._buffer[device].total);
             for (let key of ['ok', 'ok_without_param', 'ok_function', 'ok_device', 'ok_num_function', 'ok_syntax']) {
                 for (let beampos = 0; beampos < this._buffer[device][key].length; beampos++) {
                     //this._buffer[device][key][beampos] = (this._buffer[device][key][beampos] * 100 / this._buffer[device].total).toFixed(2);

--- a/lib/dataset-tools/evaluation/sentence_evaluator.js
+++ b/lib/dataset-tools/evaluation/sentence_evaluator.js
@@ -344,11 +344,11 @@ class CollectSentenceStatistics extends Stream.Writable {
         let uniqueDevices;
         if (this._splitByDevice) {
             uniqueDevices = Array.from(new Set(ex.target_devices));
-            uniqueDevices = uniqueDevices.filter(val => !val.includes('dialogue.transaction'));
             if (uniqueDevices.length === 0)
                 uniqueDevices.push('generic'); // generic device, for deviceless acts
-        } else
-            uniqueDevices = ['all'];
+        } else {
+            uniqueDevices = ['all_devices'];
+        }
         for (let device of uniqueDevices) {
             if (!(device in this._buffer)) {
                 this._buffer[device] = {

--- a/lib/dataset-tools/requoting.js
+++ b/lib/dataset-tools/requoting.js
@@ -193,7 +193,9 @@ function* getFunctions(program) {
 }
 
 function* getDevices(program) {
-    for (let fn of getFunctions(program)) {
+    let functions = getFunctions(program);
+    functions.next(); // discard the policy name (the first "function")
+    for (let fn of functions) {
         let dot = fn.lastIndexOf('.');
         yield fn.substring(0, dot);
     }

--- a/lib/dataset-tools/requoting.js
+++ b/lib/dataset-tools/requoting.js
@@ -184,18 +184,24 @@ function* getFunctions(program) {
     if (typeof program === 'string')
         program = program.split(' ');
     let inString = false;
+    let isDialoguePolicy = false;
     for (let token of program) {
-        if (token === '"')
+        if (token === '"') {
             inString = !inString;
-        else if (!inString && token.startsWith('@'))
+        } else if (!inString && token.startsWith('$dialogue')) {
+            isDialoguePolicy = true;
+        } else if (!inString && token.startsWith('@')) {
+            if (isDialoguePolicy) {
+                isDialoguePolicy = false;
+                continue; // discard. It's the policy, not a function
+            }
             yield token;
+        }
     }
 }
 
 function* getDevices(program) {
-    let functions = getFunctions(program);
-    functions.next(); // discard the policy name (the first "function")
-    for (let fn of functions) {
+    for (let fn of getFunctions(program)) {
         let dot = fn.lastIndexOf('.');
         yield fn.substring(0, dot);
     }

--- a/lib/dataset-tools/splitter.js
+++ b/lib/dataset-tools/splitter.js
@@ -53,7 +53,7 @@ const SPLIT_STRATEGIES = {
     program: (id, sentence, program) => join(requoteProgram(program)),
     combination: (id, sentence, program) => {
         const functions = Array.from(getFunctions(program));
-        if (functions.length === 0)
+        if (functions.length <= 1)
             return ':train';
         else
             return functions.join(' ');

--- a/lib/dataset-tools/splitter.js
+++ b/lib/dataset-tools/splitter.js
@@ -53,7 +53,7 @@ const SPLIT_STRATEGIES = {
     program: (id, sentence, program) => join(requoteProgram(program)),
     combination: (id, sentence, program) => {
         const functions = Array.from(getFunctions(program));
-        if (functions.length <= 1)
+        if (functions.length === 0)
             return ':train';
         else
             return functions.join(' ');

--- a/test/unit/test_requoting.js
+++ b/test/unit/test_requoting.js
@@ -21,7 +21,7 @@
 
 const assert = require('assert');
 
-const { requoteSentence, requoteProgram } = require('../../lib/dataset-tools/requoting');
+const { requoteSentence, requoteProgram, getFunctions, getDevices } = require('../../lib/dataset-tools/requoting');
 
 const SENTENCE_TEST_CASES = [
     ['tweet hello world', 'now => @com.twitter.post param:status:String = " hello world "', 'tweet QUOTED_STRING'],
@@ -82,9 +82,42 @@ function testRequotePrograms() {
     }
 }
 
+const FUNCTION_TEST_CASES = [
+    ['now => @com.twitter.post param:status:String = " hello world "', '@com.twitter.post'],
+    ['$dialogue @org.thingpedia.dialogue.transaction.execute ; now => @foo.bar.baz param:status:String = QUOTED_STRING_0 => notify() ;', '@foo.bar.baz'],
+    ['$dialogue @dialogue.policy.execute ; now => @foo.bar.baz param:status:String = " $dialogue string " => notify() ; now => @baz.bar.foo param:location:Location ', '@foo.bar.baz @baz.bar.foo']
+];
+
+function testGetFunctions() {
+    for (let i = 0; i < FUNCTION_TEST_CASES.length; i++) {
+        let [program, expected] = FUNCTION_TEST_CASES[i];
+
+        let generated = Array.from(getFunctions(program)).join(' ');
+        assert.strictEqual(generated, expected);
+    }
+}
+
+const DEVICE_TEST_CASES = [
+    ['now => @com.twitter.post param:status:String = " hello world "', '@com.twitter'],
+    ['$dialogue @org.thingpedia.dialogue.transaction.execute; now => @foo.bar.baz param:status:String = QUOTED_STRING_0 => notify();', '@foo.bar'],
+    ['$dialogue @dialogue.policy.execute ; now => @foo.bar.baz param:status:String = " $dialogue string " => notify() ; now => @baz.bar.foo param:location:Location ', '@foo.bar @baz.bar'],
+    ['$dialogue @dialogue.policy.execute ; now => @foo.bar.boo ; now => @baz.bar.foo param:status:String = " status string " ; now => @foo.bar.baz ', '@foo.bar @baz.bar @foo.bar']
+];
+
+function testGetDevices() {
+    for (let i = 0; i < DEVICE_TEST_CASES.length; i++) {
+        let [program, expected] = DEVICE_TEST_CASES[i];
+
+        let generated = Array.from(getDevices(program)).join(' ');
+        assert.strictEqual(generated, expected);
+    }
+}
+
 async function main() {
     testRequoteSentence();
     testRequotePrograms();
+    testGetFunctions();
+    testGetDevices();
 }
 module.exports = main;
 if (!module.parent)


### PR DESCRIPTION
This is the beginning of the first version of per-device-evaluation.

The device selection is currently bad, as it gives a lot of gibberish attached. One quick, hacky and imperfect solution would be to split `uniqueDevices` by commas, and select the first non "execute" bit (which could be done right after line 344 in `evaluation/sentence_evaluator.js`). This would give the right device in all cases in which there is only one device. Where there is more than one domain, it would give you the "first" device.

As per discussion in Slack, we actually want to count this sentence for each of the devices involved.

The right way to solve this is to perform this correct device extraction around line 190 instead. This would also require sending in the same "sentence" to be evaluated twice - once with each domain.