### PR TITLE
PosParser for annotation extraction from paraphrase

### DIFF
--- a/lib/pos-parser/index.ts
+++ b/lib/pos-parser/index.ts
@@ -1,0 +1,122 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Silei Xu <silei@cs.stanford.edu>
+
+import { specialTokens, NFA, toNFA } from './nfa';
+
+// maximum length of the canonical (value excluded)
+const MAX_LENGTH = 5;
+
+const a = '( a | an | any | some | all | the | ε )';
+const that = '( that | which | who | ε )';
+const is = '( is | are | was | were )';
+const does = '( does | do | did )';
+const has = '( has | have | had )';
+const find = '( show me | find me | tell me | give me | find | search | get | search for | i want | i need | i would like )';
+const who = '( what $domain | which $domain | who | where )';
+const noun = '( NN | NNS | NNP | NNPS )';
+const verb = '( VBP | VBD | VBZ )';
+const passiveVerb = '( VBN | VBG | JJ )';
+const preposition = '( IN | TO )';
+
+const queryTemplates : Record<string, string[]> = {
+    'property': [
+        `${find} ${a} $domain with [ .* $value .* ${noun} ]`,
+        `${find} ${a} $domain ${that} ${has} [ .* $value .* ${noun} ]`,
+        `${who} ${has} [ .* $value .* ${noun} ]`
+    ],
+    'verb': [
+        `${find} ${a} $domain that [ ${verb} .* $value .* ]`,
+        `${who} ${verb} [ .* value .* ]`,
+    ],
+    'passive_verb': [
+        `${find} ${a} $domain [ ${passiveVerb} .* $value .* ]`,
+        `${find} ${a} $domain ${that} ${is} [ ${passiveVerb} .* $value .* ]`,
+        `${who} ${is} [ ${passiveVerb} .* $value .* ]`,
+        `who's [ ${passiveVerb} .* $value .* ]`
+    ],
+    'preposition': [
+        `${find} ${a} $domain [ ${preposition} .* $value .* ]`,
+        `${find} ${a} $domain ${that} ${is} [ ${preposition} .* $value .* ]`,
+        `${who} ${is} [ ${preposition} .* $value .* ]`,
+        `who's [ ${preposition} .* $value .* ]`
+    ],
+    'adjective' : [
+        `${find} ${a} [ .* $value .* ] $domain`
+    ],
+    'reverse_property' : [
+        `${find} ${a} [ .* ${noun} ]`,
+        `${who} ${is} [ .* ${noun} ]`,
+        `who's [ .* ${noun} ]`
+    ],
+    'reverse_verb_projection': [
+        `${who} ${does} $value [ .* ]`
+    ]
+};
+
+interface Annotation {
+    pos : string,
+    canonical : string
+}
+
+// tokenize template string (basically add spaces around special characters)
+function tokenize(template : string) {
+    const chars : string[] = [];
+    let lastChar = ' ';
+    for (const char of template) {
+        if (char === ' ' && lastChar === ' ')
+            continue;
+
+        if (specialTokens.includes(char) && lastChar !== ' ')
+            chars.push(' ');
+        else if (specialTokens.includes(lastChar) && char !== ' ')
+            chars.push(' ');
+
+        chars.push(char);
+        lastChar = char;
+    }
+    return chars.join('').split(' ');
+}
+
+export default class PosParser {
+    private readonly queryTemplates : Record<string, NFA[]>;
+
+    constructor() {
+        this.queryTemplates = {};
+        for (const pos in queryTemplates) {
+            this.queryTemplates[pos] = [];
+            for (const template of queryTemplates[pos])
+                this.queryTemplates[pos].push(toNFA(tokenize(template)));
+        }
+    }
+
+    match(type : 'query'|'action', utterance : string, domainCanonicals : string[], value : string) : Annotation|null {
+        if (type === 'query') {
+            for (const pos in this.queryTemplates) {
+                for (const template of this.queryTemplates[pos]) {
+                    const match = template.match(utterance, domainCanonicals, value);
+                    if (match && match.split(' ').length - 1 < MAX_LENGTH)
+                        return { pos, canonical: match };
+                }
+            }
+        }
+        return null;
+    }
+}
+

