### PR TITLE
templates: introduce canonical forms for argmin/argmax

### DIFF
--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -491,7 +491,13 @@ function makeArgMaxMinTable(table, pname, direction, count) {
 }
 
 function makeSortedTable(table, pname, direction = 'desc') {
-    if (!table.schema.out[pname] || !table.schema.out[pname].isNumeric())
+    assert(typeof pname === 'string');
+    assert(direction === 'asc' || direction === 'desc');
+
+    const type = table.schema.out[pname];
+    // String are comparable but we don't want to sort alphabetically here
+    // (we need to use isComparable because Date/Time are comparable but not numeric)
+    if (!type || !type.isComparable() || type.isString)
         return null;
     if (!table.schema.is_list || table.isIndex) //avoid conflict with primitives
         return null;

--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -487,6 +487,9 @@ function makeArgMaxMinTable(table, pname, direction, count) {
         return null;
 
     count = count || new Ast.Value.Number(1);
+    if (count.isNumber && count.value <= 0)
+        return null;
+
     return new Ast.Table.Slice(null, t_sort, new Ast.Value.Number(1), count, t_sort.schema);
 }
 

--- a/languages/thingtalk/common.genie
+++ b/languages/thingtalk/common.genie
@@ -118,6 +118,7 @@ both_prefix = {
 
 npp_filter = {}
 npp_input_param = {}
+npp_argminmax = {}
 coref_npp_filter = {}
 coref_npp_input_param = {}
 
@@ -126,6 +127,7 @@ coref_npp_input_param = {}
 // e.g.: "owner of <company>", "student in <university>"
 npi_filter = {}
 npi_input_param = {}
+npi_argminmax = {}
 coref_npi_filter = {}
 coref_npi_input_param = {}
 
@@ -134,6 +136,7 @@ coref_npi_input_param = {}
 // e.g.: "called <nickname>", "born on <date>"
 pvp_filter = {}
 pvp_input_param = {}
+pvp_argminmax = {}
 coref_pvp_filter = {}
 coref_pvp_input_param = {}
 
@@ -142,6 +145,7 @@ coref_pvp_input_param = {}
 // e.g.: "at <time>", "in <area>"
 preposition_filter = {}
 preposition_input_param = {}
+preposition_argminmax = {}
 coref_preposition_filter = {}
 coref_preposition_input_param = {}
 
@@ -150,6 +154,7 @@ coref_preposition_input_param = {}
 // e.g.: "owns <company>", "studied in <university>"
 avp_filter = {}
 avp_input_param = {}
+avp_argminmax = {}
 coref_avp_filter = {}
 coref_avp_input_param = {}
 
@@ -158,6 +163,7 @@ coref_avp_input_param = {}
 // e.g.: "Bob is a PhD", the parameter `academic_degree` is implicit, and should be inferred by the value "PhD"
 npv_filter = {}
 npv_input_param = {}
+npv_argminmax = {}
 coref_npv_filter = {}
 coref_npv_input_param = {}
 
@@ -166,6 +172,7 @@ coref_npv_input_param = {}
 // e.g.: "Bob is left-handed"
 apv_filter = {}
 apv_input_param = {}
+apv_argminmax = {}
 coref_apv_filter = {}
 coref_apv_input_param = {}
 

--- a/languages/thingtalk/en/computation.genie
+++ b/languages/thingtalk/en/computation.genie
@@ -242,18 +242,6 @@ compute_question = {
 
 with_arg_min_max_table = {
     !turking {
-        ('best' | 'top-rated' | 'top rated') table:with_filtered_table => {
-            if (!table.schema.out['aggregateRating.ratingValue'])
-                return null;
-            return C.makeArgMaxMinTable(table, 'aggregateRating.ratingValue', 'desc');
-        };
-
-        ('best' | 'top') count:constant_Number table:with_filtered_table => {
-            if (!table.schema.out['aggregateRating.ratingValue'])
-                return null;
-            return C.makeArgMaxMinTable(table, 'aggregateRating.ratingValue', 'desc', count);
-        };
-
         ('nearest' | 'closest') table:complete_table ('' | 'from here' | 'to here' | 'to me')  => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;

--- a/languages/thingtalk/en/stream_tables.genie
+++ b/languages/thingtalk/en/stream_tables.genie
@@ -395,6 +395,12 @@ with_arg_min_max_table = {
     | argminmax:apv_argminmax t:two_which_filter_table
     | t:two_which_filter_table 'and' ('is' | 'are') argminmax:preposition_argminmax
     ) => C.makeArgMaxMinTable(t, argminmax[0].name, argminmax[1]);
+
+    ( argminmax:apv_argminmax count:constant_Number t:with_filtered_table
+    | count:constant_Number argminmax:apv_argminmax t:with_filtered_table
+    )
+        => C.makeArgMaxMinTable(t, argminmax[0].name, argminmax[1], count);
+
     }
 }
 

--- a/languages/thingtalk/en/stream_tables.genie
+++ b/languages/thingtalk/en/stream_tables.genie
@@ -307,99 +307,155 @@ two_verb_filter_table = {
     !nofilter table:one_verb_filter_table 'and' filter:avp_filter => C.addFilter(table, filter);
 }
 
+generic_argminmax = {
+    ('maximum' | 'highest') p:out_param_Number => [p, 'desc'];
+    ('minimum' | 'lowest') p:out_param_Number => [p, 'asc'];
+
+    ('most costly' | 'most expensive' | 'maximum') p:out_param_Currency => [p, 'desc'];
+    ('least costly'| 'cheapest' | 'minimum') p:out_param_Currency => [p, 'asc'];
+
+    ('longest' | 'most lasting') p:out_param_Measure_ms => [p, 'desc'];
+    'shortest' p:out_param_Measure_ms => [p, 'asc'];
+
+    ('maximum' | 'largest') p:out_param_Measure_byte => [p, 'desc'];
+    ('minimum' | 'smallest') p:out_param_Measure_byte => [p, 'asc'];
+
+    ('heaviest' | 'largest' | 'maximum') p:out_param_Measure_kg => [p, 'desc'];
+    ('lightest' | 'smallest' | 'minimum') p:out_param_Measure_kg => [p, 'asc'];
+
+    ('hottest' | 'highest' | 'maximum') p:out_param_Measure_C => [p, 'desc'];
+    ('coolest' | 'lowest' | 'minimum') p:out_param_Measure_C => [p, 'asc'];
+
+    ('farthest' | 'most distant' | 'longest') p:out_param_Measure_m => [p, 'desc'];
+    ('nearest' | 'closest' | 'shortest') p:out_param_Measure_m => [p, 'asc'];
+
+    ('fastest' | 'quickest' | 'speediest') p:out_param_Measure_mps => [p, 'desc'];
+    ('slowest' | 'most slowly') p:out_param_Measure_mps => [p, 'asc'];
+
+    ('latest'| 'most recent') p:out_param_Date => [p, 'desc'];
+    ('earliest' | 'soonest') p:out_param_Date => [p, 'asc'];
+
+    ('latest'| 'most recent') p:out_param_Time => [p, 'desc'];
+    ('earliest' | 'soonest') p:out_param_Time => [p, 'asc'];
+}
 
 // arg min max
 with_arg_min_max_table = {
-    ?aggregation {
-    t:complete_table ('with' | 'which has') 'the' ('maximum' | 'highest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('minimum' | 'lowest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('most costly' | 'most expensive' | 'maximum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('least costly'| 'cheapest' | 'minimum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('longest' | 'most lasting') p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the shortest' p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('maximum' | 'largest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('minimum' | 'smallest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('heaviest' | 'largest' | 'maximum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('lightest' | 'smallest' | 'minimum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('hottest' | 'highest' | 'maximum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('coolest' | 'lowest' | 'minimum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('farthest' | 'most distant' | 'longest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('nearest' | 'closest' | 'shortest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('fastest' | 'quickest' | 'speediest') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('slowest' | 'most slowly') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('latest'| 'most recent') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('with' | 'which has') 'the' ('latest'| 'most recent') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'asc');
+    // note: the *_argminmax templates expect "the" to be prepended in front,
+    // except for (avp_argminmax, pvp_argminmax and preposition_argminmax)
+    // for the whole expression, "the" will be prepended by the template that uses
+    // "with_arg_min_max_table"
 
-    t:with_filtered_table ('with' | 'which has') 'the' ('maximum' | 'highest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('minimum' | 'lowest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('most costly' | 'most expensive' | 'maximum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('least costly'| 'cheapest' | 'minimum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('longest' | 'most lasting') p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the shortest' p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('maximum' | 'largest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('minimum' | 'smallest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('heaviest' | 'largest' | 'maximum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('lightest' | 'smallest' | 'minimum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('hottest' | 'highest' | 'maximum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('coolest' | 'lowest' | 'minimum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('farthest' | 'most distant' | 'longest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('nearest' | 'closest' | 'shortest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('fastest' | 'quickest' | 'speediest') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('slowest' | 'most slowly') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('latest'| 'most recent') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('latest'| 'most recent') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('with' | 'which has') 'the' ('earliest' | 'soonest') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'asc');
+    ?aggregation {
+    ( t:complete_table ('with' | 'which has' | 'which have') 'the' argminmax:generic_argminmax
+    | t:complete_table ('with' | 'which has' | 'which have') 'the' argminmax:npp_argminmax
+    | t:complete_table ('that' | 'which') argminmax:avp_argminmax
+    | t:complete_table ('that' | 'which') ('is' | 'are') argminmax:pvp_argminmax
+    | t:complete_table ('that' | 'which') ('is' | 'are') 'the' argminmax:apv_argminmax
+    | argminmax:apv_argminmax t:complete_table
+    | t:complete_table ('that' | 'which') ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:one_clean_filter_table ('with' | 'which has' | 'which have') 'the' argminmax:generic_argminmax
+    | t:one_clean_filter_table ('with' | 'which has' | 'which have') argminmax:npp_argminmax
+    | t:one_clean_filter_table ('that' | 'which') argminmax:avp_argminmax
+    | t:one_clean_filter_table ('that' | 'which') ('is' | 'are') argminmax:pvp_argminmax
+    | t:one_clean_filter_table ('that' | 'which') ('is' | 'are') 'the' argminmax:apv_argminmax
+    | argminmax:apv_argminmax t:one_clean_filter_table
+    | t:one_clean_filter_table ('that' | 'which') ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:one_with_filter_table 'and the' argminmax:generic_argminmax
+    | t:one_with_filter_table 'and the' argminmax:npp_argminmax
+    | t:one_with_filter_table ('that' | 'which') argminmax:avp_argminmax
+    | t:one_with_filter_table ('that' | 'which') ('is' | 'are') argminmax:pvp_argminmax
+    | t:one_with_filter_table ('that' | 'which') ('is' | 'are') 'the' argminmax:apv_argminmax
+    | argminmax:apv_argminmax t:one_with_filter_table
+    | t:one_with_filter_table ('that' | 'which') ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:two_with_filter_table 'and the' argminmax:generic_argminmax
+    | t:two_with_filter_table 'and the' argminmax:npp_argminmax
+    | t:two_with_filter_table ('that' | 'which') argminmax:avp_argminmax
+    | t:two_with_filter_table ('that' | 'which') ('is' | 'are') argminmax:pvp_argminmax
+    | t:two_with_filter_table ('that' | 'which') ('is' | 'are') 'the' argminmax:apv_argminmax
+    | argminmax:apv_argminmax t:two_with_filter_table
+    | t:two_with_filter_table ('that' | 'which') ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:one_which_filter_table 'and have the' argminmax:generic_argminmax
+    | t:one_which_filter_table 'and have the' argminmax:npp_argminmax
+    | t:one_which_filter_table 'and' argminmax:avp_argminmax
+    | t:one_which_filter_table 'and' ('is' | 'are') argminmax:pvp_argminmax
+    | t:one_which_filter_table 'and' ('is' | 'are') 'the' argminmax:apv_argminmax
+    | argminmax:apv_argminmax t:one_which_filter_table
+    | t:one_which_filter_table 'and' ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:two_which_filter_table 'and have the' argminmax:generic_argminmax
+    | t:two_which_filter_table 'and have the' argminmax:npp_argminmax
+    | t:two_which_filter_table 'and' argminmax:avp_argminmax
+    | t:two_which_filter_table 'and' ('is' | 'are') argminmax:pvp_argminmax
+    | t:two_which_filter_table 'and' ('is' | 'are') 'the' argminmax:apv_argminmax
+    | argminmax:apv_argminmax t:two_which_filter_table
+    | t:two_which_filter_table 'and' ('is' | 'are') argminmax:preposition_argminmax
+    ) => C.makeArgMaxMinTable(t, argminmax[0].name, argminmax[1]);
     }
 }
 
 have_arg_min_max_table = {
     ?aggregation {
-    t:complete_table ('has' | 'gets') 'the' ('maximum' | 'highest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('minimum' | 'lowest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('most costly' | 'most expensive' | 'maximum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('least costly'| 'cheapest' | 'minimum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('longest' | 'most lasting') p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the shortest' p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('maximum' | 'largest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('minimum' | 'smallest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('heaviest' | 'largest' | 'maximum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('lightest' | 'smallest' | 'minimum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('hottest' | 'highest' | 'maximum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('coolest' | 'lowest' | 'minimum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('farthest' | 'most distant' | 'longest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('nearest' | 'closest' | 'shortest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('fastest' | 'quickest' | 'speediest') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('slowest' | 'most slowly') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('latest'| 'most recent') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('earliest' | 'soonest') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:complete_table ('has' | 'gets') 'the' ('latest'| 'most recent') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:complete_table ('has' | 'gets') 'the' ('earliest' | 'soonest') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'asc');
-    }
+    ( t:complete_table ('has' | 'gets') 'the' argminmax:generic_argminmax
+    | t:complete_table ('has' | 'gets') 'the' argminmax:npp_argminmax
+    | t:complete_table argminmax:avp_argminmax
+    | t:complete_table ('is' | 'are') argminmax:pvp_argminmax
+    | t:complete_table ('is' | 'are') 'the' argminmax:apv_argminmax
+    | t:complete_table ('is' | 'are') argminmax:preposition_argminmax
 
-    ?aggregation {
-    t:with_filtered_table ('has' | 'gets') 'the' ('maximum' | 'highest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('minimum' | 'lowest') p:out_param_Number => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('most costly' | 'most expensive' | 'maximum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('least costly'| 'cheapest' | 'minimum') p:out_param_Currency => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('longest' | 'most lasting') p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the shortest' p:out_param_Measure_ms => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('maximum' | 'largest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('minimum' | 'smallest') p:out_param_Measure_byte => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('heaviest' | 'largest' | 'maximum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('lightest' | 'smallest' | 'minimum') p:out_param_Measure_kg => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('hottest' | 'highest' | 'maximum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('coolest' | 'lowest' | 'minimum') p:out_param_Measure_C => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('farthest' | 'most distant' | 'longest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('nearest' | 'closest' | 'shortest') p:out_param_Measure_m => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('fastest' | 'quickest' | 'speediest') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('slowest' | 'most slowly') p:out_param_Measure_mps => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('latest'| 'most recent') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('earliest' | 'soonest') p:out_param_Date => C.makeArgMaxMinTable(t, p.name, 'asc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('latest'| 'most recent') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'desc');
-    t:with_filtered_table ('has' | 'gets') 'the' ('earliest' | 'soonest') p:out_param_Time => C.makeArgMaxMinTable(t, p.name, 'asc');
+    | t:with_filtered_table ('has' | 'gets') 'the' argminmax:generic_argminmax
+    | t:with_filtered_table ('has' | 'gets') 'the' argminmax:npp_argminmax
+    | t:with_filtered_table argminmax:avp_argminmax
+    | t:with_filtered_table ('is' | 'are') argminmax:pvp_argminmax
+    | t:with_filtered_table ('is' | 'are') 'the' argminmax:apv_argminmax
+    | t:with_filtered_table ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:one_have_filter_table ('and' | 'and has') 'the' argminmax:generic_argminmax
+    | t:one_have_filter_table ('and' | 'and has') 'the' argminmax:npp_argminmax
+    | t:one_have_filter_table 'and' argminmax:avp_argminmax
+    | t:one_have_filter_table 'and' ('is' | 'are') argminmax:pvp_argminmax
+    | t:one_have_filter_table 'and' ('is' | 'are') 'the' argminmax:apv_argminmax
+    | t:one_have_filter_table 'and' ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:one_verb_filter_table ('and' | 'and has') 'the' argminmax:generic_argminmax
+    | t:one_verb_filter_table ('and' | 'and has') 'the' argminmax:npp_argminmax
+    | t:one_verb_filter_table 'and' argminmax:avp_argminmax
+    | t:one_verb_filter_table 'and' ('is' | 'are') argminmax:pvp_argminmax
+    | t:one_verb_filter_table 'and' ('is' | 'are') 'the' argminmax:apv_argminmax
+    | t:one_verb_filter_table 'and' ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:one_be_filter_table ('and' | 'and has') 'the' argminmax:generic_argminmax
+    | t:one_be_filter_table ('and' | 'and has') 'the' argminmax:npp_argminmax
+    | t:one_be_filter_table 'and' argminmax:avp_argminmax
+    | t:one_be_filter_table 'and' ('' | 'is' | 'are') argminmax:pvp_argminmax
+    | t:one_be_filter_table 'and' ('' | 'is' | 'are') 'the' argminmax:apv_argminmax
+    | t:one_be_filter_table 'and' ('' | 'is' | 'are') argminmax:preposition_argminmax
+
+    | t:two_have_filter_table ('and' | 'and has') 'the' argminmax:generic_argminmax
+    | t:two_have_filter_table ('and' | 'and has') 'the' argminmax:npp_argminmax
+    | t:two_have_filter_table 'and' argminmax:avp_argminmax
+    | t:two_have_filter_table 'and' ('is' | 'are') argminmax:pvp_argminmax
+    | t:two_have_filter_table 'and' ('is' | 'are') 'the' argminmax:apv_argminmax
+    | t:two_have_filter_table 'and' ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:two_verb_filter_table ('and' | 'and has') 'the' argminmax:generic_argminmax
+    | t:two_verb_filter_table ('and' | 'and has') 'the' argminmax:npp_argminmax
+    | t:two_verb_filter_table 'and' argminmax:avp_argminmax
+    | t:two_verb_filter_table 'and' ('is' | 'are') argminmax:pvp_argminmax
+    | t:two_verb_filter_table 'and' ('is' | 'are') 'the' argminmax:apv_argminmax
+    | t:two_verb_filter_table 'and' ('is' | 'are') argminmax:preposition_argminmax
+
+    | t:two_be_filter_table ('and' | 'and has') 'the' argminmax:generic_argminmax
+    | t:two_be_filter_table ('and' | 'and has') 'the' argminmax:npp_argminmax
+    | t:two_be_filter_table 'and' argminmax:avp_argminmax
+    | t:two_be_filter_table 'and' ('' | 'is' | 'are') argminmax:pvp_argminmax
+    | t:two_be_filter_table 'and' ('' | 'is' | 'are') 'the' argminmax:apv_argminmax
+    | t:two_be_filter_table 'and' ('' | 'is' | 'are') argminmax:preposition_argminmax
+    ) => C.makeArgMaxMinTable(t, argminmax[0].name, argminmax[1]);
     }
 }
 

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -423,10 +423,14 @@ class ThingpediaLoader {
                 continue;
 
             let annotvalue = canonical[cat];
-            let isEnum = false;
+            let isEnum = false, argMinMax = undefined;
             if (vtype.isEnum && cat.endsWith('_enum')) {
                 cat = cat.substring(0, cat.length - '_enum'.length);
                 isEnum = true;
+            } else if (cat.endsWith('_argmin') || cat.endsWith('_argmax')) {
+                // _argmin is the same length as _argmax
+                cat = cat.substring(0, cat.length - '_argmin'.length);
+                argMinMax = cat.endsWith('_argmin') ? 'asc' : 'desc';
             }
 
             if (cat in ANNOTATION_RENAME)
@@ -465,6 +469,12 @@ class ThingpediaLoader {
                     for (let form of forms)
                         this._grammar.addRule(cat + '_filter', [form], this._runtime.simpleCombine(() => makeFilter(this, pvar, op, value, false)), attributes);
                 }
+            } else if (argMinMax) {
+                if (!Array.isArray(annotvalue))
+                    annotvalue = [annotvalue];
+
+                for (let form of annotvalue)
+                    this._grammar.addRule(cat + '_argminmax', [form], this._runtime.simpleCombine(() => [pvar, argMinMax]), attributes);
             } else {
                 if (!Array.isArray(annotvalue))
                     annotvalue = [annotvalue];


### PR DESCRIPTION
Of the form `adjective_argmax=["most popular"]`

All the 6 main POS categories are added, for completeness,
although for most of these I cannot think of any form.