### PR TITLE
Add "new" in front of all Type constructors

### DIFF
--- a/languages/thingtalk/ast_manip.js
+++ b/languages/thingtalk/ast_manip.js
@@ -39,7 +39,7 @@ function makeDate(base, operator, offset) {
         return base;
 
     const value = new Ast.Value.Computation(operator, [base, offset],
-        [Type.Date, Type.Measure('ms'), Type.Date], Type.Date);
+        [Type.Date, new Type.Measure('ms'), Type.Date], Type.Date);
     return value;
 }
 
@@ -243,7 +243,7 @@ function makeAggregateFilter(param, aggregationOp, field, op, value) {
             return null;
         assert(field === null || field === '*');
         const agg = new Ast.Value.Computation(aggregationOp, [param],
-            [Type.Array('x'), Type.Number], Type.Number);
+            [new Type.Array('x'), Type.Number], Type.Number);
         return new Ast.BooleanExpression.Compute(null, agg, op, value);
     } else if (['sum', 'avg', 'max', 'min'].includes(aggregationOp)) {
         const vtype = value.getType();
@@ -256,7 +256,7 @@ function makeAggregateFilter(param, aggregationOp, field, op, value) {
         }
         const agg = new Ast.Value.Computation(aggregationOp, [
             param ? new Ast.Value.ArrayField(param, field.name) : param
-        ], [Type.Array(vtype), vtype], vtype);
+        ], [new Type.Array(vtype), vtype], vtype);
         return new Ast.BooleanExpression.Compute(null, agg, op, value);
     }
     return null;
@@ -272,7 +272,7 @@ function makeAggregateFilterWithFilter(param, filter, aggregationOp, field, op, 
         if (!value.getType().isNumber)
             return null;
         assert(field === null);
-        const agg = new Ast.Value.Computation(aggregationOp, [list], [Type.Array('x'), Type.Number], Type.Number);
+        const agg = new Ast.Value.Computation(aggregationOp, [list], [new Type.Array('x'), Type.Number], Type.Number);
         return new Ast.BooleanExpression.Compute(null, agg, op, value);
     } else if (['sum', 'avg', 'max', 'min'].includes(aggregationOp)) {
         const vtype = value.getType();
@@ -285,7 +285,7 @@ function makeAggregateFilterWithFilter(param, filter, aggregationOp, field, op, 
         }
         const agg = new Ast.Value.Computation(aggregationOp, [
             field ? new Ast.Value.ArrayField(list, field.name) : list
-        ], [Type.Array(vtype), vtype], vtype);
+        ], [new Type.Array(vtype), vtype], vtype);
         return new Ast.BooleanExpression.Compute(null, agg, op, value);
     }
     return null;
