### PR TITLE
Add a new conversation API to see the raw ThingTalk results

### DIFF
--- a/lib/dialogue-agent/conversation.ts
+++ b/lib/dialogue-agent/conversation.ts
@@ -488,6 +488,19 @@ export default class Conversation extends events.EventEmitter {
         return this._addMessage({ type: MessageType.LINK, url, title });
     }
 
+    sendNewProgram(program : {
+        uniqueId : string;
+        name : string;
+        code : string;
+        results : Array<Record<string, unknown>>;
+        errors : string[];
+        icon : string|null;
+    }) {
+        if (this._debug)
+            console.log('Almond executed new program: '+ program.uniqueId);
+        return this._addMessage({ type: MessageType.NEW_PROGRAM, ...program });
+    }
+
     private get _lastDialogue() {
         if (this._log.length === 0)
             return null;

--- a/lib/dialogue-agent/dialogue-loop.ts
+++ b/lib/dialogue-agent/dialogue-loop.ts
@@ -593,11 +593,14 @@ export default class DialogueLoop {
         //this.debug(`Before execution:`);
         //this.debug(this._dialogueState.prettyprint());
 
-        const { newDialogueState, newExecutorState, newResults } = await this._agent.execute(this._dialogueState, this._executorState);
+        const { newDialogueState, newExecutorState, newPrograms, newResults } = await this._agent.execute(this._dialogueState, this._executorState);
         this._dialogueState = newDialogueState;
         this._executorState = newExecutorState;
         this.debug(`Execution state:`);
         this.debug(this._dialogueState!.prettyprint());
+
+        for (const newProgram of newPrograms)
+            await this.conversation.sendNewProgram(newProgram);
 
         const [expect, numResults] = await this._doAgentReply();
 

--- a/lib/dialogue-agent/protocol.ts
+++ b/lib/dialogue-agent/protocol.ts
@@ -30,7 +30,8 @@ export enum MessageType {
     LINK = 'link',
     BUTTON = 'button',
     RDL = 'rdl',
-    RESULT = 'result'
+    RESULT = 'result',
+    NEW_PROGRAM = 'new-program'
 }
 
 interface TextMessage {
@@ -97,6 +98,17 @@ interface ResultMessage {
     icon : string|null;
 }
 
+interface NewProgramMessage {
+    id ?: number;
+    type : MessageType.NEW_PROGRAM;
+    uniqueId : string;
+    name : string;
+    code : string;
+    results : Array<Record<string, unknown>>;
+    errors : string[];
+    icon : string|null;
+}
+
 export type Message = TextMessage
     | CommandMessage
     | PictureMessage
@@ -104,4 +116,5 @@ export type Message = TextMessage
     | ChoiceMessage
     | LinkMessage
     | ButtonMessage
-    | ResultMessage;
+    | ResultMessage
+    | NewProgramMessage;

--- a/lib/dialogue-agent/simulator/statement_simulator.ts
+++ b/lib/dialogue-agent/simulator/statement_simulator.ts
@@ -257,11 +257,11 @@ export default class ThingTalkStatementSimulator {
     }
 
     async executeStatement(stmt : Ast.ExpressionStatement,
-                           execState : ThingTalkSimulatorState) : Promise<[Ast.DialogueHistoryResultList, RawExecutionResult, ThingTalkSimulatorState]> {
+                           execState : ThingTalkSimulatorState) : Promise<[Ast.DialogueHistoryResultList, RawExecutionResult, undefined, ThingTalkSimulatorState]> {
         if (stmt.stream) {
             // nothing to do, this always returns nothing
             return [new Ast.DialogueHistoryResultList(null, [],
-                new Ast.Value.Number(0), false, null), [], execState];
+                new Ast.Value.Number(0), false, null), [], undefined, execState];
         }
 
         if (execState === undefined)
@@ -270,6 +270,7 @@ export default class ThingTalkStatementSimulator {
         // there is no way around this, we need to compile and run the program!
         const compiled = await execState.compile(stmt, this.cache);
         const [resultList, rawResults] = await execState.simulate(stmt, compiled);
-        return [resultList, rawResults, execState];
+        // ignore the new program record, it doesn't matter at simulation time
+        return [resultList, rawResults, undefined, execState];
     }
 }

--- a/test/agent/index.js
+++ b/test/agent/index.js
@@ -145,6 +145,10 @@ class TestDelegate {
             }
             this._testRunner.writeLine('button: ' + msg.title + ' ' + JSON.stringify(msg.json));
             break;
+
+        case 'new-program':
+            console.log(JSON.stringify(msg));
+            break;
         }
     }
 }


### PR DESCRIPTION
Every time a new ThingTalk program is executed, send a "new-program"
message on the conversation web socket with the unique ID of the
program (in case the program is long running), the executed code,
and the raw results returned by the Thingpedia function.

This should allow a consumer of the conversation API to display
the results of the program in a custom graphical way (eg a chart)

This PR is needed for the finance assistant project.