### PR TITLE
Add a flag to make datasets unbalanced

### DIFF
--- a/languages/thingtalk/common-constants.genie
+++ b/languages/thingtalk/common-constants.genie
@@ -94,7 +94,12 @@ constant_Measure_dBm = {
 
 // this is used for equality filtering, so !turking anything that is weird when equality compared
 constant_Any = {
-    constant_String [repeat=true];
+    !unbalanced {
+        constant_String [repeat=true];
+    }
+    ?unbalanced {
+        constant_String;
+    }
     constant_Entity__tt__picture;
     constant_Entity__tt__username;
     constant_Entity__tt__hashtag;


### PR DESCRIPTION
When generating the exact match dataset in almond-cloud, we pass
a very high pruning size so we don't prune anything at all.
If we do that, we cannot rebalance the dataset because rebalancing
creates copies, which cause us to run out of memory.