### PR TITLE
`simulate-dialogs` with parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ lib/engine/devices/builtins/faq.json
 
 workdir*
 genienlp/
+.embeddings/
 
 env/
 

--- a/languages/thingtalk/en/dlg/results.genie
+++ b/languages/thingtalk/en/dlg/results.genie
@@ -41,8 +41,10 @@ result_name_pair : D.NameList = {
 
         const r1 = results[0];
         const r2 = results[1];
-        assert(r1.value.id.equals(n1));
-        assert(r2.value.id.equals(n2));
+        if (!r1.value.id.equals(n1)) // can happen if the types are different but the value is the same
+            return null;
+        if (!r2.value.id.equals(n2))
+            return null;
         return { ctx, results: results.slice(0, 2) };
     };
 }
@@ -55,8 +57,10 @@ result_name_list : D.NameList = {
 
         const r1 = results[0];
         const r2 = results[1];
-        assert(r1.value.id.equals(n1));
-        assert(r2.value.id.equals(n2));
+        if (!r1.value.id.equals(n1))
+            return null;
+        if (!r2.value.id.equals(n2))
+            return null;
         return { ctx, results: results.slice(0, 2) };
     };
 
@@ -66,7 +70,8 @@ result_name_list : D.NameList = {
         assert(results && results.length >= 3);
         assert(ctx.resultInfo!.idType !== null);
         const r3 = results[2];
-        assert(r3.value.id.equals(n3));
+        if (!r3.value.id.equals(n3))
+            return null;
         return { ctx, results: results.slice(0, 3) };
     };
 }

--- a/lib/utils/entity-utils.ts
+++ b/lib/utils/entity-utils.ts
@@ -159,7 +159,7 @@ function makeDummyEntity(token : string) : AnyEntity {
 function makeDummyEntities(preprocessed : string) : EntityMap {
     const entities : EntityMap = {};
     for (const token of preprocessed.split(' ')) {
-        if (/^[A-Z]/.test(token))
+        if (ENTITY_MATCH_REGEX.test(token))
             entities[token] = makeDummyEntity(token);
     }
     return entities;

--- a/tool/simulate-dialogs.ts
+++ b/tool/simulate-dialogs.ts
@@ -101,13 +101,13 @@ class SimulatorStream extends Stream.Transform {
     private _dialoguePolicy : DialoguePolicy;
     private _parser : ParserClient.ParserClient | null;
     private _tpClient : Tp.BaseClient;
-    private _outputMistakesOnly: boolean;
-    private _locale: string;
+    private _outputMistakesOnly : boolean;
+    private _locale : string;
 
     constructor(policy : DialoguePolicy,
                 simulator : ThingTalkUtils.Simulator,
                 schemas : ThingTalk.SchemaRetriever,
-                parser: ParserClient.ParserClient | null,
+                parser : ParserClient.ParserClient | null,
                 tpClient : Tp.BaseClient,
                 outputMistakesOnly : boolean,
                 locale : string) {
@@ -123,7 +123,7 @@ class SimulatorStream extends Stream.Transform {
     }
 
     async _run(dlg : ParsedDialogue) : Promise<void> {
-        console.log('dialogue = ', dlg.id)
+        console.log('dialogue = ', dlg.id);
         const lastTurn = dlg[dlg.length-1];
 
         let state = null;
@@ -176,7 +176,7 @@ class SimulatorStream extends Stream.Transform {
                 // don't push anything
                 return;
             }
-            dlg[dlg.length-1].user_target = normalizedUserTarget
+            dlg[dlg.length-1].user_target = normalizedUserTarget;
             
         } else {
             userTarget = goldUserTarget;
@@ -199,7 +199,7 @@ class SimulatorStream extends Stream.Transform {
         let policyResult;
         try {
             policyResult = await this._dialoguePolicy.chooseAction(state);
-        } catch (error) {
+        } catch(error) {
             console.log(`Error while choosing action: ${error.message}. skipping.`);
             return;
         }
@@ -234,7 +234,7 @@ class DialogueToPartialDialoguesStream extends Stream.Transform {
         super({ objectMode : true });
     }
 
-    private _copyDialogueTurns(turns : Array<DialogueTurn>) : Array<DialogueTurn> {
+    private _copyDialogueTurns(turns : DialogueTurn[]) : DialogueTurn[] {
         const copy : DialogueTurn[] = [];
         for (let i = 0; i < turns.length; i++) {
             copy.push({
@@ -244,7 +244,7 @@ class DialogueToPartialDialoguesStream extends Stream.Transform {
                 intermediate_context : turns[i].intermediate_context,
                 user : turns[i].user,
                 user_target : turns[i].user_target
-            })
+            });
         }
         return copy;
     }
@@ -252,7 +252,7 @@ class DialogueToPartialDialoguesStream extends Stream.Transform {
     async _run(dlg : ParsedDialogue) : Promise<void> {
         for (let i = 1; i < dlg.length + 1; i++) {
             // do a deep copy so that later streams can modify these dialogues
-            let output = this._copyDialogueTurns(dlg.slice(0, i));
+            const output = this._copyDialogueTurns(dlg.slice(0, i));
             (output as ParsedDialogue).id = dlg.id + '-turn_' + i;
             this.push(output);
         }

--- a/tool/simulate-dialogs.ts
+++ b/tool/simulate-dialogs.ts
@@ -117,7 +117,7 @@ class SimulatorStream extends Stream.Transform {
     }
 
     async _run(dlg : ParsedDialogue) : Promise<void> {
-        console.log('dlg = ', dlg)
+        // console.log('dialogue = ', dlg)
         const lastTurn = dlg[dlg.length-1];
 
         let state = null;
@@ -151,7 +151,7 @@ class SimulatorStream extends Stream.Transform {
             if (candidates.length > 0) {
                 userTarget = candidates[0];
             } else {
-                console.log(`No valid candidate parses for this command; using the gold UT`);
+                console.log(`No valid candidate parses for this command. Top candidate was ${parsed.candidates[0].code.join(' ')}. Using the gold UT`);
                 userTarget = goldUserTarget;
             }
             const normalizedUserTarget : string = ThingTalkUtils.serializePrediction(userTarget, parsed.tokens, parsed.entities, {


### PR DESCRIPTION
This PR makes the following changes to `genie simulate-dialog`:
- Adds the option to parse the last user utterance using a neural semantic parser, instead of reading UT from file.
- For each input dialogue, output `n` partial dialogues where `n` is the number of turns in that dialogue. The `i`-th output has the entire conversation from the beginning till turn `i`.
- Adds the option to only output partial dialogues where the provided semantic parser makes a mistake. i.e. if a user turn is parsed correctly, it will not be output.
