### PR TITLE
starter/schemaorg: pass a lower batch size to auto-annotate during tests

### DIFF
--- a/starter/schemaorg/Makefile
+++ b/starter/schemaorg/Makefile
@@ -51,7 +51,8 @@ music_paraphrase =
 eval_set ?= eval
 
 process_schemaorg_flags ?= --manual --wikidata-path ./wikidata-property-labels.json
-update_canonical_flags ?= --algorithm bert,adj,bart --paraphraser-model ./models/paraphraser-bart
+auto_annotate_flags ?= --algorithm bert,adj,bart --paraphraser-model ./models/paraphraser-bart
+auto_annotate_custom_flags ?=
 template_file ?= thingtalk/en/thingtalk.genie
 dataset_file ?= emptydataset.tt
 synthetic_flags ?= \
@@ -117,7 +118,7 @@ $(experiment)/constants.tsv: $(experiment)/parameter-datasets.tsv $(experiment)/
 	cat $(geniedir)/data/en-US/constants.tsv >> $@
 
 $(experiment)/schema.tt: $(experiment)/constants.tsv $(experiment)/schema.trimmed.tt $(experiment)/parameter-datasets.tsv models/paraphraser-bart
-	$(genie) auto-annotate -o $@.tmp --constants $(experiment)/constants.tsv --thingpedia $(experiment)/schema.trimmed.tt --functions $($(experiment)_white_list) $(update_canonical_flags) --parameter-datasets $(experiment)/parameter-datasets.tsv --dataset schemaorg
+	$(genie) auto-annotate -o $@.tmp --constants $(experiment)/constants.tsv --thingpedia $(experiment)/schema.trimmed.tt --functions $($(experiment)_white_list) $(auto_annotate_flags) $(auto_annotate_custom_flags) --parameter-datasets $(experiment)/parameter-datasets.tsv --dataset schemaorg
 	mv $@.tmp $@
 
 $(experiment)/synthetic-d%.tsv: $(experiment)/schema.tt $(dataset_file) $(geniedir)/languages/thingtalk/en/*.genie

--- a/test/common.sh
+++ b/test/common.sh
@@ -21,6 +21,8 @@ do_setup() {
 starter_gen_and_train() {
 	starter_name="$1"
 	experiment_name="$2"
+	shift
+	shift
 
 	# set some configuration
 	# this uses a testing developer key
@@ -31,9 +33,9 @@ thingpedia_url = https://almond-dev.stanford.edu/thingpedia
 EOF
 
 	# make a dataset (a small one)
-	make experiment=${experiment_name} target_pruning_size=10 datadir
+	make experiment=${experiment_name} target_pruning_size=10 "$@" datadir
 
 	# train a model (for a few iterations)
 	make experiment=${experiment_name} model=small train_iterations=30 train_save_every=10 \
-	  train_log_every=5 train
+	  train_log_every=5 "$@" train
 }

--- a/test/schemaorg-starter.sh
+++ b/test/schemaorg-starter.sh
@@ -14,7 +14,7 @@ mkdir -p source-data/restaurants/
 wget https://almond-static.stanford.edu/test-data/schemaorg/restaurants/sample.json \
   -O source-data/restaurants/sample.json
 
-starter_gen_and_train schemaorg restaurants
+starter_gen_and_train schemaorg restaurants custom_auto_annotate_flags="--batch-size 32"
 
 # get some fake data to test with
 cat > restaurants/eval/annotated.tsv <<EOF


### PR DESCRIPTION
This reduces the chances of an out-of-memory in Travis.