### PR TITLE
Translation support for templates: a new approach

### DIFF
--- a/lib/i18n/default.js
+++ b/lib/i18n/default.js
@@ -249,4 +249,13 @@ DefaultLanguagePack.prototype.SINGLE_DEVICE_TEMPLATES = [];
  */
 DefaultLanguagePack.prototype.DEFINITE_ARTICLE_REGEXP = undefined;
 
+/**
+ * The list of grammatical genders for this language ("masculine", "feminine", "neuter", etc.)
+ *
+ * The first element of the list is taken as the default if no gender is specified for a
+ * template or canonical form.
+ * The list should be empty if the language has no concept of gender.
+ */
+DefaultLanguagePack.prototype.GRAMMATICAL_GENDERS = [];
+
 module.exports = DefaultLanguagePack;

--- a/lib/i18n/italian.js
+++ b/lib/i18n/italian.js
@@ -24,6 +24,8 @@ const assert = require('assert');
 const ItalianTokenizer = require('./tokenizer/italian');
 const DefaultLanguagePack = require('./default');
 
+const { coin } = require('../random');
+
 function replaceMeMy(sentence) {
     sentence = sentence.replace(/\b((?!(?:notifica|informa|invia a)\b)[a-zA-Z0-9]+) me\b/g, '$1 lui');
 
@@ -46,6 +48,53 @@ function replaceMeMy(sentence) {
     });
 }
 