@@ -312,7 +312,7 @@ function addUnit(unit, num) {
     if (num.isVarRef) {
         let v = new Ast.Value.VarRef(num.name + '__' + unit);
         v.unit = unit;
-        v.getType = () => Type.Measure(unit);
+        v.getType = () => new Type.Measure(unit);
         return v;
     } else {
         return new Ast.Value.Measure(num.value, unit);
@@ -656,11 +656,11 @@ function checkAtomFilter(table, filter) {
             return false;
         vtype = Type.String;
     } else if (filter.operator === 'in_array') {
-        vtype = Type.Array(ptype);
+        vtype = new Type.Array(ptype);
     } else if (filter.operator === 'in_array~') {
         if (!vtype.isEntity && !vtype.isString)
             return false;
-        vtype = Type.Array(Type.String);
+        vtype = new Type.Array(Type.String);
     } else if (filter.operator === '=~') {
         if (!ptype.isEntity && !ptype.isString)
             return false;
@@ -1561,8 +1561,8 @@ function makeComputeExpression(table, operation, operands, resultType) {
         new Ast.ArgumentDef(null, Ast.ArgDirection.OUT, operation, resultType)]);
     const expression = new Ast.Value.Computation(operation, operands);
     if (operation === 'distance') {
-        expression.overload = [Type.Location, Type.Location, Type.Measure('m')];
-        expression.type = Type.Measure('m');
+        expression.overload = [Type.Location, Type.Location, new Type.Measure('m')];
+        expression.type = new Type.Measure('m');
     }
 
     return new Ast.Table.Compute(null, table, expression, null, computeSchema);
@@ -1580,8 +1580,8 @@ function makeComputeFilterExpression(table, operation, operands, resultType, fil
 
     const expression = new Ast.Value.Computation(operation, operands);
     if (operation === 'distance') {
-        expression.overload = [Type.Location, Type.Location, Type.Measure('m')];
-        expression.type = Type.Measure('m');
+        expression.overload = [Type.Location, Type.Location, new Type.Measure('m')];
+        expression.type = new Type.Measure('m');
     }
     const filter = new Ast.BooleanExpression.Compute(null, expression, filterOp, filterValue);
     if (filter)
@@ -1604,7 +1604,7 @@ function makeWithinGeoDistanceExpression(table, location, filterValue) {
     // the distance should be at least 100 meters (if the value is small number)
     if (filterValue.isMeasure && Units.transformToBaseUnit(filterValue.value, unit) < 100)
         return null;
-    return makeComputeFilterExpression(table, 'distance', [new Ast.Value.VarRef('geo'), location], Type.Measure('m'), '<=', filterValue);
+    return makeComputeFilterExpression(table, 'distance', [new Ast.Value.VarRef('geo'), location], new Type.Measure('m'), '<=', filterValue);
 }
 
 function makeComputeArgMinMaxExpression(table, operation, operands, resultType, direction = 'desc') {
@@ -1640,10 +1640,10 @@ function makeAggComputeExpression(table, operation, field, list, resultType) {
         new Ast.ArgumentDef(null, Ast.ArgDirection.OUT, operation, resultType)]);
     const expression = new Ast.Value.Computation(operation, [field ? new Ast.Value.ArrayField(list, field) : list]);
     if (operation === 'count') {
-        expression.overload = [Type.Array('x'), Type.Number];
+        expression.overload = [new Type.Array('x'), Type.Number];
         expression.type = Type.Number;
     } else {
-        expression.overload = [Type.Array(resultType), resultType];
+        expression.overload = [new Type.Array(resultType), resultType];
         expression.type = resultType;
     }
 

--- a/languages/thingtalk/common-constants.genie
+++ b/languages/thingtalk/common-constants.genie
@@ -32,13 +32,13 @@ for (let i = 0; i <= MAX_SMALL_INTEGER; i++)
 
 constant_String                    = const(QUOTED_STRING, Type.String);
 
-constant_Entity__tt__url           = const(URL, Type.Entity('tt:url'));
+constant_Entity__tt__url           = const(URL, new Type.Entity('tt:url'));
 
-constant_Entity__tt__username      = const(USERNAME, Type.Entity('tt:username'));
-constant_Entity__tt__hashtag       = const(HASHTAG, Type.Entity('tt:hashtag'));
-constant_Entity__tt__phone_number  = const(PHONE_NUMBER, Type.Entity('tt:phone_number'));
-constant_Entity__tt__email_address = const(EMAIL_ADDRESS, Type.Entity('tt:email_address'));
-constant_Entity__tt__path_name     = const(PATH_NAME, Type.Entity('tt:path_name'));
+constant_Entity__tt__username      = const(USERNAME, new Type.Entity('tt:username'));
+constant_Entity__tt__hashtag       = const(HASHTAG, new Type.Entity('tt:hashtag'));
+constant_Entity__tt__phone_number  = const(PHONE_NUMBER, new Type.Entity('tt:phone_number'));
+constant_Entity__tt__email_address = const(EMAIL_ADDRESS, new Type.Entity('tt:email_address'));
+constant_Entity__tt__path_name     = const(PATH_NAME, new Type.Entity('tt:path_name'));
 
 constant_Number = const(NUMBER, Type.Number);
 constant_Currency = const(CURRENCY, Type.Currency);
@@ -54,49 +54,49 @@ constant_Boolean = {}
 constant_RecurrentTimeSpecification = {}
 
 constant_Measure_ms = {
-    ?inference const(MEASURE_ms, Type.Measure('ms'));
+    ?inference const(MEASURE_ms, new Type.Measure('ms'));
 }
 constant_Measure_byte = {
-    ?inference const(MEASURE_byte, Type.Measure('byte'));
+    ?inference const(MEASURE_byte, new Type.Measure('byte'));
 }
 constant_Measure_kg = {
-    ?inference const(MEASURE_kg, Type.Measure('kg'));
+    ?inference const(MEASURE_kg, new Type.Measure('kg'));
 }
 constant_Measure_C = {
-    ?inference const(MEASURE_C, Type.Measure('C'));
+    ?inference const(MEASURE_C, new Type.Measure('C'));
 }
 constant_Measure_m = {
-    ?inference const(MEASURE_m, Type.Measure('m'));
+    ?inference const(MEASURE_m, new Type.Measure('m'));
 }
 constant_Measure_m2 = {
-    ?inference const(MEASURE_m2, Type.Measure('m2'));
+    ?inference const(MEASURE_m2, new Type.Measure('m2'));
 }
 constant_Measure_m3 = {
-    ?inference const(MEASURE_m3, Type.Measure('m3'));
+    ?inference const(MEASURE_m3, new Type.Measure('m3'));
 }
 constant_Measure_mps = {
-    ?inference const(MEASURE_mps, Type.Measure('mps'));
+    ?inference const(MEASURE_mps, new Type.Measure('mps'));
 }
 constant_Measure_Pa = {
-    ?inference const(MEASURE_Pa, Type.Measure('Pa'));
+    ?inference const(MEASURE_Pa, new Type.Measure('Pa'));
 }
 constant_Measure_kcal = {
-    ?inference const(MEASURE_kcal, Type.Measure('kcal'));
+    ?inference const(MEASURE_kcal, new Type.Measure('kcal'));
 }
 constant_Measure_W = {
-    ?inference const(MEASURE_W, Type.Measure('W'));
+    ?inference const(MEASURE_W, new Type.Measure('W'));
 }
 constant_Measure_lx = {
-    ?inference const(MEASURE_lx, Type.Measure('lx'));
+    ?inference const(MEASURE_lx, new Type.Measure('lx'));
 }
 constant_Measure_lm = {
-    ?inference const(MEASURE_lm, Type.Measure('lm'));
+    ?inference const(MEASURE_lm, new Type.Measure('lm'));
 }
 constant_Measure_dB = {
-    ?inference const(MEASURE_dB, Type.Measure('dB'));
+    ?inference const(MEASURE_dB, new Type.Measure('dB'));
 }
 constant_Measure_dBm = {
-    ?inference const(MEASURE_dBm, Type.Measure('byte'));
+    ?inference const(MEASURE_dBm, new Type.Measure('byte'));
 }
 
 // this is used for equality filtering, so !turking anything that is weird when equality compared

--- a/languages/thingtalk/en/computation.genie
+++ b/languages/thingtalk/en/computation.genie
@@ -47,7 +47,7 @@ projection_Measure_m = {
 
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], Type.Measure('m'));
+            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], new Type.Measure('m'));
         };
 
         // these form sentences like "tell me how far X is", which is grammatical but
