### PR TITLE
simulation_exec_environment: don't crash on args outside schema

### DIFF
--- a/lib/dialogue-agent/execution/simulation_exec_environment.js
+++ b/lib/dialogue-agent/execution/simulation_exec_environment.js
@@ -401,6 +401,8 @@ class SimulationExecEnvironment extends ThingTalk.ExecEnvironment {
                 for (let key in item) {
                     const value = item[key];
                     const arg = schema.getArgument(key);
+                    if (!arg)
+                        continue;
                     mapped[key] = loadSimulationValue(schema, arg.type, value, '');
                 }
 


### PR DESCRIPTION
SimulationExecEnvironment now ignores fields in DB data that aren't defined in the schema. Previously, if entities had fields that weren't defined in the schema, this script would crash with a TypeError. The better behavior is to ignore undefined fields when constructing the map for the query.