### PR TITLE
Restore detailed message when no device of a given type is configured

### DIFF
--- a/lib/dialogue-agent/abstract_dialogue_agent.ts
+++ b/lib/dialogue-agent/abstract_dialogue_agent.ts
@@ -28,6 +28,7 @@ import { shouldAutoConfirmStatement } from '../utils/thingtalk';
 import { contactSearch, Contact } from './entity-linking/contact_search';
 import { collectDisambiguationHints, getBestEntityMatch, EntityRecord } from './entity-linking/entity-finder';
 
+import { CancellationError } from './errors';
 import ValueCategory from './value-category';
 
 interface AbstractDialogueAgentOptions {
@@ -249,6 +250,8 @@ export default abstract class AbstractDialogueAgent<PrivateStateType> {
         if (alldevices.length === 0) {
             this.debug('No device of kind ' + kind + ' available, attempting configure...');
             const device = await this.tryConfigureDevice(kind);
+            if (!device) // cancel the dialogue if we failed to set up a device
+                throw new CancellationError();
             if (selector.all)
                 return;
             selector.id = device.uniqueId;
@@ -382,7 +385,7 @@ export default abstract class AbstractDialogueAgent<PrivateStateType> {
      * @param {string} kind - the kind to configure
      * @returns {DeviceInfo} - the newly configured device
      */
-    protected async tryConfigureDevice(kind : string) : Promise<DeviceInfo> {
+    protected async tryConfigureDevice(kind : string) : Promise<DeviceInfo|null> {
         throw new TypeError('Abstract method');
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,9 +566,9 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "@types/xml2js": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.7.tgz",
-      "integrity": "sha512-f5VOKSMEE0O+/L54FHwA/a7vcx9mHeSDM71844yHCOhh8Cin2xQa0UFw0b7Vc5hoZ3Ih6ZHaDobjfLih4tWPNw==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
       "requires": {
         "@types/node": "*"
       }
@@ -3766,7 +3766,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -4206,37 +4205,30 @@
       "dev": true
     },
     "thingpedia": {
-      "version": "2.9.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/thingpedia/-/thingpedia-2.9.0-alpha.1.tgz",
-      "integrity": "sha512-SoWUyxXyabTvd6yDsYHJoyAoLzFQxsPgKJsQozKhTShHnK2HkycKMxWvZ4gxp07iEH+/GPLgQaYjAUOruafyRg==",
+      "version": "2.9.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/thingpedia/-/thingpedia-2.9.0-alpha.2.tgz",
+      "integrity": "sha512-oSUvxdVfOg7yXviuZxa/XRv8dCRy3pcxLEw4F9voKWVXyekK9T7hgvZ1nzMUAeq6F/gWyhJDRONo78uRj8AC0A==",
       "requires": {
         "@types/feedparser": "^2.2.3",
         "@types/ip": "^1.1.0",
-        "@types/node": "^14.14.14",
+        "@types/node": "^14.14.25",
         "@types/node-gettext": "^3.0.1",
         "@types/oauth": "^0.9.1",
         "@types/qs": "^6.9.5",
-        "@types/xml2js": "^0.4.7",
+        "@types/xml2js": "^0.4.8",
         "feedparser": "^2.2.9",
         "gettext-parser": "^4.0.2",
         "ip": "^1.1.0",
         "oauth": "^0.9.14",
-        "qs": "^6.7.0",
+        "qs": "^6.9.6",
         "smtlib": "^1.0.0",
         "string-interp": "^0.3.5",
         "tmp": "^0.2.1",
         "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.14.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-          "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ=="
-        }
       }
     },
     "thingtalk": {
-      "version": "github:stanford-oval/thingtalk#f726b920acd68c22353bc8e1aeed61aa3a1e9b36",
+      "version": "github:stanford-oval/thingtalk#3a985e9bd82bd2f916ad3d09eaf1226e5359719f",
       "from": "github:stanford-oval/thingtalk#master",
       "requires": {
         "@types/semver": "^7.3.4",
@@ -4263,16 +4255,6 @@
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "requires": {
         "rimraf": "^3.0.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "to-fast-properties": {
@@ -4413,9 +4395,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.4.tgz",
+      "integrity": "sha512-+Uru0t8qIRgjuCpiSPpfGuhHecMllk5Zsazj5LZvVsEStEjmIRRBZe+jHjGQvsgS7M1wONy2PQXd67EMyV6acg=="
     },
     "uglify-js": {
       "version": "3.11.1",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "sqlite3": "5.0.0",
     "stemmer": "^1.0.5",
     "string-interp": "^0.3.1",
-    "thingpedia": "~2.9.0-alpha.1",
+    "thingpedia": "^2.9.0-alpha.2",
     "thingtalk": "github:stanford-oval/thingtalk#master",
     "thingtalk-units": "^0.2.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.1.4",
     "uuid": "^8.2.0",
     "ws": "^7.4.3"
   },

--- a/test/agent/mock_thingpedia_client.js
+++ b/test/agent/mock_thingpedia_client.js
@@ -229,6 +229,10 @@ export default class MockThingpediaClient extends Tp.BaseClient {
                 ret[k] = {type: 'multiple', choices: [{ type: 'oauth2', kind: 'com.tumblr', text: "Tumblr Account" }, { type: 'form', kind: 'com.tumblr2', text: 'Some other Tumblr Thing' }]};
             else if (k === 'com.instagram')
                 ret[k] = {type: 'oauth2', kind: 'com.instagram', text: 'Instagram'};
+            else if (k === 'org.thingpedia.iot.light-bulb')
+                ret[k] = {type: 'multiple', text: 'Light Bulb', choices: [{ type: 'oauth2', kind: 'io.home-assistant', text: 'Home Assistant'}, { type: 'discovery', discoveryType: 'upnp', kind: 'com.hue', text:'Philips Hue'}] };
+            else if (k === 'org.thingpedia.iot.door')
+                ret[k] = {type: 'oauth2', kind: 'io.home-assistant', text: 'Home Assistant'};
             else if (k === 'org.thingpedia.rss')
                 ret[k] = _rssFactory;
             else if (k === 'org.thingpedia.builtin.thingengine.home' || k === 'car')

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -684,3 +684,27 @@ U: @org.thingpedia.builtin.thingengine.builtin.faq_reply(question=enum about_alm
 A: Str:QUOTED_STRING::42:.
 A: >> context = null // {}
 A: >> expecting = null
+
+====
+# 45-not-configured-light-bulb
+
+# Turn off the lights
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.iot.light-bulb.set_power(power=enum(off));
+
+A: You do not have a Light Bulb configured. You will need to enable Home Assistant or Philips Hue before you can use that command.
+A: link: Configure a new skill /devices/create
+A: >> context = null // {}
+A: >> expecting = null
+
+====
+# 46-not-configured-door
+
+# Is the door open
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.iot.door.state();
+
+A: You need to enable Home Assistant before you can use that command.
+A: link: Configure Home Assistant /devices/create
+A: >> context = null // {}
+A: >> expecting = null

--- a/test/agent/thingpedia.tt
+++ b/test/agent/thingpedia.tt
@@ -1099,4 +1099,56 @@ class @com.xkcd
   #[minimal_projection=["id", "title"]]
   #[doc="retrieve a random xkcd"];
 }
+abstract class @org.thingpedia.iot.light-bulb extends @org.thingpedia.iot.switch
+#_[name="Light Bulb"]
+#_[description="The general interface supported by all light bulbs."]
+#_[canonical="light bulb"]
+{
+  monitorable query power(out power : Enum(on, off)
+                          #_[canonical="power"])
+  #_[canonical="the power state of the light bulb"]
+  #_[confirmation="the power state of ${__device}"]
+  #_[result=["your lights are ${power}"]]
+  #_[confirmation_remote="the power state of ${__device}"]
+  #[minimal_projection=[]]
+  #[confirm=false];
 
+  action alert_long()
+  #_[canonical="loop the color in my light bulb"]
+  #_[confirmation="flash alerts on ${__device}"]
+  #_[confirmation_remote="flash alerts on ${__device}"]
+  #[confirm=true]
+  #[minimal_projection=[]];
+
+  action color_loop()
+  #_[canonical="flash the lights"]
+  #_[confirmation="loop colors on ${__device}"]
+  #_[confirmation_remote="loop colors on ${__device}"]
+  #[confirm=true]
+  #[minimal_projection=[]];
+
+  action set_power(in req power : Enum(on, off)
+                   #_[prompt=["do you want to turn it on or off"]]
+                   #_[canonical={
+                     base=["power"],
+                     property=[]
+                   }])
+  #_[canonical="set the power on the lights"]
+  #_[confirmation="turn $power ${__device}"]
+  #_[confirmation_remote="turn $power ${__device}"]
+  #[confirm=true]
+  #[minimal_projection=[]];
+}
+abstract class @org.thingpedia.iot.door
+#_[description="Interface for Door Sensor."]
+#_[name="Door Sensor"]
+#_[canonical="door sensor"] {
+  monitorable query state(out state : Enum(open, closed)
+                          #_[canonical="state"])
+  #_[canonical="door state"]
+  #_[confirmation="the state of $__device"]
+  #_[result=["the entrance is ${state}"]]
+  #_[confirmation_remote="the state of $__device"]
+  #[minimal_projection=[]]
+  #[confirm=false];
+}


### PR DESCRIPTION
The generic message is confusing, because it sounds like the agent
doesn't know what the command is about, and the word "skill" is
confusing. We used to need the generic message because we could
not distinguish a bad parse / OOD command from a good parse without
the right skill. We have confidence for that now, so we can be
confident that the command was parsed correctly.

Fixes #450