@@ -57,7 +57,7 @@ projection_Measure_m = {
         ) => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], Type.Measure('m'));
+            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], new Type.Measure('m'));
         };
 
         ( 'the distance' ('of' | 'to') table:with_filtered_table 'from' place:constant_Location
@@ -67,7 +67,7 @@ projection_Measure_m = {
         ) => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], Type.Measure('m'));
+            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], new Type.Measure('m'));
         };
 
         ( 'how' ('far' | 'near' | 'close') 'from' place:constant_Location table:with_filtered_table 'is'
@@ -77,7 +77,7 @@ projection_Measure_m = {
         ) => {
             if (!table.schema.out.geo || table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], Type.Measure('m'));
+            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], new Type.Measure('m'));
         };
     }
 }
@@ -123,7 +123,7 @@ compute_question = {
         )=> {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], Type.Measure('m'));
+            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], new Type.Measure('m'));
         };
 
         ( 'how' ('far' | 'near' | 'close') ('is' | 'are') table:with_filtered_table ('from' | 'to') place:constant_Location ('?'|'')
@@ -131,7 +131,7 @@ compute_question = {
         ) => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], Type.Measure('m'));
+            return C.makeComputeProjExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], new Type.Measure('m'));
         };
 
         ( 'how many' p:out_param_ArrayCount ('does' | 'do') table:with_filtered_table 'have ?'
@@ -219,19 +219,19 @@ with_arg_min_max_table = {
         ('nearest' | 'closest') table:complete_table ('' | 'from here' | 'to here' | 'to me')  => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], Type.Measure('m'), 'asc');
