### PR TITLE
Add templates for light-year, decade and century

### DIFF
--- a/languages/thingtalk/en/constants.genie
+++ b/languages/thingtalk/en/constants.genie
@@ -67,6 +67,8 @@ constant_date_point = {
             'the end of the week' => C.makeDate(new Ast.DateEdge('end_of', 'week'), '+', null);
             'the end of the month'=> C.makeDate(new Ast.DateEdge('end_of', 'mon'), '+', null);
             'the end of the year' => C.makeDate(new Ast.DateEdge('end_of', 'year'), '+', null);
+            'the end of the decade' => C.makeDate(new Ast.DateEdge('end_of', 'decade'), '+', null);
+            'the end of the century' => C.makeDate(new Ast.DateEdge('end_of', 'century'), '+', null);
         }
     }
 }
@@ -75,16 +77,22 @@ constant_date_range = {
     'this week'   => [C.makeDate(new Ast.DateEdge('start_of', 'week'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'week'), '+', null)];
     'this month'  => [C.makeDate(new Ast.DateEdge('start_of', 'mon'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'mon'), '+', null)];
     'this year'   => [C.makeDate(new Ast.DateEdge('start_of', 'year'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'year'), '+', null)];
+    'this decade'   => [C.makeDate(new Ast.DateEdge('start_of', 'decade'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'decade'), '+', null)];
+    'this century'   => [C.makeDate(new Ast.DateEdge('start_of', 'century'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'century'), '+', null)];
 
     !turking {
         'last week'  => [C.makeDate(new Ast.DateEdge('start_of', 'week'), '-', new Ast.Value.Measure(1, 'week')), C.makeDate(new Ast.DateEdge('start_of', 'week'), '+', null)];
         'last month' => [C.makeDate(new Ast.DateEdge('start_of', 'mon'), '-', new Ast.Value.Measure(1, 'mon')), C.makeDate(new Ast.DateEdge('start_of', 'mon'), '+', null)];
         'last year'  => [C.makeDate(new Ast.DateEdge('start_of', 'year'), '-', new Ast.Value.Measure(1, 'year')), C.makeDate(new Ast.DateEdge('start_of', 'year'), '+', null)];
+        'last decade'  => [C.makeDate(new Ast.DateEdge('start_of', 'decade'), '-', new Ast.Value.Measure(1, 'decade')), C.makeDate(new Ast.DateEdge('start_of', 'decade'), '+', null)];
+        'last century'  => [C.makeDate(new Ast.DateEdge('start_of', 'century'), '-', new Ast.Value.Measure(1, 'century')), C.makeDate(new Ast.DateEdge('start_of', 'century'), '+', null)];
 
         ?future_dates {
             'next week'  => [C.makeDate(new Ast.DateEdge('end_of', 'week'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'week'), '+', new Ast.Value.Measure(1, 'week'))];
             'next month' => [C.makeDate(new Ast.DateEdge('end_of', 'mon'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'mon'), '+', new Ast.Value.Measure(1, 'mon'))];
             'next year'  => [C.makeDate(new Ast.DateEdge('end_of', 'year'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'year'), '+', new Ast.Value.Measure(1, 'year'))];
+            'next decade'  => [C.makeDate(new Ast.DateEdge('end_of', 'decade'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'decade'), '+', new Ast.Value.Measure(1, 'decade'))];
+            'next century'  => [C.makeDate(new Ast.DateEdge('end_of', 'century'), '+', null), C.makeDate(new Ast.DateEdge('end_of', 'century'), '+', new Ast.Value.Measure(1, 'century'))];
         }
 
         // year
@@ -191,6 +199,8 @@ constant_Measure_ms = {
         !turking num:constant_Number 'weeks' => C.addUnit('week', num);
         !turking num:constant_Number 'months' => C.addUnit('mon', num);
         !turking num:constant_Number 'years' => C.addUnit('year', num);
+        !turking num:constant_Number 'decades' => C.addUnit('decade', num);
+        !turking num:constant_Number 'centuries' => C.addUnit('century', num);
 
     }
 }
@@ -245,6 +255,8 @@ constant_Measure_m = {
         num:constant_Number 'in' => C.addUnit('in', num);
         num:constant_Number 'inches' => C.addUnit('in', num);
         num:constant_Number 'cm' => C.addUnit('cm', num);
+        num:constant_Number 'ly' => C.addUnit('ly', num);
+        num:constant_Number 'light-years' => C.addUnit('ly', num);
     }
 }
 


### PR DESCRIPTION
This PR adds constant templates needed for three new measurement units added in https://github.com/stanford-oval/thingtalk-units/pull/30 PR.