### PR TITLE
sentence-generator: introduce a new, faster sampling strategy

### DIFF
--- a/lib/dataset-tools/augmentation/replace_parameters.js
+++ b/lib/dataset-tools/augmentation/replace_parameters.js
@@ -329,7 +329,7 @@ export default class ParameterReplacer {
 
     _transformValue(sentenceValue, programValue, arg) {
         if (this._requotable)
-            return {sentenceValue, programValue};
+            return { sentenceValue, programValue };
 
         if (arg && arg.metadata.pluralize && coin(0.5, this._rng)) {
             const plural = this._paramLangPack.pluralize(sentenceValue);
@@ -449,12 +449,6 @@ export default class ParameterReplacer {
             if (!this._paramLangPack.isGoodSentence(sampled)) {
                 attempts -= 1;
                 continue;
-            }
-
-            if (arg && arg.metadata.pluralize && coin(0.5, this._rng)) {
-                const plural = this._paramLangPack.pluralize(sampled);
-                if (plural)
-                    return { sentenceValue: plural, programValue: sampled };
             }
 
             return this._transformValue(sampled, sampled, arg);

--- a/lib/dialogue-agent/dialogue_state_utils.js
+++ b/lib/dialogue-agent/dialogue_state_utils.js
@@ -114,8 +114,10 @@ function computePrediction(oldState, newState, forTarget) {
             if (!oldItem.equals(newItem)) {
                 console.log(oldItem.prettyprint());
                 console.log(newItem.prettyprint());
+                console.log(oldItem);
+                console.log(newItem);
+                throw new Error(`Items unexpectedly different in computing prediction`);
             }
-            assert(oldItem.equals(newItem));
         }
     }
 

--- a/lib/dialogue-agent/simulator/simulation_exec_environment.js
+++ b/lib/dialogue-agent/simulator/simulation_exec_environment.js
@@ -139,7 +139,7 @@ class ResultGenerator {
         if (reused !== undefined)
             return reused;
 
-        const newTime = new ThingTalk.Builtin.Time(randint(0, 23), randint(0, 59), 0);
+        const newTime = new ThingTalk.Builtin.Time(randint(0, 23, this._rng), randint(0, 59, this._rng), 0);
         this._constants.get('TIME').push(newTime);
         return newTime;
     }

--- a/lib/sentence-generator/generator.ts
+++ b/lib/sentence-generator/generator.ts
@@ -1552,7 +1552,16 @@ function expandRuleSample(charts : Charts,
                     continue outerloop;
 
                 const from = charts[depth-1][currentExpansion.index].sampled;
-                assert(from.length > 0);
+                if (from.length === 0) {
+                    // uh oh!
+                    console.log(`expand NT[${nonTermList[nonTermIndex]}] -> ${expansion.join(' ')}`);
+                    console.log(`pivotIdx = ${pivotIdx}`);
+                    console.log(`ltDSize =`, ltDSize);
+                    console.log(`leftCumProd =`, leftCumProd);
+                    console.log(`rightCumProd =`, rightCumProd);
+                    console.log(`pivotProbabilityCumsum =`, pivotProbabilityCumsum);
+                    throw new Error(`Unexpected empty chart for pivot`);
+                }
                 choices[i] = uniform(from, rng);
             } else {
                 if (!(currentExpansion instanceof NonTerminal)) {
@@ -1563,7 +1572,19 @@ function expandRuleSample(charts : Charts,
 
                     const chosenDepth = categoricalPrecomputed(ltDSize[i], maxdepth+1, rng);
                     const from = charts[chosenDepth][currentExpansion.index].sampled;
-                    assert(from.length > 0);
+                    if (from.length === 0) {
+                        // uh oh!
+                        console.log(`expand NT[${nonTermList[nonTermIndex]}] -> ${expansion.join(' ')}`);
+                        console.log(`pivotIdx = ${pivotIdx}`);
+                        console.log(`currentIdx = ${i}`);
+                        console.log(`maxdepth = ${maxdepth}`);
+                        console.log(`chosenDepth = ${chosenDepth}`);
+                        console.log(`ltDSize =`, ltDSize);
+                        console.log(`leftCumProd =`, leftCumProd);
+                        console.log(`rightCumProd =`, rightCumProd);
+                        console.log(`pivotProbabilityCumsum =`, pivotProbabilityCumsum);
+                        throw new Error(`Unexpected empty chart for non-pivot`);
+                    }
                     choices[i] = uniform(from, rng);
                 }
             }

--- a/lib/sentence-generator/generator.ts
+++ b/lib/sentence-generator/generator.ts
@@ -1667,6 +1667,8 @@ function expandRule(charts : Charts,
     if (actualGenSize + prunedGenSize === 0)
         return;
     const newEstimatedPruneFactor = actualGenSize / (actualGenSize + prunedGenSize);
+    if (options.debug >= LogLevel.INFO && newEstimatedPruneFactor < 0.2)
+        console.log(`expand NT[${nonTermList[nonTermIndex]}] -> ${expansion.join(' ')} : semantic function only accepted ${(newEstimatedPruneFactor*100).toFixed(1)}% of derivations`);
 
     const elapsed = Date.now() - now;
     if (options.debug >= LogLevel.INFO && elapsed >= 10000)

--- a/lib/utils/random.ts
+++ b/lib/utils/random.ts
@@ -18,6 +18,7 @@
 //
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
+import assert from 'assert';
 
 function choose<T>(from : T[], n : number, rng : () => number = Math.random) : T[] {
     if (n === 0)
@@ -49,10 +50,10 @@ function choose<T>(from : T[], n : number, rng : () => number = Math.random) : T
     return res;
 }
 
-function coin(prob : number, rng : () => number = Math.random) : boolean {
+function coin(prob : number, rng : () => number) : boolean {
     return rng() <= prob;
 }
-function uniform<T>(array : T[], rng : () => number = Math.random) : T {
+function uniform<T>(array : T[], rng : () => number) : T {
     return array[Math.floor(rng() * array.length)];
 }
 function categorical(weights : number[], rng : () => number = Math.random) : number {
@@ -60,14 +61,16 @@ function categorical(weights : number[], rng : () => number = Math.random) : num
     cumsum[0] = weights[0];
     for (let i = 1; i < weights.length; i++)
         cumsum[i] = cumsum[i-1] + weights[i];
-
-    const value = rng() * cumsum[cumsum.length-1];
-
-    for (let i = 0; i < weights.length; i++) {
+    return categoricalPrecomputed(cumsum, cumsum.length, rng);
+}
+export function categoricalPrecomputed(cumsum : number[], arraylength = cumsum.length, rng : () => number) : number {
+    assert(arraylength <= cumsum.length);
+    const value = rng() * cumsum[arraylength-1];
+    for (let i = 0; i < arraylength; i++) {
         if (value <= cumsum[i])
             return i;
     }
-    return cumsum.length-1;
+    return arraylength-1;
 }
 
 function swap<T>(array : T[], i : number, j : number) : void {

--- a/lib/utils/random.ts
+++ b/lib/utils/random.ts
@@ -56,19 +56,28 @@ function coin(prob : number, rng : () => number) : boolean {
 function uniform<T>(array : T[], rng : () => number) : T {
     return array[Math.floor(rng() * array.length)];
 }
-function categorical(weights : number[], rng : () => number = Math.random) : number {
+function categorical(weights : number[], rng : () => number) : number {
     const cumsum = new Array(weights.length);
     cumsum[0] = weights[0];
     for (let i = 1; i < weights.length; i++)
         cumsum[i] = cumsum[i-1] + weights[i];
     return categoricalPrecomputed(cumsum, cumsum.length, rng);
 }
+
 export function categoricalPrecomputed(cumsum : number[], arraylength = cumsum.length, rng : () => number) : number {
     assert(arraylength <= cumsum.length);
     const value = rng() * cumsum[arraylength-1];
     for (let i = 0; i < arraylength; i++) {
-        if (value <= cumsum[i])
+        // note: this must be < because in some rare cases the rng() will
+        // produce exactly 0, in which case with <= we'll return the first element
+        // in the array even if the probability is 0
+        // < is incorrect for the last element (when the rng() returns exactly 1)
+        // but we'll return the last element if no element is found
+        if (value < cumsum[i]) {
+            // the element we return must have positive probability
+            assert((i === 0 && cumsum[i] > 0) || (i > 0 && cumsum[i] - cumsum[i-1] > 0));
             return i;
+        }
     }
     return arraylength-1;
 }
@@ -80,14 +89,14 @@ function swap<T>(array : T[], i : number, j : number) : void {
 }
 
 // inplace array shuffle
-function shuffle<T>(array : T[], rng : () => number = Math.random) : void {
+function shuffle<T>(array : T[], rng : () => number) : void {
     for (let i = 0; i < array.length-1; i++) {
         const idx = Math.floor(rng() * (array.length - i));
         swap(array, i, i+idx);
     }
 }
 
-function randint(low : number, high : number, rng : () => number = Math.random) : number {
+function randint(low : number, high : number, rng : () => number) : number {
     return Math.round(low + (high - low) * rng());
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4027,7 +4027,7 @@
       }
     },
     "thingtalk": {
-      "version": "github:stanford-oval/thingtalk#538ba9928ffe2e7008ce1c089e357c7f21234462",
+      "version": "github:stanford-oval/thingtalk#d0a20f0915da5361c3a207235156e8e5e41da5f1",
       "from": "github:stanford-oval/thingtalk#next",
       "requires": {
         "byline": "^5.0.0",

--- a/test/unit/test_random.js
+++ b/test/unit/test_random.js
@@ -74,13 +74,107 @@ function testReservoirSampler(rng) {
     assert.deepStrictEqual(Array.from(sampler), [6, 9, 8]);
 }
 
+function testCategorical(rng) {
+    let weights = [1, 0, 1, 2];
+    let samples = [0, 0, 0, 0];
+
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categorical(weights, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+
+    assert.deepStrictEqual(samples, [ 2481, 0, 2498, 5021 ]);
+
+    weights = [0, 0, 0, 1];
+    samples = [0, 0, 0, 0];
+
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categorical(weights, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+
+    assert.deepStrictEqual(samples, [ 0, 0, 0, 10000 ]);
+
+    weights = [1, 0, 0, 0];
+    samples = [0, 0, 0, 0];
+
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categorical(weights, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+
+    assert.deepStrictEqual(samples, [ 10000, 0, 0, 0 ]);
+}
+
+function testCategoricalPrecomputed(rng) {
+    let cumsum = [1, 2, 3, 4];
+    let samples = [0, 0, 0, 0];
+
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categoricalPrecomputed(cumsum, cumsum.length, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+    assert.deepStrictEqual(samples, [ 2479, 2452, 2546, 2523 ]);
+
+    samples = [0, 0, 0, 0];
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categoricalPrecomputed(cumsum, cumsum.length-1, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+    assert.deepStrictEqual(samples, [ 3330, 3366, 3304, 0 ]);
+
+    cumsum = [0, 0, 0, 1];
+    samples = [0, 0, 0, 0];
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categoricalPrecomputed(cumsum, cumsum.length, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+    assert.deepStrictEqual(samples, [ 0, 0, 0, 10000 ]);
+
+    cumsum = [0, 0, 1, 1];
+    samples = [0, 0, 0, 0];
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categoricalPrecomputed(cumsum, cumsum.length, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+    assert.deepStrictEqual(samples, [ 0, 0, 10000, 0 ]);
+
+    cumsum = [0, 0, 1, 2];
+    samples = [0, 0, 0, 0];
+    for (let i = 0; i < 10000; i++) {
+        const sample = random.categoricalPrecomputed(cumsum, cumsum.length, rng);
+        assert(sample >= 0);
+        assert(sample <= 3);
+        samples[sample] += 1;
+    }
+    assert.deepStrictEqual(samples, [ 0, 0, 5045, 4955 ]);
+}
+
+
 async function main() {
     const rng = seedrandom.alea('test almond');
 
     await testChoice(rng);
     await testShuffle(rng);
     await testReservoirSampler(rng);
+    await testCategorical(rng);
+    await testCategoricalPrecomputed(rng);
 }
+
 export default main;
 if (!module.parent)
     main();


### PR DESCRIPTION
Our previous sampling strategy consisted of enumerating, for each template, all possible expansions of that template, and then
sampling a portion of those expansions to call the semantic function with. This is not efficient. Instead, we can sample directly one candidate expansion without enumerating, if we are careful with setting up the probabilities correctly.

It's worth noting that previously we were doing _sampling without replacement_. The new algorithm samples _with replacement_ for speed. Practically, I don't think it makes a difference in terms of the quality of the generated datasets.

In dialogues, this gave me a 40% increase in generation throughput (turns/sec) with a small pruning size. I expect with a large pruning size it will yield even higher gains.