+            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], new Type.Measure('m'), 'asc');
         };
 
         ('nearest' | 'closest') table:with_filtered_table => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], Type.Measure('m'), 'asc');
+            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], new Type.Measure('m'), 'asc');
         };
 
         ('farthest' | 'most far away') table:with_filtered_table => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], Type.Measure('m'), 'desc');
+            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), HERE], new Type.Measure('m'), 'desc');
         };
 
         ( ('nearest' | 'closest') table:complete_table 'to' place:constant_Location
@@ -240,7 +240,7 @@ with_arg_min_max_table = {
         ) => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], Type.Measure('m'), 'asc');
+            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], new Type.Measure('m'), 'asc');
         };
 
         ( ('nearest' | 'closest') table:with_filtered_table 'to' place:constant_Location
@@ -249,7 +249,7 @@ with_arg_min_max_table = {
         ) => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], Type.Measure('m'), 'asc');
+            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], new Type.Measure('m'), 'asc');
         };
 
         ( ('farthest' | 'most far away') table:with_filtered_table 'from' place:constant_Location
@@ -258,7 +258,7 @@ with_arg_min_max_table = {
         => {
             if (!table.schema.out.geo || !table.schema.out.geo.isLocation)
                 return null;
-            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], Type.Measure('m'), 'desc');
+            return C.makeComputeArgMinMaxExpression(table, 'distance', [new Ast.Value.VarRef('geo'), place], new Type.Measure('m'), 'desc');
         };
 
         table:with_filtered_table 'with the' ('most' | 'highest number of' | 'largest number of' | 'largest count of') p:out_param_Array__Any [weight=0.33] => {

--- a/languages/thingtalk/en/dlg/coref-questions.genie
+++ b/languages/thingtalk/en/dlg/coref-questions.genie
@@ -140,7 +140,7 @@ boolean_user_search_question = {
         }
         if (param.name === 'id')
             return null;
-        return [[param.name, param.operator === 'contains' ? Type.Array(param.value.getType()) : param.value.getType()]];
+        return [[param.name, param.operator === 'contains' ? new Type.Array(param.value.getType()) : param.value.getType()]];
     };
 
     ( 'is' ('it' | 'that') 'a' param:apv_filter base:base_table '?'
@@ -172,7 +172,7 @@ boolean_user_search_question = {
         }
         if (param.name === 'id')
             return null;
-        return [[param.name, param.operator === 'contains' ? Type.Array(param.value.getType()) : param.value.getType()]];
+        return [[param.name, param.operator === 'contains' ? new Type.Array(param.value.getType()) : param.value.getType()]];
     };
 }
 
@@ -191,7 +191,7 @@ boolean_user_search_question_for_list = {
         }
         if (param.name === 'id')
             return null;
-        return [[param.name, param.operator === 'contains' ? Type.Array(param.value.getType()) : param.value.getType()]];
+        return [[param.name, param.operator === 'contains' ? new Type.Array(param.value.getType()) : param.value.getType()]];
     };
 
     ( ('is either of them' | 'is any of them' | 'are they') 'a' param:apv_filter base:base_table '?'
@@ -221,7 +221,7 @@ boolean_user_search_question_for_list = {
         }
         if (param.name === 'id')
             return null;
-        return [[param.name, param.operator === 'contains' ? Type.Array(param.value.getType()) : param.value.getType()]];
+        return [[param.name, param.operator === 'contains' ? new Type.Array(param.value.getType()) : param.value.getType()]];
     };
 }
 
@@ -271,7 +271,7 @@ boolean_user_search_question_with_name = {
         }
         if (param.name === 'id')
             return null;