--- a/lib/pos-parser/index.ts
+++ b/lib/pos-parser/index.ts
@@ -39,7 +39,7 @@ const queryTemplates : Record<string, string[]> = {
     'property': [
         `${find} ${a} $domain with [ .* $value .* ${noun} ]`,
         `${find} ${a} $domain ${that} ${has} [ .* $value .* ${noun} ]`,
-        `${who} ${has} [ .* $value .* ${noun} ]`
+        `${who} ${has} [ .* $value .* ]`
     ],
     'passive_verb': [
         `${find} ${a} $domain [ ${passiveVerb} .* $value .* ]`,
@@ -53,23 +53,20 @@ const queryTemplates : Record<string, string[]> = {
         `${who} ${is} [ ${preposition} .* $value .* ]`,
         `who's [ ${preposition} .* $value .* ]`
     ],
-    // `is`, `does` are also verbs, so we try match templates in the following order
-    // (1) passive verb and preposition
-    // (2) reverse verb (e.g., who does $value $verb?)
-    // (3) regular verb
     'verb': [
         `${who} ${does} [ $value .* ]`, // some verbs are tagged as noun, so no ${verb} requirement after $value
         `${find} ${a} $domain ${that} [ ${verb} .* $value .* ]`,
         `${who} [ ${verb} .* $value .* ]`,
     ],
-    'adjective' : [
-        `${find} ${a} [ .* $value .* ] $domain`
-    ],
     'reverse_property' : [
         `${find} ${a} [ .* ${noun} ]`,
         `${who} ${is} [ .* ${noun} ]`,
         `who's [ .* ${noun} ]`
-    ]
+    ],
+    'adjective' : [
+        `${find} ${a} [ .* $value .* ] $domain`,
+        `${who} ${is} [ .* $value .* ]`
+    ],
 };
 
 interface Annotation {

--- a/lib/pos-parser/infix-to-postfix.ts
+++ b/lib/pos-parser/infix-to-postfix.ts
@@ -33,6 +33,8 @@ const priorityMap : Record<string, number> = {
     '|': 0,
     '_': 1,
     '*': 2,
+    '[': 0,
+    ']': 0
 };
 
 function top(stack : string[]) : string|null {
@@ -47,9 +49,9 @@ function addConcatenationOp(template : string[]) : string[] {
         const current = template[i];
         const next = template[i+1];
         added.push(current);
-        if (['|', '('].includes(current))
+        if (['|', '(', '['].includes(current))
             continue;
-        if (specialTokens.includes(next) && next !== '(' && next !== '.')
+        if (['|', '*', ']', ')'].includes(next))
             continue;
         added.push('_');
     }
@@ -68,11 +70,14 @@ function infixToPostfix(template : string[]) : string[] {
             while (top(stack) !== '(')
                 postfix.push(stack.pop()!);
             stack.pop();
-        } else if (specialTokens.includes(token) && token !== '.' && token !== '[' && token !== ']') {
-            while (top(stack)! in priorityMap
+        } else if (specialTokens.includes(token) && !['.', '['].includes(token)) {
+            while (stack.length > 0 && top(stack)! in priorityMap
                 && priorityMap[top(stack)!] >= priorityMap[token])
                 postfix.push(stack.pop()!);
-            stack.push(token);
+            if (token === ']')
+                postfix.push(token);
+            else
+                stack.push(token);
         } else {
             postfix.push(token);
         }

--- a/lib/pos-parser/infix-to-postfix.ts
+++ b/lib/pos-parser/infix-to-postfix.ts
@@ -86,5 +86,6 @@ function infixToPostfix(template : string[]) : string[] {
 
 
 export {
+    specialTokens,
     infixToPostfix
 };

--- a/lib/pos-parser/infix-to-postfix.ts
+++ b/lib/pos-parser/infix-to-postfix.ts
@@ -1,0 +1,88 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Silei Xu <silei@cs.stanford.edu>
+
+const specialTokens = [
+    '_', // concatenation operator
+    '*', // closure operator
+    '|', // union operator
+    '.', // wildcard character
+    '(',
+    ')'
+];
+
+const priorityMap : Record<string, number> = {
+    '|': 0,
+    '_': 1,
+    '*': 2,
+};
+
+function top(stack : string[]) : string|null {
+    if (stack.length)
+        return stack[stack.length - 1];
+    return null;
+}
+
+function addConcatenationOp(template : string[]) : string[] {
+    const added = [];
+    for (let i = 0; i < template.length - 1; i++) {
+        const current = template[i];
+        const next = template[i+1];
+        added.push(current);
+        if (['|', '('].includes(current))
+            continue;
+        if (specialTokens.includes(next) && next !== '(')
+            continue;
+        added.push('_');
+    }
+    added.push(template[template.length - 1]);
+    return added;
+}
+
+function infixToPostfix(template : string[]) : string[] {
+    const infix : string[] = addConcatenationOp(template);
+    const postfix : string[] = [];
+    const stack : string[] = [];
+    for (const token of infix) {
+        if (token === '(') {
+            stack.push(token);
+        } else if (token === ')') {
+            while (top(stack) !== '(')
+                postfix.push(stack.pop()!);
+            stack.pop();
+        } else if (specialTokens.includes(token)) {
+            while (top(stack)! in priorityMap
+                && priorityMap[top(stack)!] >= priorityMap[token])
+                postfix.push(stack.pop()!);
+            stack.push(token);
+        } else {
+            postfix.push(token);
+        }
+    }
+
+    while (stack.length)
+        postfix.push(stack.pop()!);
+
+    return postfix;
+}
+
+
+export {
+    infixToPostfix
+};

--- a/lib/pos-parser/infix-to-postfix.ts
+++ b/lib/pos-parser/infix-to-postfix.ts
@@ -23,6 +23,8 @@ const specialTokens = [
     '*', // closure operator
     '|', // union operator
     '.', // wildcard character
+    '[', // capturing group
+    ']', // capturing group
     '(',
     ')'
 ];
@@ -66,7 +68,7 @@ function infixToPostfix(template : string[]) : string[] {
             while (top(stack) !== '(')
                 postfix.push(stack.pop()!);
             stack.pop();
-        } else if (specialTokens.includes(token) && token !== '.') {
+        } else if (specialTokens.includes(token) && token !== '.' && token !== '[' && token !== ']') {
             while (top(stack)! in priorityMap
                 && priorityMap[top(stack)!] >= priorityMap[token])
                 postfix.push(stack.pop()!);

--- a/lib/pos-parser/infix-to-postfix.ts
+++ b/lib/pos-parser/infix-to-postfix.ts
@@ -47,7 +47,7 @@ function addConcatenationOp(template : string[]) : string[] {
         added.push(current);
         if (['|', '('].includes(current))
             continue;
-        if (specialTokens.includes(next) && next !== '(')
+        if (specialTokens.includes(next) && next !== '(' && next !== '.')
             continue;
         added.push('_');
     }
@@ -66,7 +66,7 @@ function infixToPostfix(template : string[]) : string[] {
             while (top(stack) !== '(')
                 postfix.push(stack.pop()!);
             stack.pop();
-        } else if (specialTokens.includes(token)) {
+        } else if (specialTokens.includes(token) && token !== '.') {
             while (top(stack)! in priorityMap
                 && priorityMap[top(stack)!] >= priorityMap[token])
                 postfix.push(stack.pop()!);

--- a/lib/pos-parser/nfa.ts
+++ b/lib/pos-parser/nfa.ts
@@ -103,9 +103,14 @@ export class NFA {
     }
 
     private preprocess(utterance : string, domainCanonicals : string[], value : string) : Token[] {
+        // remove punctuation at the end
+        utterance = utterance.replace(/[.,?!;]\s*$/g, '');
+
         const tokenized : TokenizerResult = this.tokenizer.tokenize(utterance);
         const tokens = tokenized.rawTokens;
         const posTags : Array<string|undefined> = this.languagePack.posTag(tokenized.rawTokens);
+
+
 
         // replace value with special token $value
         if (arrayMatchCount(tokens, value.split(' ')) !== 1)
@@ -116,10 +121,17 @@ export class NFA {
         tokens[valueIndex] = '$value';
         tokens.splice(valueIndex, value.split(' ').length - 1);
 
+        // expand domain canonicals to include plurals
+        const domainCanonicalsExpanded : Set<string> = new Set();
+        for (const canonical of domainCanonicals) {
+            domainCanonicalsExpanded.add(canonical);
+            domainCanonicalsExpanded.add(this.languagePack.pluralize(canonical));
+        }
+
         // replace domain canonical with special token $domain
         let domainCanonical : string;
         let matchCount = 0;
-        for (const canonical of domainCanonicals) {
+        for (const canonical of domainCanonicalsExpanded) {
             const count : number = arrayMatchCount(tokens, canonical.split(' '));
             if (count > 0)
                 domainCanonical = canonical;

--- a/lib/pos-parser/nfa.ts
+++ b/lib/pos-parser/nfa.ts
@@ -19,7 +19,7 @@
 // Author: Silei Xu <silei@cs.stanford.edu>
 
 import assert from "assert";
-import { infixToPostfix } from "./infix-to-postfix";
+import { infixToPostfix, specialTokens } from "./infix-to-postfix";
 
 import EnglishLanguagePack from '../../lib/i18n/american-english';
 import EnglishTokenizer from '../../lib/i18n/tokenizer/english';
@@ -286,5 +286,6 @@ function toNFA(template : string[]) : NFA {
 }
 
 export {
+    specialTokens,
     toNFA
 };

--- a/lib/pos-parser/nfa.ts
+++ b/lib/pos-parser/nfa.ts
@@ -1,0 +1,160 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Silei Xu <silei@cs.stanford.edu>
+
+import assert from "assert";
+import { infixToPostfix } from "./infix-to-postfix";
+
+class State {
+    isEnd : boolean;
+    transitions : Record<string, State[]>;
+
+    constructor(isEnd = false) {
+        this.isEnd = isEnd;
+        this.transitions = {};
+    }
+
+    addTransition(token : string, to : State) {
+        if (this.isEnd) {
+            // order matters: if it's a self-loop, `isEnd` remains true
+            this.isEnd = false;
+            to.isEnd = true;
+        }
+        if (token in this.transitions)
+            this.transitions[token].push(to);
+        else
+            this.transitions[token] = [to];
+    }
+}
+
+export class NFA {
+    start : State;
+    end : State;
+
+    constructor(start ?: State, end ?: State) {
+        this.start = start || new State(false);
+        this.end = end || new State(true);
+    }
+
+    match(expression : string[]) : boolean {
+        let current : State[] = NFA._getClosure(this.start);
+
+        for (const token of expression) {
+            if (current.length === 0)
+                return false;
+
+            const next : Set<State> = new Set();
+            for (const state of current) {
+                if (token in state.transitions) {
+                    for (const nextState of state.transitions[token])
+                        NFA._getClosure(nextState).forEach(next.add, next);
+                }
+            }
+            current = Array.from(next);
+        }
+
+        return current.some((state : State) => state.isEnd);
+    }
+
+    static _getClosure(state : State) : State[] {
+        const visited = [state];
+        const stack = [state];
+        while (stack.length) {
+            const state : State = stack.pop()!;
+            if ('ε' in state.transitions) {
+                for (const s of state.transitions['ε']) {
+                    if (!visited.includes(s)) {
+                        visited.push(s);
+                        stack.push(s);
+                    }
+                }
+            }
+        }
+        return visited;
+    }
+}
+
+function edge(token : string) : NFA {
+    const start = new State(false);
+    const end = new State(true);
+
+    start.addTransition(token, end);
+    return new NFA(start, end);
+}
+
+function union(a : NFA, b : NFA) : NFA {
+    const start = new State(false);
+    const end = new State(true);
+
+    start.addTransition('ε', a.start);
+    start.addTransition('ε', b.start);
+
+    a.end.addTransition('ε', end);
+    b.end.addTransition('ε', end);
+
+    return new NFA(start, end);
+}
+
+
+function concat(a : NFA, b : NFA) : NFA {
+    a.end.addTransition('ε', b.start);
+    return new NFA(a.start, b.end);
+}
+
+function closure(a : NFA) : NFA {
+    const start = new State(false);
+    const end = new State(true);
+
+    start.addTransition('ε', a.start);
+    start.addTransition('ε', a.end);
+
+    a.end.addTransition('ε', a.start);
+    a.end.addTransition('ε', end);
+
+    return new NFA(start, end);
+}
+
+function toNFA(template : string[]) {
+    template = infixToPostfix(template);
+    const stack : NFA[] = [];
+
+    for (const token of template) {
+        if (token === '_') { // concat
+            const b : NFA = stack.pop()!;
+            const a : NFA = stack.pop()!;
+            stack.push(concat(a, b));
+        } else if (token === '|') { // union
+            const b : NFA = stack.pop()!;
+            const a : NFA = stack.pop()!;
+            stack.push(union(a, b));
+        } else if (token === '*') { // closure
+            const a : NFA = stack.pop()!;
+            stack.push(closure(a));
+        } else {
+            stack.push(edge(token));
+        }
+    }
+
+    assert(stack.length === 1);
+    return stack.pop();
+}
+
+export {
+    toNFA
+};

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -70,6 +70,6 @@ do_test([
     ('./test_trie'),
     //('./test_wikidata_utils'),
     ('./test_wikidata_utils'),
-    ('./test_infix_to_suffix'),
+    ('./test_infix_to_postfix'),
     ('./test_pos_nfa')
 ]);

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -69,4 +69,7 @@ do_test([
     ('./test_timers'),
     ('./test_trie'),
     //('./test_wikidata_utils'),
+    ('./test_wikidata_utils'),
+    ('./test_infix_to_suffix'),
+    ('./test_pos_nfa')
 ]);

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -40,6 +40,7 @@ async function do_test(array) {
 
 // test lib scripts
 do_test([
+    ('./test_bart_canonical_extractor'),
     ('./test_array_set'),
     ('./test_augment'),
     ('./test_bart_canonical_extractor'),

--- a/test/unit/test_bart_canonical_extractor.js
+++ b/test/unit/test_bart_canonical_extractor.js
@@ -100,9 +100,9 @@ function main() {
     const extractor = new AnnotationExtractor(null, [], null, {});
 
     let anyFailed = false;
-    for (let [origin, paraphrase, value, query_canonical, expected] of TEST_CASES) {
+    for (let [, paraphrase, value, query_canonical, expected] of TEST_CASES) {
         const canonical = {};
-        extractor._extractOneCanonical(canonical, origin, paraphrase, value, query_canonical);
+        extractor._extractOneCanonical(canonical, paraphrase, value, query_canonical);
         try {
             assert.deepStrictEqual(canonical, expected);
         } catch(e) {

--- a/test/unit/test_infix_to_postfix.js
+++ b/test/unit/test_infix_to_postfix.js
@@ -1,0 +1,41 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Silei Xu <silei@cs.stanford.edu>
+
+import assert from 'assert';
+import { infixToPostfix } from '../../lib/pos-parser/infix-to-postfix';
+
+const TEST_CASES = [
+    ['a b', 'a b _'],
+    ['a * b', 'a * b _'],
+    ['a * | b c', 'a * b c _ |'],
+    ['( a * | b ) c', 'a * b | c _']
+];
+
+function main() {
+    for (const [infix, expectedPostfix] of TEST_CASES) {
+        const postfix = infixToPostfix(infix.split(' '));
+        assert.strictEqual(postfix.join(' '), expectedPostfix);
+    }
+}
+
+export default main;
+if (require.main === module)
+    main();
+

--- a/test/unit/test_infix_to_postfix.js
+++ b/test/unit/test_infix_to_postfix.js
@@ -22,12 +22,19 @@ import assert from 'assert';
 import { infixToPostfix } from '../../lib/pos-parser/infix-to-postfix';
 
 const TEST_CASES = [
+    // basics (concat, closure, union)
     ['a b', 'a b _'],
     ['a * b', 'a * b _'],
     ['a * | b c', 'a * b c _ |'],
     ['( a * | b ) c', 'a * b | c _'],
     ['a b *', 'a b * _'],
-    ['a . *', 'a . * _']
+
+    // wild card
+    ['a . *', 'a . * _'],
+
+    // capturing group
+    ['a [ b ]', 'a [ b ] _'],
+    ['a [ . * c ]', 'a [ . * _ c ] _']
 ];
 
 function main() {

--- a/test/unit/test_infix_to_postfix.js
+++ b/test/unit/test_infix_to_postfix.js
@@ -25,7 +25,9 @@ const TEST_CASES = [
     ['a b', 'a b _'],
     ['a * b', 'a * b _'],
     ['a * | b c', 'a * b c _ |'],
-    ['( a * | b ) c', 'a * b | c _']
+    ['( a * | b ) c', 'a * b | c _'],
+    ['a b *', 'a b * _'],
+    ['a . *', 'a . * _']
 ];
 
 function main() {

--- a/test/unit/test_infix_to_postfix.js
+++ b/test/unit/test_infix_to_postfix.js
@@ -23,6 +23,7 @@ import { infixToPostfix } from '../../lib/pos-parser/infix-to-postfix';
 
 const TEST_CASES = [
     // basics (concat, closure, union)
+    ['a', 'a'],
     ['a b', 'a b _'],
     ['a * b', 'a * b _'],
     ['a * | b c', 'a * b c _ |'],
@@ -33,8 +34,13 @@ const TEST_CASES = [
     ['a . *', 'a . * _'],
 
     // capturing group
-    ['a [ b ]', 'a [ b ] _'],
-    ['a [ . * c ]', 'a [ . * _ c ] _']
+    ['a [ b ]', 'a [ b _ ]'],
+    ['a [ . * c ]', 'a [ . * _ c _ ]'],
+    ['[ a ]', '[ a ]'],
+    ['. * [ a ]', '. * [ a _ ]'],
+    ['. * [ a ] . *', '. * [ a _ ] . * _'],
+    ['[ . * ] a', '[ . * ] a _'],
+    ['[ . * a ]', '[ . * a _ ]']
 ];
 
 function main() {

--- a/test/unit/test_pos_nfa.js
+++ b/test/unit/test_pos_nfa.js
@@ -23,24 +23,29 @@ import { toNFA } from '../../lib/pos-parser/nfa';
 
 const TEST_CASES = [
     [
-        '( show me | find me | find | search for ) a $value $domain', ['restaurant', 'diner'], 'chinese',
-        ['Show me a Chinese restaurant', 'search for a Chinese diner'],
-        ['search me a Chinese restaurant']
+        '( show me | find me | find | search for ) a [ $value ] $domain', ['restaurant', 'diner'], 'chinese',
+        [
+            ['Show me a Chinese restaurant', '$value'],
+            ['search for a Chinese diner', '$value'],
+            ['search me a Chinese restaurant', null],
+        ]
     ],
     [
-        '( show me | find me | find | search for ) a $domain that ( VBP | VBD | VBZ ) . * $value . *', ['restaurant', 'diner'], 'chinese',
-        ['Show me a restaurant that serves Chinese food', 'search for a diner that serve good traditional Chinese style food'],
-        ['Show me a restaurant that Chinese food is served']
+        '( show me | find me | find | search for ) a $domain that [ ( VBP | VBD | VBZ ) . * $value . * ]', ['restaurant', 'diner'], 'chinese',
+        [
+            ['Show me a restaurant that serves Chinese food', 'serves $value food'],
+            ['search for a diner that serves good traditional Chinese style food', 'serves good traditional $value style food'],
+            ['Show me a restaurant that Chinese food is served', null],
+        ]
     ]
 ];
 
 function main() {
-    for (const [template, domainCanonicals, value, matchExamples, unmatchExamples] of TEST_CASES) {
+    for (const [template, domainCanonicals, value, examples] of TEST_CASES) {
         const nfa = toNFA(template.split(' '));
-        for (const example of matchExamples)
-            assert(nfa.match(example, domainCanonicals, value));
-        for (const example of unmatchExamples)
-            assert(!nfa.match(example, domainCanonicals, value));
+        for (const [utterance, match] of examples)
+            //console.log(utterance, nfa.match(utterance, domainCanonicals, value));
+            assert.strictEqual(match, nfa.match(utterance, domainCanonicals, value));
     }
 }
 

--- a/test/unit/test_pos_nfa.js
+++ b/test/unit/test_pos_nfa.js
@@ -23,7 +23,7 @@ import { toNFA } from '../../lib/pos-parser/nfa';
 
 const TEST_CASES = [
     [
-        '( show me | find me | find | search for ) ( a | ε ) [ $value ] $domain', ['restaurant', 'diner'], 'chinese',
+        '( show me | find me | find | search for ) ( a | ε ) [ . * $value . * ] $domain', ['restaurant', 'diner'], 'chinese',
         [
             ['Show me a Chinese restaurant', '$value'],
             ['search for a Chinese diner', '$value'],
@@ -45,8 +45,8 @@ const TEST_CASES = [
 function main() {
     for (const [template, domainCanonicals, value, examples] of TEST_CASES) {
         const nfa = toNFA(template.split(' '));
-        for (const [utterance, match] of examples)
-            assert.strictEqual(match, nfa.match(utterance, domainCanonicals, value));
+        for (const [utterance, expectedMatch] of examples)
+            assert.strictEqual(nfa.match(utterance, domainCanonicals, value), expectedMatch);
     }
 }
 

--- a/test/unit/test_pos_nfa.js
+++ b/test/unit/test_pos_nfa.js
@@ -1,0 +1,42 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Silei Xu <silei@cs.stanford.edu>
+
+import assert from 'assert';
+import { toNFA } from '../../lib/pos-parser/nfa';
+
+const TEST_CASES = [
+    ['a | b', ['a', 'b'], ['ab', '']],
+    ['a * | b c ( d | f )', ['a a', 'b c d'], ['a c d', 'b c d f']]
+];
+
+function main() {
+    for (const [template, matchExamples, unmatchExamples] of TEST_CASES) {
+        const nfa = toNFA(template.split(' '));
+        for (const example of matchExamples)
+            assert(nfa.match(example.split(' ')));
+        for (const example of unmatchExamples)
+            assert(!nfa.match(example.split(' ')));
+    }
+}
+
+export default main;
+if (require.main === module)
+    main();
+

--- a/test/unit/test_pos_nfa.js
+++ b/test/unit/test_pos_nfa.js
@@ -23,18 +23,20 @@ import { toNFA } from '../../lib/pos-parser/nfa';
 
 const TEST_CASES = [
     [
-        '( show me | find me | find | search for ) a [ $value ] $domain', ['restaurant', 'diner'], 'chinese',
+        '( show me | find me | find | search for ) ( a | ε ) [ $value ] $domain', ['restaurant', 'diner'], 'chinese',
         [
             ['Show me a Chinese restaurant', '$value'],
             ['search for a Chinese diner', '$value'],
+            ['find me Chinese restaurants', '$value'],
             ['search me a Chinese restaurant', null],
         ]
     ],
     [
-        '( show me | find me | find | search for ) a $domain that [ ( VBP | VBD | VBZ ) . * $value . * ]', ['restaurant', 'diner'], 'chinese',
+        '( show me | find me | find | search for ) ( a | ε ) $domain that [ ( VBP | VBD | VBZ ) . * $value . * ]', ['restaurant', 'diner'], 'chinese',
         [
             ['Show me a restaurant that serves Chinese food', 'serves $value food'],
             ['search for a diner that serves good traditional Chinese style food', 'serves good traditional $value style food'],
+            ['find me diners that serve chinese dishes.', 'serve $value dishes'],
             ['Show me a restaurant that Chinese food is served', null],
         ]
     ]
@@ -44,7 +46,6 @@ function main() {
     for (const [template, domainCanonicals, value, examples] of TEST_CASES) {
         const nfa = toNFA(template.split(' '));
         for (const [utterance, match] of examples)
-            //console.log(utterance, nfa.match(utterance, domainCanonicals, value));
             assert.strictEqual(match, nfa.match(utterance, domainCanonicals, value));
     }
 }

--- a/test/unit/test_pos_nfa.js
+++ b/test/unit/test_pos_nfa.js
@@ -22,17 +22,25 @@ import assert from 'assert';
 import { toNFA } from '../../lib/pos-parser/nfa';
 
 const TEST_CASES = [
-    ['a | b', ['a', 'b'], ['ab', '']],
-    ['a * | b c ( d | f )', ['a a', 'b c d'], ['a c d', 'b c d f']]
+    [
+        '( show me | find me | find | search for ) a $value $domain', ['restaurant', 'diner'], 'chinese',
+        ['Show me a Chinese restaurant', 'search for a Chinese diner'],
+        ['search me a Chinese restaurant']
+    ],
+    [
+        '( show me | find me | find | search for ) a $domain that ( VBP | VBD | VBZ ) . * $value . *', ['restaurant', 'diner'], 'chinese',
+        ['Show me a restaurant that serves Chinese food', 'search for a diner that serve good traditional Chinese style food'],
+        ['Show me a restaurant that Chinese food is served']
+    ]
 ];
 
 function main() {
-    for (const [template, matchExamples, unmatchExamples] of TEST_CASES) {
+    for (const [template, domainCanonicals, value, matchExamples, unmatchExamples] of TEST_CASES) {
         const nfa = toNFA(template.split(' '));
         for (const example of matchExamples)
-            assert(nfa.match(example.split(' ')));
+            assert(nfa.match(example, domainCanonicals, value));
         for (const example of unmatchExamples)
-            assert(!nfa.match(example.split(' ')));
+            assert(!nfa.match(example, domainCanonicals, value));
     }
 }
 

--- a/test/unit/test_wikidata_utils.js
+++ b/test/unit/test_wikidata_utils.js
@@ -33,9 +33,7 @@ const TEST_CASES_PROPERTY_LABELS = [
 
 const TEST_CASES_PROPERTY_LIST = [
     ['Q5', ['P18', 'P19', 'P20', 'P21', 'P3373']],
-    ['Q515', ['P17', 'P18', 'P31', 'P41', 'P47', 'P4290']
-
-    ]
+    ['Q515', ['P17', 'P18', 'P31', 'P41', 'P47']]
 ];
 
 async function main() {

--- a/tool/autoqa/lib/canonical-extractor.js
+++ b/tool/autoqa/lib/canonical-extractor.js
@@ -25,17 +25,8 @@ import * as util from 'util';
 import * as child_process from 'child_process';
 import stemmer from 'stemmer';
 
-import EnglishLanguagePack from '../../../lib/i18n/american-english';
-
-const VALUE_MAP = {
-    "1": ["one"],
-    "2": ["two"],
-    "3": ["three"],
-    "4": ["four"],
-    "feb 14 2017": ["february 14 2017", "february 14, 2017", "feb 14, 2017", "14 february 2017", "14 february, 2017", "14 feb 2017", "14 feb, 2017"],
-    "may 4th, 2016": ["may 4 2016", "may 4, 2016", "may 4th 2016", "4th may 2016", "4th may, 2016", "4 may 2016", "4 may, 2016"],
-    "august 2nd 2017": ["august 2, 2017", "august 2 2017", "august 2nd, 2017", "2 august 2017", "2nd august 2017", "2 august, 2017", "2nd august, 2017"]
-};
+import PosParser from '../../../lib/pos-parser';
+import EnglishTokenizer from '../../../lib/i18n/tokenizer/english';
 
 export default class AnnotationExtractor {
     constructor(klass, queries, model, options) {
@@ -43,7 +34,8 @@ export default class AnnotationExtractor {
         this.model = model;
         this.queries = queries;
         this.options = options;
-        this._langPack = new EnglishLanguagePack();
+        this.parser = new PosParser();
+        this.tokenizer = new EnglishTokenizer();
 
         this._input = [];
         this._output = [];
@@ -290,125 +282,17 @@ export default class AnnotationExtractor {
         }
 
         for (let paraphrase of paraphrases)
-            this._extractOneCanonical(canonical, origin, paraphrase, value, query_canonical);
+            this._extractOneCanonical(canonical, paraphrase, value, query_canonical);
     }
 
-    _hasValue(paraphrase, value) {
-        // find exact match
-        if (paraphrase.includes(value))
-            return value;
-
-        // find similar
-        if (value in VALUE_MAP) {
-            for (let alternative of VALUE_MAP[value]) {
-                if (paraphrase.includes(alternative))
-                    return alternative;
-            }
-        }
-
-        const pluralized = this._langPack.pluralize(value);
-        if (paraphrase.includes(pluralized))
-            return pluralized;
-
-        return false;
-    }
-
-    _extractOneCanonical(canonical, origin, paraphrase, value, query_canonical) {
-        origin = origin.toLowerCase();
+    _extractOneCanonical(canonical, paraphrase, value, query_canonical) {
         paraphrase = paraphrase.toLowerCase();
-        value = value.toLowerCase();
-        value = this._hasValue(paraphrase, value);
+        value = this.tokenizer.tokenize(value).tokens.join(' ');
 
-        if (!value)
-            return;
-
-        if (paraphrase.endsWith('.') || paraphrase.endsWith('?') || paraphrase.endsWith('!'))
-            paraphrase = paraphrase.slice(0, -1);
-
-        const pluralized_query_canonical = this._langPack.pluralize(query_canonical);
-        let tags = this._langPack.posTag(paraphrase.split(' '));
-
-        let prefixes = [];
-        if (origin.startsWith('who ')) {
-            prefixes.push('who ');
-            prefixes.push('who\'s ');
-        } if (origin.startsWith('which ')) {
-            let standard_prefix = origin.slice(0, origin.indexOf(query_canonical) + query_canonical.length + 1);
-            prefixes.push(standard_prefix);
-            prefixes.push(standard_prefix.replace('which ', 'what '));
-            prefixes.push(standard_prefix.replace(query_canonical, pluralized_query_canonical));
-            prefixes.push(standard_prefix.replace(query_canonical, pluralized_query_canonical).replace('which ', 'what '));
-        } else {
-            let standard_prefix = origin.slice(0, origin.indexOf(query_canonical) + query_canonical.length + 1);
-            prefixes.push(standard_prefix);
-            let to_replace = origin.includes(`a ${query_canonical}`) ? `a ${query_canonical}` : query_canonical;
-            const query_canonical_alternatives = [
-                `${pluralized_query_canonical}`,
-                `some ${pluralized_query_canonical}`,
-                `all ${pluralized_query_canonical}`,
-                `any ${query_canonical}`,
-                `any ${pluralized_query_canonical}`,
-                `an ${query_canonical}`,
-                `the ${query_canonical}`
-            ];
-            for (let alternative of query_canonical_alternatives)
-                prefixes.push(standard_prefix.replace(to_replace, alternative));
-        }
-
-        if (paraphrase.startsWith('show me ') && paraphrase.endsWith(query_canonical)) {
-            const clause = paraphrase.slice('show me '.length, -query_canonical.length - 1);
-            if ((clause.startsWith('a ') || clause.startsWith('an ') || clause.startsWith('the ')) && clause.split(' ').length <= 3) {
-                canonical['adjective'] = canonical['adjective'] || [];
-                canonical['adjective'].push(clause.slice(clause.indexOf(' ') + 1).replace(value, '#'));
-            }
-            return;
-        }
-
-        for (let prefix of new Set(prefixes)) {
-            if (!paraphrase.startsWith(prefix))
-                continue;
-
-            let clause = paraphrase.slice(prefix.length);
-            let length = prefix.trim().split(' ').length;
-
-            if (prefix === 'who\'s'
-                || clause.startsWith('is ') || clause.startsWith('are ')
-                || clause.startsWith('was ') || clause.startsWith('were ')) {
-                if (clause.startsWith('is ') || clause.startsWith('are ')
-                    || clause.startsWith('was ') || clause.startsWith('are ')) {
-                    clause = clause.slice(clause.indexOf(' ') + 1);
-                    length += 1;
-                }
-                if ((clause.startsWith('a ') || clause.startsWith('an ') || clause.startsWith('the ')) &&
-                    ['NN', 'NNS', 'NNP', 'NNPS'].includes(tags[length + 1])) {
-                    canonical['reverse_property'] = canonical['reverse_property'] || [];
-                    canonical['reverse_property'].push(clause.replace(value, '#'));
-                } else if (['VBN', 'VBG', 'JJ'].includes(tags[length])) {
-                    canonical['passive_verb'] = canonical['passive_verb'] || [];
-                    canonical['passive_verb'].push(clause.replace(value, '#'));
-                } else if (['IN', 'TO'].includes(tags[length])) {
-                    canonical['preposition'] = canonical['preposition'] || [];
-                    canonical['preposition'].push(clause.replace(value, '#'));
-                }
-            } else if (clause.startsWith('with ') || clause.startsWith('has ') || clause.startsWith('have ')) {
-                canonical['property'] = canonical['property'] || [];
-                canonical['property'].push(clause.slice(clause.indexOf(' ') + 1).replace(value, '#'));
-            } else if ((clause.startsWith('that ') || clause.startsWith('who ')) && ['VBP', 'VBZ', 'VBD'].includes(tags[length + 1])) {
-                canonical['verb'] = canonical['verb'] || [];
-                canonical['verb'].push(clause.slice(clause.indexOf(' ') + 1).replace(value, '#'));
-            } else if ((clause.startsWith('do ') || clause.startsWith(`does ${value}`) || clause.startsWith(`did ${value}`))) {
-                canonical['verb'] = canonical['verb'] || [];
-                canonical['reverse_verb_projection'] = canonical['reverse_verb_projection'] || [];
-                canonical['verb'].push(clause.slice(clause.indexOf(' ') + 1).replace(value, '#'));
-                canonical['reverse_verb_projection'].push(clause.slice(clause.indexOf(' ') + 1).replace(value, '').trim());
-            } else if (['VBN', 'VBG', 'JJ'].includes(tags[length])) {
-                canonical['passive_verb'] = canonical['passive_verb'] || [];
-                canonical['passive_verb'].push(clause.replace(value, '#'));
-            } else if (['VBP', 'VBZ', 'VBD'].includes(tags[length])) {
-                canonical['verb'] = canonical['verb'] || [];
-                canonical['verb'].push(clause.replace(value, '#'));
-            }
-            break;
+        const match = this.parser.match('query', paraphrase, [query_canonical], value);
+        if (match) {
+            canonical[match.pos] = canonical[match.pos] || [];
+            canonical[match.pos].push(match.canonical.replace('$value', '#'));
         }
     }
 }

--- a/tool/autoqa/lib/canonical-extractor.js
+++ b/tool/autoqa/lib/canonical-extractor.js
@@ -287,12 +287,15 @@ export default class AnnotationExtractor {
 
     _extractOneCanonical(canonical, paraphrase, value, query_canonical) {
         paraphrase = paraphrase.toLowerCase();
-        value = this.tokenizer.tokenize(value).tokens.join(' ');
+        value = this.tokenizer.tokenize(value).rawTokens.join(' ');
 
-        const match = this.parser.match('query', paraphrase, [query_canonical], value);
-        if (match) {
-            canonical[match.pos] = canonical[match.pos] || [];
-            canonical[match.pos].push(match.canonical.replace('$value', '#'));
+        const annotations = this.parser.match('query', paraphrase, [query_canonical], value);
+        if (annotations) {
+            for (const annotation of annotations) {
+                canonical[annotation.pos] = canonical[annotation.pos] || [];
+                canonical[annotation.pos].push(annotation.canonical.replace('$value', '#'));
+            }
         }
     }
+
 }


### PR DESCRIPTION
A parser based on part-of-speech information to extract canonical annotations from paraphrases. 
It's implemented as a regular language using NFA, with support for the following operators:
- `*` closure
- `_` concat (implicit)
- `|` union
- `()` parentheses 
- `.` wildcard 

In addition, it uses `[]` to indicate matching group. 

This generates exactly the same annotations as the old code for the 6 schema.org domains. 