### PR TITLE
Fix running the dialogue agent after building

### DIFF
--- a/lib/dialogue-agent/dialogue_policy.ts
+++ b/lib/dialogue-agent/dialogue_policy.ts
@@ -34,6 +34,18 @@ import type Conversation from './conversation';
 const MAX_DEPTH = 7;
 const TARGET_PRUNING_SIZES = [25, 50, 100];
 
+let TEMPLATE_FILE_PATH : string;
+try {
+    // try the path relative to our build location first (in dist/lib/dialogue-agent)
+    TEMPLATE_FILE_PATH = require.resolve('../../../languages-dist/thingtalk/en/dialogue.genie');
+} catch(e) {
+    if (e.code !== 'MODULE_NOT_FOUND')
+        throw e;
+    // if that fails, try the location relative to our source directory
+    // (in case we're running with ts-node)
+     TEMPLATE_FILE_PATH = require.resolve('../../languages-dist/thingtalk/en/dialogue.genie');
+}
+
 function arrayEqual<T>(a : T[], b : T[]) : boolean {
     if (a.length !== b.length)
         return false;
@@ -120,7 +132,7 @@ export default class DialoguePolicy {
             },
             rng: this._rng,
             locale: this._locale,
-            templateFiles: [require.resolve('../../languages/thingtalk/en/dialogue.genie')],
+            templateFiles: [TEMPLATE_FILE_PATH],
             targetLanguage: 'thingtalk',
             thingpediaClient: this._thingpedia,
             schemaRetriever: this._schemas,

--- a/lib/sentence-generator/compiler/index.ts
+++ b/lib/sentence-generator/compiler/index.ts
@@ -206,7 +206,10 @@ export async function importGenie(filename : string,
     // try loading compiled js first
     let target : 'js'|'ts' = 'js';
     try {
-        return (await import(filename + '.' + target)).default;
+        if (filename.endsWith('.js'))
+            return (await import(filename)).default;
+        else
+            return (await import(filename + '.' + target)).default;
     } catch(e) {
         if (e.code !== 'MODULE_NOT_FOUND')
             throw e;


### PR DESCRIPTION
If genie is run from the dist/ directory, the relative path to
the compiled templates is different.

Tests did not catch this because they use ts-node and run genie
from the source directory.