### PR TITLE
Add a script to import a Wikidata dump into ElasticSearch 

### DIFF
--- a/lib/i18n/tokenizer/base.js
+++ b/lib/i18n/tokenizer/base.js
@@ -120,7 +120,11 @@ module.exports = class BaseTokenizer {
 
         this._addDefinition('EMOJI1', /(?:{NONBMP}\uFE0F?|{BMP_EMOJI2}|{BMP_EMOJI1})(\ud83c[\udffb-\udfff])?[\u2640\u2642]?(\ud83e[\uddb0-\uddb3])?/);
         this._addDefinition('EMOJI2', /{EMOJI1}(\u200d{EMOJI1})*/);
-        this._lexer.addRule(/{EMOJI2}/, (lexer) => makeToken(lexer.index, lexer.text));
+
+        // keep flags together...
+        this._addDefinition('EMOJI_FLAG', /(?:\uD83C[\uDDE6-\uDDFF]){2}/);
+
+        this._lexer.addRule(/{EMOJI_FLAG}|{EMOJI2}/, (lexer) => makeToken(lexer.index, lexer.text));
 
         // letters (includes combining accents and letters commonly used in Western European languages)
         // taken from https://www.unicode.org/Public/UNIDATA/DerivedCoreProperties.txt (Alphabetic class, with some tweaks)

--- a/tool/autoqa/wikidata/es-import.js
+++ b/tool/autoqa/wikidata/es-import.js
@@ -1,0 +1,203 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+"use strict";
+
+const path = require('path');
+const JSONStream = require('JSONStream');
+const stream = require('stream');
+const zlib = require('zlib');
+const fs = require('fs');
+const pfs = fs.promises;
+const Tp = require('thingpedia');
+
+const I18n = require('../../../lib/i18n');
+const StreamUtils = require('../../../lib/utils/stream-utils');
+
+async function loadURL(url) {
+    const parsed = new URL(url);
+
+    if (parsed.protocol === 'file:') {
+        const stat = await pfs.stat(parsed.pathname);
+        let stream = fs.createReadStream(parsed.pathname);
+        if (parsed.pathname.endsWith('.gz'))
+            stream = stream.pipe(zlib.createGunzip());
+
+        return [stream, stat.size];
+    } else if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        const res = await Tp.Helpers.Http.getStream(url);
+        let stream = res;
+        if (parsed.pathname.endsWith('.gz'))
+            stream = stream.pipe(zlib.createGunzip());
+        let size = -1;
+        if (res.headers['content-length'])
+            size = Number(res.headers['content-length']);
+        return [stream, size];
+    } else {
+        throw new Error(`Invalid URL ${url}`);
+    }
+}
+
+class ItemProcessor extends stream.Transform {
+    constructor(offset) {
+        super({
+            objectMode: true,
+            highWaterMark: 50000
+        });
+
+        this._tokenizer = I18n.get('en-US').getTokenizer();
+
+        this._offset = offset;
+        this._n = 0;
+    }
+
+    _transform(item, encoding, callback) {
+        this._n ++;
+        if (this._n && (this._n % 50000) === 0)
+            console.log(this._n);
+        if (this._n < this._offset) {
+            callback();
+            return;
+        }
+
+        if (item.type !== 'item' || !item.labels.en) {
+            callback();
+            return;
+        }
+
+        const label = item.labels.en.value;
+        const description = item.descriptions.en ? item.descriptions.en.value : undefined;
+
+        const tokenized = this._tokenizer.tokenize(label);
+        // remove all entities that contain quoted strings, urls dates or times
+        // but allow numbers (so years, ordinals and other confusable things can go in)
+        if (tokenized.tokens.some((t) => /^(QUOTED_STRING|URL|DATE|TIME|EMAIL_ADDRESS|PHONE_NUMBER)/.test(t))) {
+            callback();
+            return;
+        }
+
+        const types = (item.claims.P31 || [])
+            .filter((stmt) => stmt.rank !== 'deprecated' &&
+                stmt.mainsnak &&
+                stmt.mainsnak.snaktype === 'value' &&
+                stmt.mainsnak.datavalue.type === 'wikibase-entityid' &&
+                stmt.mainsnak.datavalue.value['entity-type'] === 'item')
+            .map((stmt) => stmt.mainsnak.datavalue.value.id);
+
+        const aliases = (item.aliases.en || [])
+            .filter((alias) => alias.language === 'en')
+            .map((alias) => this._tokenizer.tokenize(alias.value).rawTokens.join(' '));
+
+        for (const t of types) {
+            this.push({
+                name: label,
+                type: 'org.wikidata:' + t,
+                value: item.id,
+                canonical: tokenized.rawTokens.join(' '),
+                aliases,
+                description
+            });
+        }
+        callback();
+    }
+
+    _flush(callback) {
+        callback();
+    }
+}
+
+class ESBulkInserter extends stream.Writable {
+    constructor(config) {
+        super({
+            objectMode: true,
+            highWaterMark: 50000
+        });
+
+        this._config = config;
+        this._url = config.url + '/' + config.index;
+        this._auth = 'Basic ' + (Buffer.from(config.username + ':' + config.password).toString('base64'));
+    }
+
+    _computeID(item) {
+        return item.type + ':' + item.value;
+    }
+
+    _writev(items, callback) {
+        items = items.map((item) => item.chunk);
+
+        let buffer = '';
+        for (const item of items) {
+            buffer += JSON.stringify({ index: { _id: this._computeID(item) } }) + '\n';
+            buffer += JSON.stringify(item) + '\n';
+        }
+
+        Tp.Helpers.Http.post(this._url + '/_bulk', buffer, {
+            dataContentType: 'application/x-ndjson',
+            auth: this._auth
+        }).then((res) => {
+            const parsed = JSON.parse(res);
+            if (res.errors) {
+                console.error(parsed);
+                callback(new Error('some operation failed'));
+            } else {
+                callback();
+            }
+        }, callback);
+    }
+
+    _write(item, encoding, callback) {
+        Tp.Helpers.Http.post(this._url + '/_doc/' + encodeURIComponent(this._computeID(item)), JSON.stringify(item), {
+            dataContentType: 'application/json',
+            auth: this._auth
+        }).then(() => callback(), callback);
+    }
+}
+
+module.exports = {
+    initArgparse(subparsers) {
+        const parser = subparsers.addParser('wikidata-es-import', {
+            addHelp: true,
+            description: "Import a wikidata dump into ElasticSearch"
+        });
+        parser.addArgument('--url', {
+            required: false,
+            defaultValue: 'https://dumps.wikimedia.org/wikidatawiki/entities/latest-all.json.gz',
+            help: 'URL of the Wikidata dump to process (can be a file:// URL or a http(s):// URL).'
+        });
+        parser.addArgument('--es-config', {
+            required: true,
+            help: 'Path to a JSON file containing the ElasticSearch configuration (url, username, password).'
+        });
+        parser.addArgument('--offset', {
+            required: false,
+            defaultValue: 0,
+            help: 'Skip this many entities from the dump (resume uploading).'
+        });
+    },
+
+    async execute(args) {
+        const [stream,] = await loadURL(args.url);
+
+        await StreamUtils.waitFinish(stream
+            .setEncoding('utf8')
+            .pipe(JSONStream.parse('*'))
+            .pipe(new ItemProcessor(args.offset))
+            .pipe(new ESBulkInserter(require(path.resolve(args.es_config)))));
+    }
+};

--- a/tool/genie.js
+++ b/tool/genie.js
@@ -66,6 +66,7 @@ const subcommands = {
     'sgd-normalize-data': require('./autoqa/sgd/normalize-data'),
 
     'wikidata-process-schema': require('./autoqa/wikidata/process-schema'),
+    'wikidata-es-import': require('./autoqa/wikidata/es-import'),
 
     'auto-annotate': require('./autoqa/auto-annotate'),
     'make-string-datasets': require('./autoqa/make-string-datasets'),


### PR DESCRIPTION
To use, create an es-config.json file with "url", "index" (ES-speak for database table name), "username" and "password".

This script has been tested and works, except Wikidata is BIG (88M items) so it always dies halfway through. One can fast-restart it with --offset, although the decompression work is wasted (decompressing the JSON dump on disk would be too big)