### PR TITLE
Remove sound support from the test assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,5 @@
       "thingtalk",
       "thingpedia"
     ]
-  },
-  "optionalDependencies": {
-    "pulseaudio2": "^0.3.1"
   }
 }

--- a/tool/assistant.js
+++ b/tool/assistant.js
@@ -247,14 +247,10 @@ module.exports = {
             required: false,
             help: 'NLP server URL to use for NLG; must be specified to use neural NLG.'
         });
-        parser.addArgument('--wake-word-model', {
-            required: false,
-            help: 'Path to a wake-word model to use.'
-        });
     },
 
     async execute(args) {
-        const platform = new Platform(path.resolve(args.workdir), args.locale, args.thingpediaUrl, args.wake_word_model);
+        const platform = new Platform(path.resolve(args.workdir), args.locale, args.thingpediaUrl);
         const prefs = platform.getSharedPreferences();
         prefs.set('developer-dir', args.thingpedia_dir);
         prefs.set('experimental-use-neural-nlg', !!args.nlg_server);

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,13 +401,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bindings@^1.3.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -1101,11 +1094,6 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
-
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -1978,11 +1966,6 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nan@^2.14.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -2355,14 +2338,6 @@ psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
-
-pulseaudio2@^0.3.1:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/pulseaudio2/-/pulseaudio2-0.3.3.tgz#f06c4d306948182318a0faf4b4603f5c212a86f4"
-  integrity sha512-OLtThHLd6yPPkFg7ysZ7i0xx/8BV+w75/0ZScdBRD1Gvctef4BBXolGJfETGf07TxtlCKQcgLZ6gFSm2oJLXLg==
-  dependencies:
-    bindings "^1.3.1"
-    nan "^2.14.1"
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
"genie assistant" is meant to be a quick way to test a new model
interactively. Supporting speech is nice, but it has heavy,
platform-specific dependencies (including the wake word stuff).

It was useful to have the code (even though it was not actually
working in practice) as guidance on how to enable almond-server,
which has real sound. Now that almond-server is up to date,
let's remove this.