### PR TITLE
Add kf-serving inference backend

### DIFF
--- a/lib/prediction/localparserclient.ts
+++ b/lib/prediction/localparserclient.ts
@@ -45,8 +45,8 @@ const NLG_QUESTION = 'what should the agent say ?';
 export interface LocalParserOptions {
     id ?: string;
     nprocesses ?: number;
-    kf_inference_ingress ?: string;
-    kf_inference_domain ?: string;
+    kfInferenceIngress ?: string;
+    kfInferenceDomain ?: string;
 }
 
 function compareScore(a : PredictionCandidate, b : PredictionCandidate) : number {

--- a/lib/prediction/localparserclient.ts
+++ b/lib/prediction/localparserclient.ts
@@ -45,6 +45,8 @@ const NLG_QUESTION = 'what should the agent say ?';
 export interface LocalParserOptions {
     id ?: string;
     nprocesses ?: number;
+    kf_inference_ingress ?: string;
+    kf_inference_domain ?: string;
 }
 
 function compareScore(a : PredictionCandidate, b : PredictionCandidate) : number {
@@ -75,7 +77,7 @@ export default class LocalParserClient {
         this._locale = locale;
         this._langPack = I18n.get(locale);
         this._tokenizer = this._langPack.getTokenizer();
-        this._predictor = new Predictor(options.id || 'local', modeldir, options.nprocesses);
+        this._predictor = new Predictor(modeldir, options);
 
         this._exactmatcher = exactmatcher;
         this._tpClient = tpClient;

--- a/lib/prediction/predictor.ts
+++ b/lib/prediction/predictor.ts
@@ -102,8 +102,8 @@ class Worker extends events.EventEmitter {
 
     start() {
         if (this._kfInferenceIngress && this._kfInferenceDomain) {
-            const url = `http://${this._kfInferenceIngress}/v1/models/${this._kfInferenceName}:predict`
-            const host = `${this._kfInferenceName}.${this._kfInferenceDomain}`
+            const url = `http://${this._kfInferenceIngress}/v1/models/${this._kfInferenceName}:predict`;
+            const host = `${this._kfInferenceName}.${this._kfInferenceDomain}`;
             console.log(`using kfserving inference service: ${url}, host: ${host}`);
             this._stream = new HttpEmitter(url, host);
         } else {

--- a/lib/prediction/predictor.ts
+++ b/lib/prediction/predictor.ts
@@ -54,9 +54,9 @@ interface Example {
 
 class Worker extends events.EventEmitter {
     id : string;
-    private _kf_inference_name : string;
-    private _kf_inference_ingress ?: string;
-    private _kf_inference_domain ?: string;
+    private _kfInferenceName : string;
+    private _kfInferenceIngress ?: string;
+    private _kfInferenceDomain ?: string;
     private _child : child_process.ChildProcess|null;
     private _hadError : boolean;
     private _stream : JsonDatagramSocket|HttpEmitter|null;
@@ -69,13 +69,13 @@ class Worker extends events.EventEmitter {
     private _minibatchStartTime = 0;
 
     constructor(id : string, modeldir : string,
-                kf_inference_name : string, kf_inference_ingress ?: string, kf_inference_domain ?: string) {
+                kfInferenceName : string, kfInferenceIngress ?: string, kfInferenceDomain ?: string) {
         super();
 
         this.id = id;
-        this._kf_inference_name = kf_inference_name;
-        this._kf_inference_ingress = kf_inference_ingress;
-        this._kf_inference_domain = kf_inference_domain;
+        this._kfInferenceName = kfInferenceName;
+        this._kfInferenceIngress = kfInferenceIngress;
+        this._kfInferenceDomain = kfInferenceDomain;
 
         this._child = null;
         this._hadError = false;
@@ -101,12 +101,12 @@ class Worker extends events.EventEmitter {
     }
 
     start() {
-        if (this._kf_inference_ingress && this._kf_inference_domain) {
-            const url = `http://${this._kf_inference_ingress}/v1/models/${this._kf_inference_name}:predict`
-            const host = `${this._kf_inference_name}.${this._kf_inference_domain}`
+        if (this._kfInferenceIngress && this._kfInferenceDomain) {
+            const url = `http://${this._kfInferenceIngress}/v1/models/${this._kfInferenceName}:predict`
+            const host = `${this._kfInferenceName}.${this._kfInferenceDomain}`
             console.log(`using kfserving inference service: ${url}, host: ${host}`);
             this._stream = new HttpEmitter(url, host);
-	} else {
+        } else {
             const args = [
                 'server',
                 '--stdin',
@@ -306,9 +306,9 @@ export default class Predictor {
     }
 
     private _startWorker() {
-        const kf_inference_name = this.id.replace(/\W/g, '');
+        const kfInferenceName = this.id.replace(/\W/g, '');
         const worker = new Worker(`${this.id}/${this._nextId++}`, this._modeldir,
-            kf_inference_name, this._options.kf_inference_ingress, this._options.kf_inference_domain);
+            kfInferenceName, this._options.kfInferenceIngress, this._options.kfInferenceDomain);
         worker.on('error', (err) => {
             console.error(`Worker ${worker.id} had an error: ${err.message}`);
             worker.stop();

--- a/lib/utils/http_emitter.ts
+++ b/lib/utils/http_emitter.ts
@@ -1,0 +1,70 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+/* -*- mode: js; indent-tabs-mode: nil; -*- */
+//
+// Copyright (c) 2015 The Board of Trustees of the Leland Stanford Junior University
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+import * as events from 'events';
+import * as Tp from 'thingpedia';
+
+// HttpEmitter wraps http calls in EventEmitter interface
+export default class HttpEmitter extends events.EventEmitter {
+    private _url : string;
+    private _host : string;
+
+    constructor(url : string, host : string) {
+        super();
+        this._url = url;
+	this._host = host;
+    }
+
+    write(msg : unknown, callback ?: (err : Error|null|undefined) => void) : void {
+        Tp.Helpers.Http.post(this._url, JSON.stringify(msg), {
+            dataContentType: 'application/json',
+            extraHeaders: {'Host': this._host}
+        }).then((res) => {
+            const parsed = JSON.parse(res);
+            if (parsed.predictions) {
+                this.emit('data', JSON.parse(parsed.predictions));
+            } else {
+                if (callback) {
+                    callback(new Error(`Unexpected http response: ${res}`));
+                }
+            }
+        }, callback);
+    }
+}

--- a/lib/utils/http_emitter.ts
+++ b/lib/utils/http_emitter.ts
@@ -37,13 +37,10 @@ export default class HttpEmitter extends events.EventEmitter {
             extraHeaders: {'Host': this._host}
         }).then((res) => {
             const parsed = JSON.parse(res);
-            if (parsed.predictions) {
+            if (parsed.predictions)
                 this.emit('data', JSON.parse(parsed.predictions));
-            } else {
-                if (callback) {
-                    callback(new Error(`Unexpected http response: ${res}`));
-                }
-            }
+            else if (callback)
+                callback(new Error(`Unexpected http response: ${res}`));
         }, callback);
     }
 }

--- a/lib/utils/http_emitter.ts
+++ b/lib/utils/http_emitter.ts
@@ -16,27 +16,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-/* -*- mode: js; indent-tabs-mode: nil; -*- */
-//
-// Copyright (c) 2015 The Board of Trustees of the Leland Stanford Junior University
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to
-// deal in the Software without restriction, including without limitation the
-// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-// sell copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-// IN THE SOFTWARE.
 
 import * as events from 'events';
 import * as Tp from 'thingpedia';
@@ -49,7 +28,7 @@ export default class HttpEmitter extends events.EventEmitter {
     constructor(url : string, host : string) {
         super();
         this._url = url;
-	this._host = host;
+        this._host = host;
     }
 
     write(msg : unknown, callback ?: (err : Error|null|undefined) => void) : void {


### PR DESCRIPTION
The inference service will be accessible within cluster using following HTTP.
We use the model/lang as inference service name, but the name is limited to alphanumeric.  

For example, the name for `@org.thingpedia.models.contextual/en` is `orgthingpediamodelscontextualen` .

The service can be accessed with following HTTP call:

URL:  http://cluster-local-gateway.istio-system.svc.cluster.local/v1/models/orgthingpediamodelscontextualen:predict
HTTP Header {Host: orgthingpediamodelscontextualen.kfserving-test.svc.cluster.local }