### PR TITLE
Fix starter code with BSD sed

### DIFF
--- a/starter/schemaorg/Makefile
+++ b/starter/schemaorg/Makefile
@@ -149,7 +149,7 @@ shared-parameter-datasets.tsv:
 	  download-string-values --manifest $@ --append-manifest -d shared-parameter-datasets
 
 %/parameter-datasets.tsv : %/schema.trimmed.tt %/data.json shared-parameter-datasets.tsv
-	sed 's|\tshared-parameter-datasets|\t../shared-parameter-datasets|g' shared-parameter-datasets.tsv > $@
+	sed -e "s|$(echo -e '\t')shared-parameter-datasets|$(echo -e '\t')../shared-parameter-datasets|g" shared-parameter-datasets.tsv > $@
 	$(genie) make-string-datasets --manifest $@.local -d $*/parameter-datasets --thingpedia $*/schema.trimmed.tt --data $*/data.json --class-name $($(*)_class_name) --dataset schemaorg
 	cat $@.local >> $@
 	rm $@.local

--- a/starter/wikidata/Makefile
+++ b/starter/wikidata/Makefile
@@ -154,7 +154,7 @@ shared-parameter-datasets.tsv:
 	  wget --no-verbose https://almond-static.stanford.edu/test-data/wikidata-parameter-datasets/$*.tar.xz ; \
 	  tar -C . -xvf $*.tar.xz ; \
 	else \
-	  sed 's|shared-parameter-datasets/|../shared-parameter-datasets/|g' shared-parameter-datasets.tsv > $@ ; \
+	  sed -e "s|$(echo -e '\t')shared-parameter-datasets|$(echo -e '\t')../shared-parameter-datasets|g" shared-parameter-datasets.tsv > $@ ; \
 	  $(genie) wikidata-make-string-datasets --manifest $@.local -d $*/parameter-datasets --thingpedia $*/wikidata.tt; \
 	  cat $@.local >> $@; \
 	  rm $@.local; \


### PR DESCRIPTION
BSD sed does not interpret backslash escapes the way GNU sed does.