### PR TITLE
Add simple user confirm template

### DIFF
--- a/languages/thingtalk/dialogue_acts/recommendation.js
+++ b/languages/thingtalk/dialogue_acts/recommendation.js
@@ -182,6 +182,9 @@ function makeRecommendationReply(ctx, proposal) {
     if (action || hasLearnMore)
         options.end = false;
     if (action === null) {
+        // we don't want 'confirm' to loop sys_recommend_one states
+        if (ctx.state.dialogueAct === 'confirm')
+            return null;
         return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_recommend_one', null), proposal, null, options);
     } else {
         const chainParam = findChainParam(topResult, action);
@@ -222,9 +225,12 @@ function positiveRecommendationReply(ctx, acceptedAction, name) {
         // A: how about the ... ?
         // U: sure I like that
         //
-        // this doesn't make much sense, so we don't want this flow
-        if (actionProposal === null)
-            return null;
+        // This falls into the simple "confirm" state category,
+        // where the agent will propose an action the following turn.
+        if (actionProposal === null) {
+            const clone = ctx.clone();
+            return makeSimpleState(clone, 'confirm', null);
+        }
 
         acceptedAction = actionProposal;
     }

--- a/languages/thingtalk/dialogue_acts/recommendation.js
+++ b/languages/thingtalk/dialogue_acts/recommendation.js
@@ -229,6 +229,13 @@ function positiveRecommendationReply(ctx, acceptedAction, name) {
         // where the agent will propose an action the following turn.
         if (actionProposal === null) {
             const clone = ctx.clone();
+
+            // make sure user is talking about the correct entity
+            if (!name)
+                return null;
+            if (name[0].value !== ctx.aux.topResult.value.id.value)
+                return null;
+
             return makeSimpleState(clone, 'confirm', null);
         }
 

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -214,10 +214,9 @@ $agent = {
     ctx:ctx_learn_more system_learn_more
         => S.makeAgentReply(ctx, S.makeSimpleState(ctx, 'sys_learn_more_what', null));
 
-    // answer simple confirm state
-    // FIXME this should instantiate a new action proposal
-    ctx:ctx_confirm anything_else_phrase
-        => S.makeAgentReply(ctx, S.makeSimpleState(ctx, 'sys_anything_else', null));
+    // answer simple confirm state with recommendation
+    ctx:ctx_confirm proposal:system_recommendation
+        => D.makeRecommendationReply(ctx, proposal);
 }
 
 $user = {

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -214,9 +214,10 @@ $agent = {
     ctx:ctx_learn_more system_learn_more
         => S.makeAgentReply(ctx, S.makeSimpleState(ctx, 'sys_learn_more_what', null));
 
-    // propose action after confirm
-    ctx:ctx_confirm proposal:system_recommendation
-        => D.makeRecommendationReply(ctx, proposal);
+    // answer simple confirm state
+    // FIXME this should instantiate a new action proposal
+    ctx:ctx_confirm anything_else_phrase
+        => S.makeAgentReply(ctx, S.makeSimpleState(ctx, 'sys_anything_else', null));
 }
 
 $user = {

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -215,7 +215,7 @@ $agent = {
         => S.makeAgentReply(ctx, S.makeSimpleState(ctx, 'sys_learn_more_what', null));
 
     // answer simple confirm state with recommendation
-    ctx:ctx_confirm proposal:system_recommendation
+    ctx:ctx_confirm proposal:system_confirmed_recommendation
         => D.makeRecommendationReply(ctx, proposal);
 }
 

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -99,6 +99,7 @@ context
     ctx_incomplete_action_after_search,
     ctx_learn_more,
     ctx_display_nonlist_result,
+    ctx_confirm,
 
     // agent states (used to continue the conversation with more user utterances)
     // these more or less map to the agent dialogue acts, except we don't distinguish
@@ -212,6 +213,10 @@ $agent = {
     // learn more
     ctx:ctx_learn_more system_learn_more
         => S.makeAgentReply(ctx, S.makeSimpleState(ctx, 'sys_learn_more_what', null));
+
+    // propose action after confirm
+    ctx:ctx_confirm proposal:system_recommendation
+        => D.makeRecommendationReply(ctx, proposal);
 }
 
 $user = {

--- a/languages/thingtalk/en/dlg/recommendation.genie
+++ b/languages/thingtalk/en/dlg/recommendation.genie
@@ -183,6 +183,12 @@ system_recommendation = {
     };
 }
 
+// recommendations following a user confirm state
+system_confirmed_recommendation = {
+    ctx:ctx_confirm ('would you like to' | 'would you like me to') action:contextual_action_phrase [weight=0.1]
+        => D.makeActionRecommendation(ctx, action);
+}
+
 recommendation_accept_phrase_with_action = {
     accept_phrase generic_preamble_for_action action:coref_action_command => action;
 }

--- a/languages/thingtalk/state_manip.js
+++ b/languages/thingtalk/state_manip.js
@@ -621,6 +621,9 @@ function tagContextForAgent(ctx) {
         assert(ctx.results);
         return ['ctx_learn_more'];
 
+    case 'confirm':
+        return ['ctx_confirm'];
+
     case 'execute':
     case 'ask_recommend':
         if (ctx.nextInfo !== null) {


### PR DESCRIPTION
Adds the `confirm` user state, which follows `sys_recommend_N` states.

In a `confirm` state, the user accepts the result of an agent recommendation without providing an action to do with the result. In response, the agent should propose an action related to the result that was just `confirm`ed.