+const PREPOSITIONS = {
+    // of
+    'di il': 'del',
+    'di la': 'della',
+    'di lo': 'dello',
+    'di l\'': 'dell\'',
+    'di i': 'dei',
+    'di gli': 'degli',
+    'di le': 'delle',
+
+    // to
+    'a il': 'al',
+    'a la': 'alla',
+    'a lo': 'allo',
+    'a l\'': 'all\'',
+    'a i': 'ai',
+    'a gli': 'agli',
+    'a le': 'alle',
+
+    // from
+    'da il': 'dal',
+    'da la': 'dalla',
+    'da lo': 'dallo',
+    'da l\'': 'dall\'',
+    'da i': 'dai',
+    'da gli': 'dagli',
+    'da le': 'dalle',
+
+    // in
+    'in il': 'nel',
+    'in la': 'nella',
+    'in lo': 'nello',
+    'in l\'': 'nell\'',
+    'in i': 'nei',
+    'in gli': 'negli',
+    'in le': 'nelle',
+
+    // on
+    'su il': 'sul',
+    'su la': 'sulla',
+    'su lo': 'sullo',
+    'su l\'': 'sull\'',
+    'su i': 'sui',
+    'su gli': 'sugli',
+    'su le': 'sulle',
+};
+
 class ItalianLanguagePack extends DefaultLanguagePack {
     getTokenizer() {
         if (this._tokenizer)
@@ -53,13 +102,43 @@ class ItalianLanguagePack extends DefaultLanguagePack {
         return this._tokenizer = new ItalianTokenizer();
     }
 
-    postprocessSynthetic(sentence, program) {
+    postprocessSynthetic(sentence, program, rng, forTarget = 'user') {
         if (program.isProgram && program.principal !== null)
             sentence = replaceMeMy(sentence);
 
-        return sentence.replace(/ (nuovi|nuove) (loro|suoi|miei|il|i|gli|le|un|una) /, (_new, what) => ` ${what} ${_new} `)
-            //.replace(/ 's (my|their|his|her) /, ` 's `) //' // is there an equivalent in Italian? depends on the templates...
-            .trim();
+        sentence = sentence.replace(/ (nuov[iaeo]) (loro|suoi|miei|il|i|gli|le|un|una) /, (_new, what) => ` ${what} ${_new} `);
+
+        // adjust articles
+        sentence = sentence
+            .replace(/\bla(?= [haeiou])/g, 'l\'')
+            .replace(/\bil(?= [haeiou])/g, 'l\'')
+            // x, z, gn, ps, pn, or s followed by consonant
+            // (h is weird in that it's sometimes a vowel and sometimes a consonant, because
+            // it only appears in foreign loan words)
+            .replace(/\bil(?= (?:s[^haeiou]|gn|ps|pn|z))/g, 'lo')
+            .replace(/\bi(?= (?:[haeiou]|s[^aeiou]|gn|ps|pn|z))/g, 'gli')
+
+            .replace(/\buna(?= [haeiou])/g, 'nessun\'')
+            .replace(/\bun(?= (?:s[^haeiou]|gn|ps|pn|z))/g, 'uno')
+
+            // special cases
+            .replace(/\bnessuna(?= [haeiou])/g, 'nessun\'')
+            .replace(/\bnessun(?= (?:s[^haeiou]|gn|ps|pn|z))/g, 'nessuno');
+
+        // "di il" -> "del"
+        sentence = sentence.replace(/\b(di|a|da|in|su) (il|la|lo|l'|i|gli|le)\b/g, (str) => {
+            return PREPOSITIONS[str] || str;
+        });
+
+        // "posta -lo" -> "postalo"
+        sentence = sentence.replace(/ -l([oaie])\b/g, 'l$1');
+
+        if (!sentence.endsWith(' ?') && !sentence.endsWith(' !') && !sentence.endsWith(' .') && coin(0.5, rng))
+            sentence = sentence.trim() + ' .';
+        if (sentence.endsWith(' ?') && coin(0.5, rng))
+            sentence = sentence.substring(0, sentence.length-2);
+
+        return sentence.trim();
     }
 
     pluralize(noun) {

--- a/lib/i18n/italian.js
+++ b/lib/i18n/italian.js
@@ -24,7 +24,7 @@ const assert = require('assert');
 const ItalianTokenizer = require('./tokenizer/italian');
 const DefaultLanguagePack = require('./default');
 
-const { coin } = require('../random');
+const { coin } = require('../utils/random');
 
 function replaceMeMy(sentence) {
     sentence = sentence.replace(/\b((?!(?:notifica|informa|invia a)\b)[a-zA-Z0-9]+) me\b/g, '$1 lui');

--- a/lib/i18n/italian.js
+++ b/lib/i18n/italian.js
@@ -169,4 +169,8 @@ ItalianLanguagePack.prototype.NO_IDEA = [
 
 ItalianLanguagePack.prototype.DEFINITE_ARTICLE_REGEXP = /(il|lo|la|i|gli|le|l') /;
 
+// there are two grammatical genders
+// humans, otoh...
+ItalianLanguagePack.prototype.GRAMMATICAL_GENDERS = ['masculine', 'feminine'];
+
 module.exports = ItalianLanguagePack;

--- a/lib/sentence-generator/compiler/grammar.js
+++ b/lib/sentence-generator/compiler/grammar.js
@@ -221,8 +221,8 @@ function peg$parse(input, options) {
       peg$c45 = function(first, rest) {
           return new Ast.RuleAttributes([first].concat(take(rest, 2)));
       },
-      peg$c46 = function(flag, name, type, attrs) {
-          const c = new Ast.Rule.Constants(name, type, attrs || new Ast.RuleAttributes());
+      peg$c46 = function(flag, name, type, prefix, suffix, attrs) {
+          const c = new Ast.Rule.Constants(name, type, prefix ? prefix[2] : '', suffix ? suffix[2] : '', attrs || new Ast.RuleAttributes());
           if (flag)
             return new Ast.Rule.Condition(flag, [c]);
           else
@@ -1908,34 +1908,116 @@ function peg$parse(input, options) {
                         if (s11 !== peg$FAILED) {
                           s12 = peg$parse__();
                           if (s12 !== peg$FAILED) {
-                            if (input.charCodeAt(peg$currPos) === 41) {
-                              s13 = peg$c17;
+                            s13 = peg$currPos;
+                            if (input.charCodeAt(peg$currPos) === 44) {
+                              s14 = peg$c27;
                               peg$currPos++;
                             } else {
+                              s14 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c28); }
+                            }
+                            if (s14 !== peg$FAILED) {
+                              s15 = peg$parse__();
+                              if (s15 !== peg$FAILED) {
+                                s16 = peg$parseStringLiteral();
+                                if (s16 !== peg$FAILED) {
+                                  s17 = peg$parse__();
+                                  if (s17 !== peg$FAILED) {
+                                    s14 = [s14, s15, s16, s17];
+                                    s13 = s14;
+                                  } else {
+                                    peg$currPos = s13;
+                                    s13 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s13;
+                                  s13 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s13;
+                                s13 = peg$FAILED;
+                              }
+                            } else {
+                              peg$currPos = s13;
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                            }
+                            if (s13 === peg$FAILED) {
+                              s13 = null;
                             }
                             if (s13 !== peg$FAILED) {
-                              s14 = peg$parse__();
+                              s14 = peg$currPos;
+                              if (input.charCodeAt(peg$currPos) === 44) {
+                                s15 = peg$c27;
+                                peg$currPos++;
+                              } else {
+                                s15 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c28); }
+                              }
+                              if (s15 !== peg$FAILED) {
+                                s16 = peg$parse__();
+                                if (s16 !== peg$FAILED) {
+                                  s17 = peg$parseStringLiteral();
+                                  if (s17 !== peg$FAILED) {
+                                    s18 = peg$parse__();
+                                    if (s18 !== peg$FAILED) {
+                                      s15 = [s15, s16, s17, s18];
+                                      s14 = s15;
+                                    } else {
+                                      peg$currPos = s14;
+                                      s14 = peg$FAILED;
+                                    }
+                                  } else {
+                                    peg$currPos = s14;
+                                    s14 = peg$FAILED;
+                                  }
+                                } else {
+                                  peg$currPos = s14;
+                                  s14 = peg$FAILED;
+                                }
+                              } else {
+                                peg$currPos = s14;
+                                s14 = peg$FAILED;
+                              }
+                              if (s14 === peg$FAILED) {
+                                s14 = null;
+                              }
                               if (s14 !== peg$FAILED) {
-                                s15 = peg$parseRuleAttributeList();
-                                if (s15 === peg$FAILED) {
-                                  s15 = null;
+                                if (input.charCodeAt(peg$currPos) === 41) {
+                                  s15 = peg$c17;
+                                  peg$currPos++;
+                                } else {
+                                  s15 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                                 }
                                 if (s15 !== peg$FAILED) {
                                   s16 = peg$parse__();
                                   if (s16 !== peg$FAILED) {
-                                    if (input.charCodeAt(peg$currPos) === 59) {
-                                      s17 = peg$c24;
-                                      peg$currPos++;
-                                    } else {
-                                      s17 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+                                    s17 = peg$parseRuleAttributeList();
+                                    if (s17 === peg$FAILED) {
+                                      s17 = null;
                                     }
                                     if (s17 !== peg$FAILED) {
-                                      peg$savedPos = s0;
-                                      s1 = peg$c46(s1, s7, s11, s15);
-                                      s0 = s1;
+                                      s18 = peg$parse__();
+                                      if (s18 !== peg$FAILED) {
+                                        if (input.charCodeAt(peg$currPos) === 59) {
+                                          s19 = peg$c24;
+                                          peg$currPos++;
+                                        } else {
+                                          s19 = peg$FAILED;
+                                          if (peg$silentFails === 0) { peg$fail(peg$c25); }
+                                        }
+                                        if (s19 !== peg$FAILED) {
+                                          peg$savedPos = s0;
+                                          s1 = peg$c46(s1, s7, s11, s13, s14, s17);
+                                          s0 = s1;
+                                        } else {
+                                          peg$currPos = s0;
+                                          s0 = peg$FAILED;
+                                        }
+                                      } else {
+                                        peg$currPos = s0;
+                                        s0 = peg$FAILED;
+                                      }
                                     } else {
                                       peg$currPos = s0;
                                       s0 = peg$FAILED;

--- a/lib/sentence-generator/compiler/grammar.pegjs
+++ b/lib/sentence-generator/compiler/grammar.pegjs
@@ -139,8 +139,8 @@ RuleAttributeList = '[' __ first:RuleAttribute __ rest:(',' __ RuleAttribute __)
 }
 
 Rule
-  = flag:RuleFlag? __ ConstToken __ '(' __ name:Identifier __ ',' __ type:CodeNoComma __ ')' __ attrs:RuleAttributeList? __ ';' {
-    const c = new Ast.Rule.Constants(name, type, attrs || new Ast.RuleAttributes());
+  = flag:RuleFlag? __ ConstToken __ '(' __ name:Identifier __ ',' __ type:CodeNoComma __ prefix:(',' __ StringLiteral __)? suffix:(',' __ StringLiteral __)? ')' __ attrs:RuleAttributeList? __ ';' {
+    const c = new Ast.Rule.Constants(name, type, prefix ? prefix[2] : '', suffix ? suffix[2] : '', attrs || new Ast.RuleAttributes());
     if (flag)
       return new Ast.Rule.Condition(flag, [c]);
     else

--- a/lib/sentence-generator/compiler/index.js
+++ b/lib/sentence-generator/compiler/index.js
@@ -122,7 +122,7 @@ module.exports = async function compile(entrypoint) {
                 return require(req);
         }
         function import_(what) {
-            return _importCache[what];
+            return _importCache[what].compiled;
         }
 
         let compiled;
@@ -132,7 +132,7 @@ module.exports = async function compile(entrypoint) {
             console.error(parsed.codegen());
             throw e;
         }
-        _importCache[filename] = compiled;
+        _importCache[filename] = { parsed, compiled };
     }
 
     queue.push(() => parse(entrypoint));

--- a/lib/sentence-generator/compiler/meta_ast.js
+++ b/lib/sentence-generator/compiler/meta_ast.js
@@ -28,6 +28,13 @@ class Grammar {
         this.statements = statements;
     }
 
+    visit(visitor) {
+        if (!visitor.visitGrammar(this))
+            return;
+        for (let stmt of this.statements)
+            stmt.visit(visitor);
+    }
+
     codegen() {
         let buffer = '';
 
@@ -54,6 +61,10 @@ class CodeBlock extends Statement {
         this.code = code;
     }
 
+    visit(visitor) {
+        visitor.visitCodeBlock(this);
+    }
+
     codegen() {
         return this.code;
     }
@@ -71,6 +82,10 @@ class IdentifierNTR extends NonTerminalRef {
         this.name = name;
     }
 
+    visit(visitor) {
+        visitor.visitIdentifierNTR(this);
+    }
+
     codegen() {
         return stringEscape(this.name);
     }
@@ -83,6 +98,10 @@ class ComputedNTR extends NonTerminalRef {
 
         this.isComputed = true;
         this.code = nameCode;
+    }
+
+    visit(visitor) {
+        visitor.visitComputedNTR(this);
     }
 
     codegen() {
@@ -99,6 +118,14 @@ class NonTerminalStmt extends Statement {
 
         this.name = name;
         this.rules = rules;
+    }
+
+    visit(visitor) {
+        if (!visitor.visitNonTerminalStmt(this))
+            return;
+        this.name.visit(visitor);
+        for (let rule of this.rules)
+            rule.visit(visitor);
     }
 
     codegen(prefix = '') {
@@ -119,6 +146,10 @@ class ContextStmt extends Statement {
         this.names = names;
     }
 
+    visit(visitor) {
+        visitor.visitContextStmt(this);
+    }
+
     codegen(prefix = '') {
         return this.names.map((name) => `${prefix}$grammar.declareContext(${stringEscape(name)});\n`).join('');
     }
@@ -135,6 +166,10 @@ class FunctionDeclarationStmt extends Statement {
         this.code = code;
     }
 
+    visit(visitor) {
+        visitor.visitFunctionDeclarationStmt(this);
+    }
+
     codegen(prefix = '') {
         return `${prefix}$grammar.declareFunction('${this.name}', (${this.args.join(', ')}) => {${this.code}});\n`;
     }
@@ -148,6 +183,14 @@ class ForLoop extends Statement {
         this.isForLoop = true;
         this.head = head;
         this.statements = statements;
+    }
+
+    visit(visitor) {
+        if (!visitor.visitForLoop(this))
+            return;
+
+        for (let stmt of this.statements)
+            stmt.visit(visitor);
     }
 
     codegen(prefix = '') {
@@ -169,6 +212,15 @@ class IfStmt extends Statement {
         this.cond = cond;
         this.iftrue = iftrue;
         this.iffalse = iffalse;
+    }
+
+    visit(visitor) {
+        if (!visitor.visitIfStmt(this))
+            return;
+        for (let stmt of this.iftrue)
+            stmt.visit(visitor);
+        for (let stmt of this.iffalse)
+            stmt.visit(visitor);
     }
 
     codegen(prefix = '') {
@@ -195,6 +247,10 @@ class Import extends Statement {
         this.what = what;
     }
 
+    visit(visitor) {
+        visitor.visitImport(this);
+    }
+
     codegen(prefix = '') {
         return `${prefix}$grammar = await $import(${stringEscape(this.what)})($options, $locale, $grammar);\n`;
     }
@@ -204,6 +260,10 @@ Statement.Import = Import;
 class RuleAttributes {
     constructor(attributes = []) {
         this.attributes = attributes;
+    }
+
+    visit(visitor) {
+        visitor.visitRuleAttributes(this);
     }
 
     codegen() {
@@ -218,7 +278,7 @@ exports.RuleAttributes = RuleAttributes;
 class Rule {}
 exports.Rule = Rule;
 
-class Constants extends Rule {
+class ConstantsRule extends Rule {
     constructor(token, typeCode, prefix, suffix, attrs) {
         super();
 
@@ -230,11 +290,15 @@ class Constants extends Rule {
         this.attrs = attrs;
     }
 
+    visit(visitor) {
+        visitor.visitConstantsRule(this);
+    }
+
     codegen(nonTerminal, prefix = '') {
         return `${prefix}$grammar.addConstants(${nonTerminal.codegen()}, ${stringEscape(this.token)}, ${this.typeCode}, ${stringEscape(this.prefix)}, ${stringEscape(this.suffix)}, ${this.attrs.codegen()});\n`;
     }
 }
-Rule.Constants = Constants;
+Rule.Constants = ConstantsRule;
 
 function makeBodyLambda(head, body) {
     const bodyArgs = [];
@@ -249,7 +313,43 @@ function makeBodyLambda(head, body) {
     return `(${bodyArgs.join(', ')}) => ${body}`;
 }
 
-class Expansion extends Rule {
+function getTranslationKey(expansion) {
+    let str = '';
+    let comment = '';
+    let positionalIdx = 0;
+    let needsComment = false;
+
+    for (const part of expansion) {
+        if (str)
+            str += ' ';
+        if (comment)
+            comment += ' ';
+        if (part.isStringLiteral) {
+            str += part.value;
+            comment += part.value;
+        } else if (part.isComputedStringLiteral) {
+            str += '${' + String(positionalIdx++) + '}';
+            comment += '${' + part.code + '}';
+            needsComment = true;
+        } else if (part.isNonTerminal && part.category.isIdentifier) {
+            str += '${' + part.category.name + '}';
+            comment += '${' + part.category.name + '}';
+        } else if (part.isNonTerminal && part.category.isComputed) {
+            str += '${' + String(positionalIdx++) + '}';
+            comment += '${' + part.category.code + '}';
+            needsComment = true;
+        } else if (part.isChoice) {
+            str += '{' + part.values.join('|') + '}';
+            comment += '{' + part.values.join('|') + '}';
+        } else {
+            throw new TypeError();
+        }
+    }
+
+    return [str, comment, needsComment];
+}
+
+class ExpansionRule extends Rule {
     constructor(head, body, condition, attrs) {
         super();
         assert(Array.isArray(head));
@@ -261,21 +361,41 @@ class Expansion extends Rule {
         this.attrs = attrs;
     }
 
+    visit(visitor) {
+        if (!visitor.visitExpansionRule(this))
+            return;
+
+        for (let head of this.head)
+            head.visit(visitor);
+    }
+
+    getTranslationKey() {
+        return getTranslationKey(this.head);
+    }
+
     codegen(nonTerminal, prefix = '') {
         const expanderCode = makeBodyLambda(this.head, this.bodyCode);
 
         return `${prefix}$grammar.addRule(${nonTerminal.codegen()}, [${this.head.map((h) => h.codegen()).join(', ')}], $runtime.simpleCombine((${expanderCode}), ${this.conditionCode ? stringEscape(this.conditionCode) : 'null'}, ${nonTerminal.isIdentifier && nonTerminal.name === '$root'}), ${this.attrs.codegen()});\n`;
     }
 }
-Rule.Expansion = Expansion;
+Rule.Expansion = ExpansionRule;
 
-class Condition extends Rule {
+class ConditionRule extends Rule {
     constructor(flag, rules) {
         super();
 
         this.isCondition = true;
         this.flag = flag;
         this.rules = rules;
+    }
+
+    visit(visitor) {
+        if (!visitor.visitConditionRule(this))
+            return;
+
+        for (let rule of this.rules)
+            rule.visit(visitor);
     }
 
     codegen(nonTerminal, prefix = '') {
@@ -291,9 +411,9 @@ class Condition extends Rule {
         return buffer;
     }
 }
-Rule.Condition = Condition;
+Rule.Condition = ConditionRule;
 
-class Replacement extends Rule {
+class ReplacementRule extends Rule {
     constructor(head, placeholder, bodyCode, optionCode, attrs) {
         super();
 
@@ -305,13 +425,25 @@ class Replacement extends Rule {
         this.attrs = attrs;
     }
 
+    getTranslationKey() {
+        return getTranslationKey(this.head);
+    }
+
+    visit(visitor) {
+        if (!visitor.visitReplacementRule(this))
+            return;
+
+        for (let head of this.head)
+            head.visit(visitor);
+    }
+
     codegen(nonTerminal, prefix = '') {
         const expanderCode = makeBodyLambda(this.head, this.bodyCode);
 
         return (`${prefix}$grammar.addRule(${nonTerminal.codegen()}, [${this.head.map((h) => h.codegen()).join(', ')}], $runtime.combineReplacePlaceholder(${this.placeholder}, (${expanderCode}), ${this.optionCode}), ${this.attrs.codegen()});\n`);
     }
 }
-Rule.Replacement = Replacement;
+Rule.Replacement = ReplacementRule;
 
 class RuleHeadPart {}
 exports.RuleHeadPart = RuleHeadPart;
@@ -323,6 +455,10 @@ class NonTerminalRuleHead extends RuleHeadPart {
         this.isNonTerminal = true;
         this.name = name;
         this.category = category;
+    }
+
+    visit(visitor) {
+        visitor.visitNonTerminalRuleHead(this);
     }
 
     codegen() {
@@ -339,6 +475,10 @@ class StringLiteralRuleHead extends RuleHeadPart {
         this.value = value;
     }
 
+    visit(visitor) {
+        visitor.visitStringLiteralRuleHead(this);
+    }
+
     codegen() {
         return stringEscape(this.value);
     }
@@ -353,6 +493,10 @@ class ComputedStringLiteralRuleHead extends RuleHeadPart {
         this.code = code;
     }
 
+    visit(visitor) {
+        visitor.visitComputedStringLiteralRuleHead(this);
+    }
+
     codegen() {
         return this.code;
     }
@@ -365,6 +509,10 @@ class ChoiceRuleHead extends RuleHeadPart {
 
         this.isChoice = true;
         this.values = values;
+    }
+
+    visit(visitor) {
+        visitor.visitChoiceRuleHead(this);
     }
 
     codegen() {

--- a/lib/sentence-generator/compiler/meta_ast.js
+++ b/lib/sentence-generator/compiler/meta_ast.js
@@ -219,17 +219,19 @@ class Rule {}
 exports.Rule = Rule;
 
 class Constants extends Rule {
-    constructor(token, typeCode, attrs) {
+    constructor(token, typeCode, prefix, suffix, attrs) {
         super();
 
         this.isConstants = true;
         this.token = token;
         this.typeCode = typeCode;
+        this.prefix = prefix;
+        this.suffix = suffix;
         this.attrs = attrs;
     }
 
     codegen(nonTerminal, prefix = '') {
-        return `${prefix}$grammar.addConstants(${nonTerminal.codegen()}, ${stringEscape(this.token)}, ${this.typeCode}, ${this.attrs.codegen()});\n`;
+        return `${prefix}$grammar.addConstants(${nonTerminal.codegen()}, ${stringEscape(this.token)}, ${this.typeCode}, ${stringEscape(this.prefix)}, ${stringEscape(this.suffix)}, ${this.attrs.codegen()});\n`;
     }
 }
 Rule.Constants = Constants;

--- a/lib/sentence-generator/compiler/visitor.js
+++ b/lib/sentence-generator/compiler/visitor.js
@@ -1,0 +1,86 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+"use strict";
+
+module.exports = class AstNodeVisitor {
+    visitGrammar(node) {
+        return true;
+    }
+
+    visitCodeBlock(node) {
+        return true;
+    }
+
+    visitIdentifierNTR(node) {
+        return true;
+    }
+    visitComputedNTR(node) {
+        return true;
+    }
+
+    visitNonTerminalStmt(node) {
+        return true;
+    }
+    visitContextStmt(node) {
+        return true;
+    }
+    visitFunctionDeclarationStmt(node) {
+        return true;
+    }
+    visitForLoop(node) {
+        return true;
+    }
+    visitIfStmt(node) {
+        return true;
+    }
+    visitImport(node) {
+        return true;
+    }
+
+    visitRuleAttributes(node) {
+        return true;
+    }
+
+    visitConstantsRule(node) {
+        return true;
+    }
+    visitExpansionRule(node) {
+        return true;
+    }
+    visitConditionRule(node) {
+        return true;
+    }
+    visitReplacementRule(node) {
+        return true;
+    }
+
+    visitNonTerminalRuleHead(node) {
+        return true;
+    }
+    visitStringLiteralRuleHead(node) {
+        return true;
+    }
+    visitComputedStringLiteralRuleHead(node) {
+        return true;
+    }
+    visitChoiceRuleHead(node) {
+        return true;
+    }
+};

--- a/lib/sentence-generator/generator.js
+++ b/lib/sentence-generator/generator.js
@@ -200,7 +200,7 @@ class SentenceGenerator extends events.EventEmitter {
         this._rules[symbolId].push(new Rule(rulenumber, expansion, combiner, attributes));
     }
 
-    addConstants(symbol, token, type, attributes = {}) {
+    addConstants(symbol, token, type, prefix = '', suffix = '', attributes = {}) {
         if (this._finalized)
             throw new GenieTypeError(`Grammar was finalized, cannot add more rules`);
         // ignore $user when loading the agent templates and vice-versa
@@ -213,8 +213,14 @@ class SentenceGenerator extends events.EventEmitter {
         attributes.forConstant = true;
         for (let constant of this._target.createConstants(token, type, this._options.maxConstants || DEFAULT_MAX_CONSTANTS, this._contextual)) {
             const sentencepiece = constant instanceof Constant ? constant : constant.display;
+            const expansion = [];
+            if (prefix)
+                expansion.push(prefix);
+            expansion.push(sentencepiece);
+            if (suffix)
+                expansion.push(suffix);
             const combiner = () => new Derivation(constant.value, List.singleton(sentencepiece), attributes.priority);
-            this._addRuleInternal(symbolId, [sentencepiece], combiner, attributes);
+            this._addRuleInternal(symbolId, expansion, combiner, attributes);
         }
     }
 

--- a/lib/sentence-generator/runtime.js
+++ b/lib/sentence-generator/runtime.js
@@ -370,8 +370,6 @@ class Choice {
     }
 }
 
-//const everything = new Set;
-
 module.exports = {
     LogLevel,
 

--- a/po/extract-translatable-annotations.js
+++ b/po/extract-translatable-annotations.js
@@ -19,17 +19,13 @@
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 "use strict";
 
+process.on('unhandledRejection', (up) => { throw up; });
+
 const ThingTalk = require('thingtalk');
 const fs = require('fs');
 const util = require('util');
 
-function stringEscape(str) {
-    if (str === null || str === undefined)
-        return 'null';
-    return '"' + str.replace(/(["\\])/g, '\\$1').replace(/\n/g, '\\n') + '"';
-    // the following comment fixes broken syntax highlighting in GtkSourceView
-    //]/
-}
+const { stringEscape } = require('../lib/utils/escaping');
 
 function extract(key, str) {
     if (typeof str === 'string') {

--- a/po/extract-translatable-templates.js
+++ b/po/extract-translatable-templates.js
@@ -1,0 +1,99 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2019-2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+"use strict";
+
+process.on('unhandledRejection', (up) => { throw up; });
+
+const assert = require('assert');
+
+const { stringEscape } = require('../lib/utils/escaping');
+
+const genieCompiler = require('../lib/sentence-generator/compiler');
+const AstNodeVisitor = require('../lib/sentence-generator/compiler/visitor');
+
+class Extractor extends AstNodeVisitor {
+    constructor() {
+        super();
+
+        this._contexts = new Set;
+        this._nonTerm = null;
+    }
+
+    visitContextStmt(stmt) {
+        for (let name of stmt.names)
+            this._contexts.add(name);
+    }
+
+    visitNonTerminalStmt(stmt) {
+        this._nonTerm = stmt.name.name || stmt.name.code;
+        return true;
+    }
+
+    _visitRule(rule) {
+        const [str, comment, needsComment] = rule.getTranslationKey();
+        if (!str)
+            return true;
+
+        if (needsComment)
+            console.log(`/* ${comment} */`);
+        console.log(`var x = pgettext(${stringEscape('template/' + this._nonTerm)}, ${stringEscape(str)});`);
+        return true;
+    }
+
+    visitExpansionRule(rule) {
+        // do not generate a translation if the rule only references a non-terminal
+        // (with or without a context)
+        if (rule.head.length === 1 && rule.head[0].isNonTerminal)
+            return false;
+        if (rule.head.length === 2 && rule.head[0].isNonTerminal && rule.head[1].isNonTerminal
+            && this._contexts.has(rule.head[0].category.name))
+            return false;
+
+        return this._visitRule(rule);
+    }
+    visitReplacementRule(rule) {
+        assert(rule.head[0].isNonTerminal);
+        if (rule.head[1].isNonTerminal)
+            return;
+        return this._visitRule(rule);
+    }
+
+    // stubs that are called by the compiled templates
+    addConstants() {
+    }
+    declareFunction() {
+    }
+    declareConstants() {
+    }
+    declareSymbol() {
+    }
+}
+
+async function main() {
+    const extractor = new Extractor();
+
+    // compile everything
+    await genieCompiler(process.argv[2]);
+
+    // for every compiled file
+    for (let { parsed } of Object.values(genieCompiler._importCache))
+        parsed.visit(extractor);
+}
+main();

--- a/po/update-po.sh
+++ b/po/update-po.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec msgmerge -U $1 ./po/${npm_package_name}.pot
+exec msgmerge -U $1 ./po/genie-toolkit.pot

--- a/po/update-pot.sh
+++ b/po/update-pot.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 
+set -e
+set -x
+
 podir=`dirname $0`
 mkdir -p $podir/tmp
-for f in $podir/../data/builtins/*.tt ; do
+
+find lib -name \*.js > po/POTFILES
+for f in $podir/../data/builtins/*/manifest.tt ; do
 	kind=`basename $f .tt`
 	node $podir/extract-translatable-annotations.js $f > $podir/tmp/$kind.js
+	echo $podir/tmp/$kind.js >> po/POTFILES
 done
-find lib -name \*.js > po/POTFILES
-xgettext -kN_ -c -f po/POTFILES -x po/POTFILES.skip -o po/${npm_package_name}.pot --from-code UTF-8 --package-name ${npm_package_name} --package-version ${npm_package_version}
+node $podir/extract-translatable-templates.js $podir/../languages/thingtalk/en/dialogue.genie > $podir/tmp/templates.js
+echo $podir/tmp/templates.js >> po/POTFILES
+xgettext -kN_ -c -f po/POTFILES -x po/POTFILES.skip -o po/genie-toolkit.pot --from-code UTF-8 --package-name genie-toolkit --package-version ${npm_package_version}

--- a/test/it-IT/dataset.tt
+++ b/test/it-IT/dataset.tt
@@ -1,0 +1,37 @@
+dataset @org.thingpedia.dynamic.everything language "it" {
+    query (p_query :String)  := @com.bing.web_search(query=p_query)
+    #_[utterances=["${p_query:const} su bing","bing $p_query","siti web che corrispondono a $p_query"]]
+    #_[preprocessed=["${p_query:const} su bing","bing $p_query","siti web che corrispondono a $p_query"]]
+    #[id=48846292] #[click_count=1] #[like_count=0]
+    #[name="WebSearchWithQuery"];
+    query (p_query :String)  := @com.bing.image_search(query=p_query)
+    #_[utterances=["immagini ${p_query:const} su bing","immagini che corrispondono a $p_query su bing"]]
+    #_[preprocessed=["immagini ${p_query:const} su bing","immagini che corrispondono a $p_query su bing"]]
+    #[id=48846295] #[click_count=1] #[like_count=0]
+    #[name="ImageSearchWithQuery"];
+    query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width == p_width && height == p_height)
+    #_[utterances=["immagini da bing che corrispondono a $p_query con dimensione $p_width x $p_height"]]
+    #_[preprocessed=["immagini da bing che corrispondono a $p_query con dimensione $p_width x $p_height"]]
+    #[id=48846297] #[click_count=1] #[like_count=0]
+    #[name="ImageSearchWithQueryByWidthAndByHeight"];
+    query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width >= p_width && height >= p_height)
+    #_[utterances=["immagini da bing che corrispondono a $p_query più grandi di $p_width x $p_height","immagini da bing che corrispondono a $p_query più grandi $p_width x $p_height in entrambe le dimensioni"]]
+    #_[preprocessed=["immagini da bing che corrispondono a $p_query più grandi di $p_width x $p_height _","immagini da bing che corrispondono a $p_query più grandi $p_width x $p_height in entrambe le dimensioni"]]
+    #[id=48846298] #[click_count=1] #[like_count=0]
+    #[name="ImageSearchWithQueryByWidthGreaterThanAndByHeightGreaterThan"];
+    query (p_query :String, p_width :Number)  := (@com.bing.image_search(query=p_query)), width >= p_width
+    #_[utterances=["immagini da bing che corrispondono a $p_query più larghe di $p_width"]]
+    #_[preprocessed=["immagini da bing che corrispondono a $p_query più larghe di $p_width"]]
+    #[id=48846300] #[click_count=1] #[like_count=0]
+    #[name="ImageSearchWithQueryByWidthGreaterThan"];
+    query (p_query :String, p_height :Number)  := (@com.bing.image_search(query=p_query)), height >= p_height
+    #_[utterances=["immagini da bing che corrispondono a $p_query più alte di $p_height","immagini da bing che corrispondono a $p_query più lunghe di $p_height"]]
+    #_[preprocessed=["immagini da bing che corrispondono a $p_query più alte di $p_height","immagini da bing che corrispondono a $p_query più lunghe di $p_height"]]
+    #[id=48846301] #[click_count=1] #[like_count=0]
+    #[name="ImageSearchWithQueryByHeightGreaterThan"];
+    query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width <= p_width && height <= p_height)
+    #_[utterances=["immagini da bing che corrispondono a $p_query più piccole di $p_width x $p_height"]]
+    #_[preprocessed=["immagini da bing che corrispondono a $p_query più piccole di $p_width x $p_height"]]
+    #[id=48846303] #[click_count=1] #[like_count=0]
+    #[name="ImageSearchWithQueryByWidthLessThanAndByHeightLessThan"];
+}

--- a/test/it-IT/thingpedia.tt
+++ b/test/it-IT/thingpedia.tt
@@ -1,0 +1,23 @@
+class @com.bing
+#_[canonical="ricerca bing"] {
+  monitorable list query image_search(in req query: String #_[prompt="Cosa vuoi cercare?"] #_[canonical="query"],
+                                      out title: String #_[canonical="titolo"],
+                                      out picture_url: Entity(tt:picture) #_[canonical="immagine"],
+                                      out link: Entity(tt:url) #_[canonical="link"],
+                                      out width: Number #_[prompt="Che larghezza stai cercando (in pixel)?"] #_[canonical="larghezza"],
+                                      out height: Number #_[prompt="Che altezza stai cercando (in pixel)?"] #_[canonical="altezza"])
+  #_[canonical="cerca immagini su bing"]
+  #_[confirmation="immagini che corrispondono a $query su Bing"]
+  #_[formatted=[{type="rdl",webCallback="${link}",displayTitle="${title}"}, {type="picture",url="${picture_url}"}]]
+  #[confirm=false];
+
+  monitorable list query web_search(in req query: String #_[prompt="Cosa vuoi cercare?"] #_[canonical="query"],
+                                    out title: String #_[canonical="titolo"],
+                                    out description: String #_[canonical="descrizione"],
+                                    out link: Entity(tt:url) #_[canonical="link"])
+  #_[canonical="ricerca web su bing"]
+  #_[confirmation="siti web che corrispondono a $query su Bing"]
+  #_[formatted=[{type="rdl",webCallback="${link}",displayTitle="${title}",displayText="${description}"}]]
+  #[confirm=false];
+}
+


### PR DESCRIPTION
This is a Gettext-based approach to translating templates.
We run static code extraction on the templates, prepare a file for translation, translate using standard tools people are familiar with, and then merge back into the templates.

The last bit is still missing so this PR is a draft.