-        return [name, [[param.name, param.operator === 'contains' ? Type.Array(param.value.getType()) : param.value.getType()]]];
+        return [name, [[param.name, param.operator === 'contains' ? new Type.Array(param.value.getType()) : param.value.getType()]]];
     };
 
     ( 'is' name:constant_name 'a' param:apv_filter base:base_table '?'
@@ -295,7 +295,7 @@ boolean_user_search_question_with_name = {
         }
         if (param.name === 'id')
             return null;
-        return [name, [[param.name, param.operator === 'contains' ? Type.Array(param.value.getType()) : param.value.getType()]]];
+        return [name, [[param.name, param.operator === 'contains' ? new Type.Array(param.value.getType()) : param.value.getType()]]];
     };
 }
 

--- a/languages/thingtalk/load-thingpedia.js
+++ b/languages/thingtalk/load-thingpedia.js
@@ -114,7 +114,7 @@ class ThingpediaLoader {
         this._recordType(Type.Currency);
         this._recordType(Type.Number);
         for (let unit of Units.BaseUnits)
-            this._recordType(Type.Measure(unit));
+            this._recordType(new Type.Measure(unit));
 
         await this._loadMetadata();
     }
@@ -983,7 +983,7 @@ class ThingpediaLoader {
 
     _addEntityConstants() {
         for (let entityType in this._entities) {
-            const ttType = Type.Entity(entityType);
+            const ttType = new Type.Entity(entityType);
             let typestr = typeToStringSafe(ttType);
             const { has_ner_support } = this._entities[entityType];
 

--- a/languages/thingtalk/utils.js
+++ b/languages/thingtalk/utils.js
@@ -56,7 +56,7 @@ function makeFilter(loader, pname, op, value, negate = false) {
         if (loader.params.out.has(pname.name + '+' + Type.RecurrentTimeSpecification) && (vtype.isTime || vtype.isDate))
             ptype = Type.RecurrentTimeSpecification;
         else
-            ptype = Type.Array(vtype);
+            ptype = new Type.Array(vtype);
         if (vtype.isString)
             op = 'contains~';
     } else if (op === '==' && vtype.isString) {

--- a/lib/dataset-tools/mturk/sample-utils.js
+++ b/lib/dataset-tools/mturk/sample-utils.js
@@ -27,27 +27,27 @@ const TYPES = {
     QUOTED_STRING: Type.String,
     NUMBER: Type.Number,
     CURRENCY: Type.Currency,
-    DURATION: Type.Measure('ms'),
+    DURATION: new Type.Measure('ms'),
     LOCATION: Type.Location,
     DATE: Type.Date,
     TIME: Type.Time,
 
-    EMAIL_ADDRESS: Type.Entity('tt:email_address'),
-    PHONE_NUMBER: Type.Entity('tt:phone_number'),
-    HASHTAG: Type.Entity('tt:hashtag'),
-    USERNAME: Type.Entity('tt:username'),
-    URL: Type.Entity('tt:url'),
-    PATH_NAME: Type.Entity('tt:path_name'),
+    EMAIL_ADDRESS: new Type.Entity('tt:email_address'),
+    PHONE_NUMBER: new Type.Entity('tt:phone_number'),
+    HASHTAG: new Type.Entity('tt:hashtag'),
+    USERNAME: new Type.Entity('tt:username'),
+    URL: new Type.Entity('tt:url'),
+    PATH_NAME: new Type.Entity('tt:path_name'),
 };
 
 module.exports = {
     entityTypeToTTType(entityType, unit) {
         if (entityType === 'NUMBER' && !!unit)
-            return Type.Measure(unit);
+            return new Type.Measure(unit);
         else if (entityType.startsWith('GENERIC_ENTITY_'))
-            return Type.Entity(entityType.substring('GENERIC_ENTITY_'.length));
+            return new Type.Entity(entityType.substring('GENERIC_ENTITY_'.length));
         else if (entityType.startsWith('MEASURE_'))
-            return Type.Measure(entityType.substring('MEASURE_'.length));
+            return new Type.Measure(entityType.substring('MEASURE_'.length));
         else
             return TYPES[entityType];
     },

--- a/lib/dialogue-agent/simulator/statement_simulator.js
+++ b/lib/dialogue-agent/simulator/statement_simulator.js
@@ -125,15 +125,15 @@ class ThingTalkSimulatorState {
         if (jsValue instanceof ThingTalk.Builtin.Currency)
             return Type.Currency;
         if (jsValue instanceof ThingTalk.Builtin.Entity)
-            return Type.Entity('');
+            return new Type.Entity('');
         if (jsValue instanceof ThingTalk.Builtin.Time)
             return Type.Time;
         if (jsValue instanceof Date)
             return Type.Date;
         if (Array.isArray(jsValue) && jsValue.length > 0)
-            return Type.Array(this._inferType(jsValue[0]));
+            return new Type.Array(this._inferType(jsValue[0]));
         if (Array.isArray(jsValue))
-            return Type.Array(Type.Any);
+            return new Type.Array(Type.Any);
 
         return Type.Any;
     }

--- a/lib/dialogue-agent/statement_executor.js
+++ b/lib/dialogue-agent/statement_executor.js
@@ -42,7 +42,7 @@ class InferenceStatementExecutor {
 
     _inferType(key, jsValue) {
         if (key === 'distance') // HACK
-            return Type.Measure('m');
+            return new Type.Measure('m');
         if (typeof jsValue === 'boolean')
             return Type.Boolean;
         if (typeof jsValue === 'string')
@@ -52,15 +52,15 @@ class InferenceStatementExecutor {
         if (jsValue instanceof ThingTalk.Builtin.Currency)
             return Type.Currency;
         if (jsValue instanceof ThingTalk.Builtin.Entity)
-            return Type.Entity('');
+            return new Type.Entity('');
         if (jsValue instanceof ThingTalk.Builtin.Time)
             return Type.Time;
         if (jsValue instanceof Date)
             return Type.Date;
         if (Array.isArray(jsValue) && jsValue.length > 0)
-            return Type.Array(this._inferType(key, jsValue[0]));
+            return new Type.Array(this._inferType(key, jsValue[0]));
         if (Array.isArray(jsValue))
-            return Type.Array(Type.Any);
+            return new Type.Array(Type.Any);
 
         return Type.Any;
     }

--- a/lib/languages/thingtalk/constants.js
+++ b/lib/languages/thingtalk/constants.js
@@ -82,7 +82,7 @@ function extractConstants(ast) {
         }
 
         visitMeasureValue(value) {
-            const normalizedUnit = Type.Measure(value.unit).unit;
+            const normalizedUnit = new Type.Measure(value.unit).unit;
             // TODO:
             // - use the user's preferred measurement unit and/or the most appropriate unit for the
             //   specific value rather than what's in the result object

--- a/test/unit/test_base_canonical_generator.js
+++ b/test/unit/test_base_canonical_generator.js
@@ -26,9 +26,9 @@ const Type = ThingTalk.Type;
 const baseCanonical = require('../../tool/autoqa/lib/base-canonical-generator');
 
 const TEST_CASES = [
-    ['author', Type.Entity('org.schema.Restaurant:Person'), { default: 'property', base: ['author'] }],
+    ['author', new Type.Entity('org.schema.Restaurant:Person'), { default: 'property', base: ['author'] }],
     ['datePublished', Type.Date, { default: 'property', base: ['date published'] }],
-    ['review', Type.Array(Type.Entity('org.schema.Restaurant:Review')), { default: 'property', base: ['reviews'] }],
+    ['review', new Type.Array(new Type.Entity('org.schema.Restaurant:Review')), { default: 'property', base: ['reviews'] }],
     ['servesCuisine', Type.String, { default: 'verb', verb: ["serves # cuisine"], base: ["cuisine"] }],
 
     ['from_location', Type.Location, { default: 'passive_verb', base: ['from location'], passive_verb: ['from'] }],

--- a/tool/autoqa/schemaorg/manual-annotations.js
+++ b/tool/autoqa/schemaorg/manual-annotations.js
@@ -33,14 +33,14 @@ const BUILTIN_TYPEMAP = {
     DateTime: Type.Date,
     Date: Type.Date,
     DataType: Type.Any,
-    URL: Type.Entity('tt:url'),
-    ImageObject: Type.Entity('tt:picture'),
-    Barcode: Type.Entity('tt:picture'),
+    URL: new Type.Entity('tt:url'),
+    ImageObject: new Type.Entity('tt:picture'),
+    Barcode: new Type.Entity('tt:picture'),
 
-    Mass: Type.Measure('kg'),
-    Energy: Type.Measure('kcal'),
-    Distance: Type.Measure('m'),
-    Duration: Type.Measure('ms'),
+    Mass: new Type.Measure('kg'),
+    Energy: new Type.Measure('kcal'),
+    Distance: new Type.Measure('m'),
+    Duration: new Type.Measure('ms'),
 
     GeoCoordinates: Type.Location,
     MonetaryAmount: Type.Currency,
@@ -117,41 +117,41 @@ const PROPERTY_FORCE_NOT_ARRAY = new Set([
 ]);
 
 const PROPERTY_TYPE_OVERRIDE = {
-    'telephone': Type.Entity('tt:phone_number'),
-    'email': Type.Entity('tt:email_address'),
-    'faxNumber': Type.Entity('tt:phone_number'),
-    'image': Type.Entity('tt:picture'),
-    'logo': Type.Entity('tt:picture'),
+    'telephone': new Type.Entity('tt:phone_number'),
+    'email': new Type.Entity('tt:email_address'),
+    'faxNumber': new Type.Entity('tt:phone_number'),
+    'image': new Type.Entity('tt:picture'),
+    'logo': new Type.Entity('tt:picture'),
     'checkinTime': Type.Time,
     'checkoutTime': Type.Time,
     'price': Type.Currency,
 
-    'weight': Type.Measure('ms'),
-    'depth': Type.Measure('m'),
+    'weight': new Type.Measure('ms'),
+    'depth': new Type.Measure('m'),
     'description': Type.String,
-    'addressCountry': Type.Entity('tt:country'),
-    'addressRegion': Type.Entity('tt:us_state'),
+    'addressCountry': new Type.Entity('tt:country'),
+    'addressRegion': new Type.Entity('tt:us_state'),
 
     // we want to prefer VideoObject to the default Clip
-    'video': Type.Entity('org.schema:VideoObject'),
+    'video': new Type.Entity('org.schema:VideoObject'),
 
     // we want to prefer Organization to the default Person
-    'publisher': Type.Entity('org.schema:Organization'),
+    'publisher': new Type.Entity('org.schema:Organization'),
 
     // weird number like things, but mostly text
     'recipeYield': Type.String,
 
-    'genre': Type.Array(Type.String),
-    'creator': Type.Array(Type.Entity('org.schema.Movie:Person')),
+    'genre': new Type.Array(Type.String),
+    'creator': new Type.Array(new Type.Entity('org.schema.Movie:Person')),
     'contentRating': Type.String,
-    'byArtist': Type.Entity('org.schema.Music:Person'),
+    'byArtist': new Type.Entity('org.schema.Music:Person'),
 
     'openingHours': Type.RecurrentTimeSpecification,
-    'priceRange': Type.Enum(['cheap', 'moderate', 'expensive', 'luxury']),
+    'priceRange': new Type.Enum(['cheap', 'moderate', 'expensive', 'luxury']),
     'workLocation': Type.Location,
 
-    'inLanguage': Type.Entity('tt:iso_lang_code'),
-    'knowsLanguage': Type.Array(Type.Entity('tt:iso_lang_code'))
+    'inLanguage': new Type.Entity('tt:iso_lang_code'),
+    'knowsLanguage': new Type.Array(new Type.Entity('tt:iso_lang_code'))
 };
 
 const PROPERTY_CANONICAL_OVERRIDE = {

--- a/tool/autoqa/schemaorg/process-schema.js
+++ b/tool/autoqa/schemaorg/process-schema.js
@@ -149,13 +149,13 @@ class SchemaProcessor {
             return BUILTIN_TYPEMAP[typename];
 
         if (typeHierarchy[typename].isItemList)
-            return Type.Array(this.typeToThingTalk(typeHierarchy[typename].itemType, typeHierarchy, manualAnnotation));
+            return new Type.Array(this.typeToThingTalk(typeHierarchy[typename].itemType, typeHierarchy, manualAnnotation));
         if (typeHierarchy[typename].isEnum && typeHierarchy[typename].enum.length > 0)
-            return Type.Enum(typeHierarchy[typename].enum);
+            return new Type.Enum(typeHierarchy[typename].enum);
         if (typeHierarchy[typename].representAsStruct)
             return this.makeCompoundType(typename, typeHierarchy[typename], typeHierarchy, manualAnnotation);
 
-        return Type.Entity(this._prefix + typename);
+        return new Type.Entity(this._prefix + typename);
     }
 
     getBestPropertyType(propname, property, typeHierarchy, manualAnnotation) {
@@ -223,7 +223,7 @@ class SchemaProcessor {
             if (/number/i.test(propname) || /level/i.test(propname) || /quantity/i.test(propname))
                 return [best, Type.Number];
             if (/duration/i.test(propname))
-                return [best, Type.Measure('ms')];
+                return [best, new Type.Measure('ms')];
 
             console.error(`Cannot guess the correct type of ${propname} of type QuantitativeValue, assuming Number`);
             return [best, Type.Number];
@@ -245,7 +245,7 @@ class SchemaProcessor {
             isArray = false;
 
         if (isArray)
-            tttype = Type.Array(tttype);
+            tttype = new Type.Array(tttype);
         return [best, tttype];
     }
 
@@ -323,7 +323,7 @@ class SchemaProcessor {
         if (!anyfield)
             throw new Error(`Struct type ${startingTypename} has no fields`);
 
-        return Type.Compound(startingTypename, fields);
+        return new Type.Compound(startingTypename, fields);
     }
 
     loadPropertyCanonicalOverride(name) {
@@ -613,7 +613,7 @@ class SchemaProcessor {
                 continue;
 
             const args = [
-                new Ast.ArgumentDef(null, Ast.ArgDirection.OUT, 'id', Type.Entity(this._prefix + typename), {
+                new Ast.ArgumentDef(null, Ast.ArgDirection.OUT, 'id', new Type.Entity(this._prefix + typename), {
                     nl: { canonical: { base: ['name'], passive_verb: ['called', 'named'] } },
                     impl: {
                         'unique': new Ast.Value.Boolean(true),

--- a/tool/autoqa/sgd/manual-annotations.js
+++ b/tool/autoqa/sgd/manual-annotations.js
@@ -22,11 +22,11 @@ const ThingTalk = require('thingtalk');
 const Type = ThingTalk.Type;
 
 const PROPERTY_TYPE_OVERRIDE = {
-    'approximate_ride_duration': Type.Measure('ms'),
+    'approximate_ride_duration': new Type.Measure('ms'),
     'precipitation': Type.Number,
     'humidity': Type.Number,
-    'wind': Type.Measure('mps'),
-    'temperature': Type.Measure('C'),
+    'wind': new Type.Measure('mps'),
+    'temperature': new Type.Measure('C'),
     'balance': Type.Currency,
     'price_per_night': Type.Currency,
     'rent': Type.Currency,

--- a/tool/autoqa/sgd/process-schema.js
+++ b/tool/autoqa/sgd/process-schema.js
@@ -44,10 +44,10 @@ function predictType(slot) {
             return Type.Boolean;
         if (slot.possible_values.every((v) => !isNaN(v)))
             return Type.Number;
-        return Type.Enum(slot.possible_values.map(cleanEnumValue));
+        return new Type.Enum(slot.possible_values.map(cleanEnumValue));
     }
     if (slot.name === 'phone_number')
-        return Type.Entity('tt:phone_number');
+        return new Type.Entity('tt:phone_number');
     if (slot.name.startsWith('number_of_') || slot.name.endsWith('_number') || slot.name === 'number' ||
         slot.name.endsWith('_size') || slot.name === 'size' ||
         slot.name.endsWith('_rating') || slot.name === 'rating')

--- a/tool/sample.js
+++ b/tool/sample.js
@@ -139,7 +139,7 @@ class ContextSourceLoader extends Stream.Writable {
             // collapse NUMBER_ followed by unit into measure or duration
             if (type === 'NUMBER' && i < code.length-1 && code[i+1].startsWith('unit:')) {
                 const unit = code[i+1].substring('unit:'.length);
-                const baseunit = ThingTalk.Type.Measure(unit).unit;
+                const baseunit = new ThingTalk.Type.Measure(unit).unit;
                 if (baseunit === 'ms')
                     type = 'DURATION';
                 else


### PR DESCRIPTION
As part of the TypeScript-ification of ThingTalk, the Type
class is no longer an adt, and is now a regular class. Hence,
we need to use "new" to construct non-singleton types.

Let's do this early so nothing will break when we merge
this change in ThingTalk.