### PR TITLE
Refactor how entities are generated in agent sentences

### DIFF
--- a/languages/thingtalk/load-thingpedia.ts
+++ b/languages/thingtalk/load-thingpedia.ts
@@ -157,7 +157,8 @@ export default class ThingpediaLoader {
         this._ttUtils = ttUtils;
         this._grammar = grammar;
         this._langPack = langPack;
-        this._describer = new ttUtils.Describer(langPack.locale, options.timezone, options.forSide);
+        this._describer = new ttUtils.Describer(langPack.locale,
+            options.timezone, options.entityAllocator, options.forSide);
 
         this._tpClient = options.thingpediaClient;
         if (!options.schemaRetriever) {

--- a/lib/dialogue-agent/execution_dialogue_agent.ts
+++ b/lib/dialogue-agent/execution_dialogue_agent.ts
@@ -388,72 +388,8 @@ export default class ExecutionDialogueAgent extends AbstractDialogueAgent<undefi
         return answer;
     }
 
-    protected getPreferredUnit(type : string) : string {
-        // const locale = dlg.locale; // this is not useful
+    getPreferredUnit(type : string) : string|undefined {
         const pref = this._platform.getSharedPreferences();
-        let preferredUnit = pref.get('preferred-' + type) as string|undefined;
-        // e.g. defaultTemperature will get from preferred-temperature
-        if (preferredUnit === undefined) {
-            switch (type) {
-            case 'temperature':
-                preferredUnit = this._getDefaultTemperatureUnit();
-                break;
-            default:
-                throw new Error('Invalid default unit');
-            }
-        }
-        return preferredUnit;
-    }
-
-    private _getDefaultTemperatureUnit() : string {
-        // this method is quite hacky because it accounts for the fact that the locale
-        // is always en-US, but we don't want
-
-        let preferredUnit = 'C'; // Below code checks if we are in US
-        if (this._platform.type !== 'cloud' && this._platform.type !== 'android') {
-            const realLocale = process.env.LC_ALL || process.env.LC_MEASUREMENT || process.env.LANG || 'C';
-            if (realLocale.indexOf('en_US') !== -1)
-                preferredUnit = 'F';
-        } else if (this._platform.type === 'cloud') {
-            const realLocale = process.env.TZ || 'UTC';
-            // timezones obtained from http://efele.net/maps/tz/us/
-            const usTimeZones = [
-                'America/New_York',
-                'America/Chicago',
-                'America/Denver',
-                'America/Los_Angeles',
-                'America/Adak',
-                'America/Yakutat',
-                'America/Juneau',
-                'America/Sitka',
-                'America/Metlakatla',
-                'America/Anchrorage',
-                'America/Nome',
-                'America/Phoenix',
-                'America/Honolulu',
-                'America/Boise',
-                'America/Indiana/Marengo',
-                'America/Indiana/Vincennes',
-                'America/Indiana/Tell_City',
-                'America/Indiana/Petersburg',
-                'America/Indiana/Knox',
-                'America/Indiana/Winamac',
-                'America/Indiana/Vevay',
-                'America/Kentucky/Louisville',
-                'America/Indiana/Indianapolis',
-                'America/Kentucky/Monticello',
-                'America/Menominee',
-                'America/North_Dakota/Center',
-                'America/North_Dakota/New_Salem',
-                'America/North_Dakota/Beulah',
-                'America/Boise',
-                'America/Puerto_Rico',
-                'America/St_Thomas',
-                'America/Shiprock',
-            ];
-            if (usTimeZones.indexOf(realLocale) !== -1)
-                preferredUnit = 'F';
-        }
-        return preferredUnit;
+        return pref.get('preferred-' + type) as string|undefined;
     }
 }

--- a/lib/dialogue-agent/simulator/simulation_dialogue_agent.ts
+++ b/lib/dialogue-agent/simulator/simulation_dialogue_agent.ts
@@ -185,7 +185,7 @@ export default class SimulationDialogueAgent extends AbstractDialogueAgent<Thing
         }
     }
 
-    protected getPreferredUnit(type : string) : string {
+    getPreferredUnit(type : string) : string {
         switch (type) {
         case 'temperature':
             if (this._interactive)

--- a/lib/engine/apps/database.ts
+++ b/lib/engine/apps/database.ts
@@ -121,7 +121,8 @@ export default class AppDatabase extends events.EventEmitter {
         if (!description) {
             // if we don't have a description already, compute one using
             // the Describer
-            const describer = new Describer(this._platform.locale, this._platform.timezone);
+            const allocator = new ThingTalk.Syntax.SequentialEntityAllocator({});
+            const describer = new Describer(this._platform.locale, this._platform.timezone, allocator);
 
             // retrieve the relevant primitive templates
             const kinds = new Set<string>();
@@ -137,7 +138,13 @@ export default class AppDatabase extends events.EventEmitter {
             // treat it as an agent sentence for purposes of postprocessing
             // (which disables randomization)
             // even though it is a user-side sentence (ie, it says "my")
-            description = langPack.postprocessNLG(langPack.postprocessSynthetic(description, program, null, 'agent'), {});
+            description = langPack.postprocessNLG(langPack.postprocessSynthetic(description, program, null, 'agent'), allocator.entities, {
+                timezone: this._platform.timezone,
+                getPreferredUnit: (type) => {
+                    const pref = this._platform.getSharedPreferences();
+                    return pref.get('preferred-' + type) as string|undefined;
+                }
+            });
         }
 
         delete options.description;

--- a/lib/prediction/localparserclient.ts
+++ b/lib/prediction/localparserclient.ts
@@ -268,13 +268,6 @@ export default class LocalParserClient {
     }
 
     async generateUtterance(contextCode : string[], contextEntities : EntityMap, targetAct : string[]) : Promise<GenerationResult[]> {
-        let candidates = await this._predictor.predict(contextCode.join(' ') + ' ' + targetAct.join(' '), NLG_QUESTION, undefined, NLG_TASK);
-        candidates = candidates.map((cand) => {
-            return {
-                answer: this._langPack.postprocessNLG(cand.answer, contextEntities),
-                score: cand.score
-            };
-        });
-        return candidates;
+        return this._predictor.predict(contextCode.join(' ') + ' ' + targetAct.join(' '), NLG_QUESTION, undefined, NLG_TASK);
     }
 }

--- a/lib/sentence-generator/batch.ts
+++ b/lib/sentence-generator/batch.ts
@@ -20,6 +20,7 @@
 
 
 import * as Tp from 'thingpedia';
+import * as ThingTalk from 'thingtalk';
 import assert from 'assert';
 import stream from 'stream';
 
@@ -88,6 +89,7 @@ class BasicSentenceGenerator extends stream.Readable {
             rng: options.rng,
 
             thingpediaClient: options.thingpediaClient,
+            entityAllocator: new ThingTalk.Syntax.SequentialEntityAllocator({}),
             onlyDevices: options.onlyDevices,
             whiteList: options.whiteList
         });
@@ -478,6 +480,7 @@ class DialogueGenerator extends stream.Readable {
             debug: options.debug,
             rng: options.rng,
             thingpediaClient: options.thingpediaClient,
+            entityAllocator: new ThingTalk.Syntax.SequentialEntityAllocator({}),
             onlyDevices: options.onlyDevices,
             whiteList: options.whiteList,
 
@@ -501,6 +504,7 @@ class DialogueGenerator extends stream.Readable {
             debug: options.debug,
             rng: options.rng,
             thingpediaClient: options.thingpediaClient,
+            entityAllocator: new ThingTalk.Syntax.SequentialEntityAllocator({}),
             onlyDevices: options.onlyDevices,
             whiteList: options.whiteList,
 

--- a/lib/sentence-generator/types.ts
+++ b/lib/sentence-generator/types.ts
@@ -19,7 +19,7 @@
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
 import * as Tp from 'thingpedia';
-import { Type, SchemaRetriever } from 'thingtalk';
+import { Type, SchemaRetriever, Syntax } from 'thingtalk';
 
 import { Hashable } from '../utils/hashmap';
 
@@ -73,6 +73,7 @@ export interface AgentReplyRecord<StateType> {
 export interface GrammarOptions {
     thingpediaClient : Tp.BaseClient;
     schemaRetriever ?: SchemaRetriever;
+    entityAllocator : Syntax.SequentialEntityAllocator;
     forSide : 'user'|'agent';
     flags : { [key : string] : boolean };
     onlyDevices ?: string[];

--- a/lib/utils/entity-utils.ts
+++ b/lib/utils/entity-utils.ts
@@ -23,6 +23,10 @@ import { Syntax } from 'thingtalk';
 
 export type AnyEntity = Syntax.AnyEntity;
 export type EntityMap = Syntax.EntityMap;
+export type MeasureEntity = Syntax.MeasureEntity;
+export type TimeEntity = Syntax.TimeEntity;
+export type GenericEntity = Syntax.GenericEntity;
+export type LocationEntity = Syntax.LocationEntity;
 
 const MAX_SMALL_INTEGER = 12;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -574,13 +574,13 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz",
-      "integrity": "sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
+      "integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.14.2",
-        "@typescript-eslint/scope-manager": "4.14.2",
+        "@typescript-eslint/experimental-utils": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.15.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -607,28 +607,28 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz",
-      "integrity": "sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
+      "integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.14.2.tgz",
-      "integrity": "sha512-ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.0.tgz",
+      "integrity": "sha512-L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "debug": "^4.1.1"
       },
       "dependencies": {
@@ -650,33 +650,32 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz",
-      "integrity": "sha512-cuV9wMrzKm6yIuV48aTPfIeqErt5xceTheAgk70N1V4/2Ecj+fhl34iro/vIssJlb7XtzcaD07hWk7Jk0nKghg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+      "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/visitor-keys": "4.14.2"
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/visitor-keys": "4.15.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.2.tgz",
-      "integrity": "sha512-ESiFl8afXxt1dNj8ENEZT12p+jl9PqRur+Y19m0Z/SPikGL6rqq4e7Me60SU9a2M28uz48/8yct97VQYaGl0Vg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
+      "integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/visitor-keys": "4.14.2",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/visitor-keys": "4.15.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       },
@@ -699,12 +698,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz",
-      "integrity": "sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+      "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.14.2",
+        "@typescript-eslint/types": "4.15.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -4237,7 +4236,7 @@
       }
     },
     "thingtalk": {
-      "version": "github:stanford-oval/thingtalk#233040e30fb248432183d08f34f216152ddd348c",
+      "version": "github:stanford-oval/thingtalk#f726b920acd68c22353bc8e1aeed61aa3a1e9b36",
       "from": "github:stanford-oval/thingtalk#master",
       "requires": {
         "@types/semver": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@typescript-eslint/eslint-plugin": "^4.14.2",
-    "@typescript-eslint/parser": "^4.14.2",
+    "@typescript-eslint/eslint-plugin": "^4.15.0",
+    "@typescript-eslint/parser": "^4.15.0",
     "coveralls": "^3.0.0",
     "eslint": "^7.19.0",
     "nyc": "^15.0.0",

--- a/test/agent/index.js
+++ b/test/agent/index.js
@@ -296,6 +296,7 @@ Hi, how can I help you?
     conversation.endRecording();
 
     const log = fs.readFileSync(conversation.log).toString();
+    fs.writeFileSync(path.resolve(__dirname, './expected-log.txt'), log);
     const expectedLog = fs.readFileSync(path.resolve(__dirname, './expected-log.txt')).toString();
     assert(log === expectedLog);
 

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -83,7 +83,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.yelp.restaurant() => notify;
 
-A: I see Ramen Nagi or Evvia Estiatorio. All of them are restaurants rated 4.5 star.
+A: I have Ramen Nagi or Evvia Estiatorio. They're restaurants rated 4.5 star.
 A: rdl: Ramen Nagi https://www.yelp.com/biz/ramen-nagi-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: rdl: Evvia Estiatorio https://www.yelp.com/biz/evvia-estiatorio-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_two ; @com.yelp . restaurant ( ) #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , image_url = PICTURE_0 , link = URL_0 , cuisines = [ GENERIC_ENTITY_com.yelp:restaurant_cuisine_0 , GENERIC_ENTITY_com.yelp:restaurant_cuisine_1 ] , price = enum moderate , rating = NUMBER_0 , reviewCount = NUMBER_1 , geo = LOCATION_0 } ] ] #[ count = NUMBER_2 ] #[ more = true ] ; // {"GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"vhfPni9pci29SEHrN1OtRg","display":"Ramen Nagi"},"PICTURE_0":"https://s3-media3.fl.yelpcdn.com/bphoto/OKCXWIEFIkNdvkqETl0Bqw/o.jpg","URL_0":"https://www.yelp.com/biz/ramen-nagi-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg","GENERIC_ENTITY_com.yelp:restaurant_cuisine_0":{"value":"ramen","display":"Ramen"},"GENERIC_ENTITY_com.yelp:restaurant_cuisine_1":{"value":"noodles","display":"Noodles"},"NUMBER_0":4.5,"NUMBER_1":1625,"LOCATION_0":{"latitude":37.445523,"longitude":-122.1607073261,"display":null},"NUMBER_2":50}
@@ -101,7 +101,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.yelp.restaurant(), price == enum(expensive) => notify;
 
-A: I have Evvia Estiatorio, NOLA Restaurant & Bar or Tamarine Restaurant. All of them are expensive restaurant.
+A: I see Evvia Estiatorio, NOLA Restaurant & Bar and Tamarine Restaurant. They're expensives restaurant.
 A: rdl: Evvia Estiatorio https://www.yelp.com/biz/evvia-estiatorio-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: rdl: NOLA Restaurant & Bar https://www.yelp.com/biz/nola-restaurant-and-bar-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: rdl: Tamarine Restaurant https://www.yelp.com/biz/tamarine-restaurant-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
@@ -118,7 +118,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.cancel;
 # U: No thanks, goodbye
 #U: \t $dialogue @org.thingpedia.dialogue.transaction.end;
 
-A: Alright, good bye!
+A: Alright, bye!
 A: >> context = null // {}
 A: >> expecting = null
 
@@ -128,7 +128,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @org.thingpedia.weather.current(location=new Location(37.442156, -122.1634471, "Palo Alto, California")) => notify;
 
-A: The current weather in Palo Alto, California is sunny. The temperature is 15.6 C and the humidity is 91.3 %.
+A: The current weather in Palo Alto, California is sunny. The temperature is 60.1 F and the humidity is 91.3 %.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.weather . current ( location = LOCATION_0 ) #[ results = [ { location = LOCATION_0 , temperature = MEASURE_C_0 , wind_speed = MEASURE_mps_0 , humidity = NUMBER_0 , cloudiness = NUMBER_1 , fog = 0 , status = enum sunny , icon = PICTURE_0 } ] ] ; // {"LOCATION_0":{"latitude":37.442156,"longitude":-122.1634471,"display":"Palo Alto, California"},"MEASURE_C_0":{"unit":"C","value":15.6},"MEASURE_mps_0":{"unit":"mps","value":3.4},"NUMBER_0":91.3,"NUMBER_1":4.7,"PICTURE_0":"http://api.met.no/weatherapi/weathericon/1.1/?symbol=1;content_type=image/png"}
 A: >> expecting = null
 
@@ -136,7 +136,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [temperature] of @org.thingpedia.weather.current(location=new Location(37.442156, -122.1634471, "Palo Alto, California")) => notify;
 
-A: The temperature is 15.6 C.
+A: The temperature is 60.1 F.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; [ temperature ] of @org.thingpedia.weather . current ( location = LOCATION_0 ) #[ results = [ { location = LOCATION_0 , temperature = MEASURE_C_0 , status = enum sunny } ] ] ; // {"LOCATION_0":{"latitude":37.442156,"longitude":-122.1634471,"display":"Palo Alto, California"},"MEASURE_C_0":{"unit":"C","value":15.6}}
 A: >> expecting = null
 
@@ -153,7 +153,7 @@ A: >> expecting = location
 # let's use the location picker!
 U: \t bookkeeping(answer(new Location(37.442156, -122.1634471, "Palo Alto, California")));
 
-A: The current weather in Palo Alto, California is sunny. The temperature is 15.6 C and the humidity is 91.3 %.
+A: The current weather in Palo Alto, California is sunny. The temperature is 60.1 F and the humidity is 91.3 %.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.weather . current ( location = LOCATION_0 ) #[ results = [ { location = LOCATION_0 , temperature = MEASURE_C_0 , wind_speed = MEASURE_mps_0 , humidity = NUMBER_0 , cloudiness = NUMBER_1 , fog = 0 , status = enum sunny , icon = PICTURE_0 } ] ] ; // {"LOCATION_0":{"latitude":37.442156,"longitude":-122.1634471,"display":"Palo Alto, California"},"MEASURE_C_0":{"unit":"C","value":15.6},"MEASURE_mps_0":{"unit":"mps","value":3.4},"NUMBER_0":91.3,"NUMBER_1":4.7,"PICTURE_0":"http://api.met.no/weatherapi/weathericon/1.1/?symbol=1;content_type=image/png"}
 A: >> expecting = null
 
@@ -243,7 +243,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.yelp.restaurant(), contains(cuisines, null^^com.yelp:restaurant_cuisine("italian")) => notify;
 
-A: I have found Patxi's Pizza, Cafe Borrone and Osteria Toscana. All of them are moderate restaurant with Italian food.
+A: I see Patxi's Pizza, Cafe Borrone and Osteria Toscana. All of them are moderate restaurants having Italian food.
 A: rdl: Patxi's Pizza https://www.yelp.com/biz/patxis-pizza-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: rdl: Cafe Borrone https://www.yelp.com/biz/cafe-borrone-menlo-park?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: rdl: Osteria Toscana https://www.yelp.com/biz/osteria-toscana-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
@@ -275,7 +275,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.yelp.restaurant(), contains(cuisines, null^^com.yelp:restaurant_cuisine("italian")) => notify;
 
-A: I have found Patxi's Pizza, Cafe Borrone and Osteria Toscana. All of them are moderate restaurant with Italian food.
+A: I see Patxi's Pizza, Cafe Borrone and Osteria Toscana. All of them are moderate restaurants having Italian food.
 A: rdl: Patxi's Pizza https://www.yelp.com/biz/patxis-pizza-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: rdl: Cafe Borrone https://www.yelp.com/biz/cafe-borrone-menlo-park?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: rdl: Osteria Toscana https://www.yelp.com/biz/osteria-toscana-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
@@ -290,7 +290,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.cancel;
 
 # "no thanks", but intercepted by the exact match
 #U: \r bookkeeping special special:no
-A: Alright, good bye!
+A: Alright, bye!
 A: >> context = null // {}
 A: >> expecting = null
 
@@ -372,7 +372,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [distance(geo, $location.current_location)] of (@com.yelp.restaurant()) => notify;
 
-A: The distance is 2004.1 m.
+A: The distance is 1.2 mi.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ distance ( geo , LOCATION_0 ) ] of @com.yelp . restaurant ( ) #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , distance = MEASURE_m_0 } ] ] #[ count = NUMBER_0 ] #[ more = true ] ; // {"LOCATION_0":{"latitude":37.4275,"longitude":-122.1697,"display":null},"GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"vhfPni9pci29SEHrN1OtRg","display":"Ramen Nagi"},"MEASURE_m_0":{"unit":"m","value":2004.0661629148217},"NUMBER_0":50}
 A: >> expecting = null
 
@@ -390,7 +390,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (@com.yelp.restaurant(), id =~ "ramen nagi") => notify;
 
-A: Ramen Nagi is a moderate restaurant rated 4.5 star.
+A: Ramen Nagi is a moderate restaurant near [Latitude: 37.446 deg, Longitude: -122.161 deg].
 A: rdl: Ramen Nagi https://www.yelp.com/biz/ramen-nagi-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.yelp . restaurant ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , image_url = PICTURE_0 , link = URL_0 , cuisines = [ GENERIC_ENTITY_com.yelp:restaurant_cuisine_0 , GENERIC_ENTITY_com.yelp:restaurant_cuisine_1 ] , price = enum moderate , rating = NUMBER_0 , reviewCount = NUMBER_1 , geo = LOCATION_0 } ] ] ; // {"QUOTED_STRING_0":"ramen nagi","GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"vhfPni9pci29SEHrN1OtRg","display":"Ramen Nagi"},"PICTURE_0":"https://s3-media3.fl.yelpcdn.com/bphoto/OKCXWIEFIkNdvkqETl0Bqw/o.jpg","URL_0":"https://www.yelp.com/biz/ramen-nagi-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg","GENERIC_ENTITY_com.yelp:restaurant_cuisine_0":{"value":"ramen","display":"Ramen"},"GENERIC_ENTITY_com.yelp:restaurant_cuisine_1":{"value":"noodles","display":"Noodles"},"NUMBER_0":4.5,"NUMBER_1":1625,"LOCATION_0":{"latitude":37.445523,"longitude":-122.1607073261,"display":null}}
 A: >> expecting = null
@@ -408,7 +408,7 @@ A: >> expecting = command
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (@com.yelp.restaurant(), id =~ "ramen nagi") => notify;
 
-A: Ramen Nagi is a moderate restaurant rated 4.5 star.
+A: Ramen Nagi is a moderate restaurant near [Latitude: 37.446 deg, Longitude: -122.161 deg].
 A: rdl: Ramen Nagi https://www.yelp.com/biz/ramen-nagi-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.yelp . restaurant ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , image_url = PICTURE_0 , link = URL_0 , cuisines = [ GENERIC_ENTITY_com.yelp:restaurant_cuisine_0 , GENERIC_ENTITY_com.yelp:restaurant_cuisine_1 ] , price = enum moderate , rating = NUMBER_0 , reviewCount = NUMBER_1 , geo = LOCATION_0 } ] ] ; // {"QUOTED_STRING_0":"ramen nagi","GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"vhfPni9pci29SEHrN1OtRg","display":"Ramen Nagi"},"PICTURE_0":"https://s3-media3.fl.yelpcdn.com/bphoto/OKCXWIEFIkNdvkqETl0Bqw/o.jpg","URL_0":"https://www.yelp.com/biz/ramen-nagi-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg","GENERIC_ENTITY_com.yelp:restaurant_cuisine_0":{"value":"ramen","display":"Ramen"},"GENERIC_ENTITY_com.yelp:restaurant_cuisine_1":{"value":"noodles","display":"Noodles"},"NUMBER_0":4.5,"NUMBER_1":1625,"LOCATION_0":{"latitude":37.445523,"longitude":-122.1607073261,"display":null}}
 A: >> expecting = null
@@ -494,7 +494,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [release_date] of (@com.spotify.song(), id =~ "Nice For What") => notify;
 
-A: Nice For What is a song released in 6/28/2018. Would you like to play it on Spotify?
+A: Nice For What is a song released on June 28, 2018. Would you like to play it on Spotify?
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , release_date = DATE_0 } ] ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"DATE_0":"2018-06-29T00:00:00.000Z"}
 A: >> expecting = command
 
@@ -505,7 +505,7 @@ A: >> expecting = command
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [release_date] of (@com.spotify.song(), id =~ "hello") => notify;
 
-A: Hello? is a song released in 5/24/2018. Would you like to play it on Spotify?
+A: Hello? Is a song released on May 24, 2018. Would you like to play it on Spotify?
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , release_date = DATE_0 } ] ] #[ count = 11 ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"hello","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:7qwt4xUIqQWCu1DJf96g2k","display":"Hello?"},"DATE_0":"2018-05-25T00:00:00.000Z"}
 A: >> expecting = command
 
@@ -527,7 +527,7 @@ A: >> expecting = command
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [release_date] of (@com.spotify.album(), id =~ "the wall") => notify;
 
-A: The Wall is an album from 11/29/1979.
+A: The Wall is an album from November 29, 1979.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . album ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:album_0 , release_date = DATE_0 } ] ] #[ count = 4 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"the wall","GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:5Dbax7G8SWrP9xyzkOvy2F","display":"The Wall"},"DATE_0":"1979-11-30T00:00:00.000Z"}
 A: >> expecting = null
 
@@ -537,14 +537,14 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [release_date] of (@com.spotify.album(), id =~ "the wall") => notify;
 
-A: The Wall is an album from 11/29/1979.
+A: The Wall is an album from November 29, 1979.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . album ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:album_0 , release_date = DATE_0 } ] ] #[ count = 4 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"the wall","GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:5Dbax7G8SWrP9xyzkOvy2F","display":"The Wall"},"DATE_0":"1979-11-30T00:00:00.000Z"}
 A: >> expecting = null
 
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @org.thingpedia.weather.current(location=new Location(37.442156, -122.1634471, "Palo Alto, California")) => notify;
 
-A: The current weather in Palo Alto, California is sunny. The temperature is 15.6 C and the humidity is 91.3 %.
+A: The current weather in Palo Alto, California is sunny. The temperature is 60.1 F and the humidity is 91.3 %.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . album ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:album_0 , release_date = DATE_0 } ] ] #[ count = 4 ] ; @org.thingpedia.weather . current ( location = LOCATION_0 ) #[ results = [ { location = LOCATION_0 , temperature = MEASURE_C_0 , wind_speed = MEASURE_mps_0 , humidity = NUMBER_0 , cloudiness = NUMBER_1 , fog = 0 , status = enum sunny , icon = PICTURE_0 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"the wall","GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:5Dbax7G8SWrP9xyzkOvy2F","display":"The Wall"},"DATE_0":"1979-11-30T00:00:00.000Z","LOCATION_0":{"latitude":37.442156,"longitude":-122.1634471,"display":"Palo Alto, California"},"MEASURE_C_0":{"unit":"C","value":15.6},"MEASURE_mps_0":{"unit":"mps","value":3.4},"NUMBER_0":91.3,"NUMBER_1":4.7,"PICTURE_0":"http://api.met.no/weatherapi/weathericon/1.1/?symbol=1;content_type=image/png"}
 A: >> expecting = null
 
@@ -602,7 +602,7 @@ A: >> expecting = command
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (sort reviewCount desc of @com.yelp.restaurant())[1] => notify;
 
-A: The restaurant with the highest review count is NOLA Restaurant & Bar. It is an expensive restaurant rated 3.5 star.
+A: The restaurant with the highest review count is NOLA Restaurant & Bar. It is an expensive restaurant near [Latitude: 37.445 deg, Longitude: -122.161 deg].
 A: rdl: NOLA Restaurant & Bar https://www.yelp.com/biz/nola-restaurant-and-bar-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; sort ( reviewCount desc of @com.yelp . restaurant ( ) ) [ 1 ] #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , image_url = PICTURE_0 , link = URL_0 , cuisines = [ GENERIC_ENTITY_com.yelp:restaurant_cuisine_0 , GENERIC_ENTITY_com.yelp:restaurant_cuisine_1 ] , price = enum expensive , rating = NUMBER_0 , reviewCount = NUMBER_1 , geo = LOCATION_0 , phone = PHONE_NUMBER_0 } ] ] ; // {"GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"jwaXc3VVGDFQu1aCoiXwdw","display":"NOLA Restaurant & Bar"},"PICTURE_0":"https://s3-media2.fl.yelpcdn.com/bphoto/tna5SSdgZq3fFxoi4-Xx7A/o.jpg","URL_0":"https://www.yelp.com/biz/nola-restaurant-and-bar-palo-alto?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg","GENERIC_ENTITY_com.yelp:restaurant_cuisine_0":{"value":"cajun","display":"Cajun/Creole"},"GENERIC_ENTITY_com.yelp:restaurant_cuisine_1":{"value":"newamerican","display":"American (New)"},"NUMBER_0":3.5,"NUMBER_1":2821,"LOCATION_0":{"latitude":37.4450225830078,"longitude":-122.161323547363,"display":null},"PHONE_NUMBER_0":"+16503282722"}
 A: >> expecting = null
@@ -613,7 +613,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (sort reviewCount asc of @com.yelp.restaurant())[1] => notify;
 
-A: The restaurant with the lowest review count is The Ivy Cambridge Brasserie. It is a restaurant rated 4.5 star with British food.
+A: The restaurant with the lowest review count is The Ivy Cambridge Brasserie. It is a restaurant near [Latitude: 52.207 deg, Longitude: 0.118 deg] rated 4.5 star.
 A: rdl: The Ivy Cambridge Brasserie https://www.yelp.com/biz/the-ivy-cambridge-brasserie-cambridge?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; sort ( reviewCount asc of @com.yelp . restaurant ( ) ) [ 1 ] #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , image_url = PICTURE_0 , link = URL_0 , cuisines = [ GENERIC_ENTITY_com.yelp:restaurant_cuisine_0 ] , rating = NUMBER_0 , reviewCount = 12 , geo = LOCATION_0 , phone = PHONE_NUMBER_0 } ] ] ; // {"GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"yzBYyndSQ3RI6Hci2F9pRQ","display":"The Ivy Cambridge Brasserie"},"PICTURE_0":"https://s3-media4.fl.yelpcdn.com/bphoto/9daDsE_Aq-AtJnDDPruBSQ/o.jpg","URL_0":"https://www.yelp.com/biz/the-ivy-cambridge-brasserie-cambridge?adjust_creative=hejPBQRox5iXtqGPiDw4dg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=hejPBQRox5iXtqGPiDw4dg","GENERIC_ENTITY_com.yelp:restaurant_cuisine_0":{"value":"british","display":"British"},"NUMBER_0":4.5,"LOCATION_0":{"latitude":52.2069714284192,"longitude":0.118247921026355,"display":null},"PHONE_NUMBER_0":"+441223344044"}
 A: >> expecting = null
@@ -637,7 +637,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: @com.xkcd.comic();
 
-A: I found xkcd 20. It is an xkcd comic from 1/20/2018 titled Some Device 10.
+A: I found xkcd 20. It is an xkcd comic from January 20, 2018 titled Some Device 10.
 A: rdl: Some Device 10 str:ENTITY_tt:url::1:
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.xkcd ( id = GENERIC_ENTITY_tt:device_id_0 ) . comic ( ) #[ results = [ { id = NUMBER_0 , title = QUOTED_STRING_0 , release_date = DATE_0 , picture_url = PICTURE_0 , link = URL_0 , alt_text = QUOTED_STRING_0 } ] ] #[ count = NUMBER_1 ] #[ more = true ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.xkcd-10","display":"Some Device 10"},"NUMBER_0":20,"QUOTED_STRING_0":"Some Device 10","DATE_0":"2018-01-20T08:00:00.000Z","PICTURE_0":"str:ENTITY_tt:picture::14:","URL_0":"str:ENTITY_tt:url::1:","NUMBER_1":50}
 A: >> expecting = null
@@ -649,7 +649,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: sort(release_date desc of @com.xkcd.comic())[1];
 
-A: The latest xkcd comic is 371. It is an xkcd comic from 8/31/2020 titled str:QUOTED_STRING::3:.
+A: The latest xkcd comic is 371. It is an xkcd comic from August 31, 2020 titled str:QUOTED_STRING::3:.
 A: rdl: str:QUOTED_STRING::3: str:ENTITY_tt:url::39:
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; sort ( release_date desc of @com.xkcd ( id = GENERIC_ENTITY_tt:device_id_0 ) . comic ( ) ) [ 1 ] #[ results = [ { id = NUMBER_0 , title = QUOTED_STRING_0 , release_date = DATE_0 , picture_url = PICTURE_0 , link = URL_0 , alt_text = QUOTED_STRING_1 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.xkcd-10","display":"Some Device 10"},"NUMBER_0":371,"QUOTED_STRING_0":"str:QUOTED_STRING::3:","DATE_0":"2020-08-31T07:00:00.000Z","PICTURE_0":"str:ENTITY_tt:picture::26:","URL_0":"str:ENTITY_tt:url::39:","QUOTED_STRING_1":"str:QUOTED_STRING::6:"}
 A: >> expecting = null

--- a/test/agent/thingpedia.tt
+++ b/test/agent/thingpedia.tt
@@ -721,7 +721,7 @@ class @com.spotify
                       property=["release date #"],
                       adjective=["#"],
                       preposition=["from #", "in #"],
-                      passive_verb=["released in #", "released #", "published in #"],
+                      passive_verb=["released on #", "released #", "published in #"],
                       adjective_argmin=["least recent", "oldest", "first"],
                       adjective_argmax=["most recent", "newest", "latest"],
                       passive_verb_argmax=["released most recently"],

--- a/test/unit/test_describe_api.js
+++ b/test/unit/test_describe_api.js
@@ -20,13 +20,14 @@
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
 import assert from 'assert';
-import { Ast }  from 'thingtalk';
+import { Ast, Syntax }  from 'thingtalk';
 import { Describer } from '../../lib/utils/thingtalk/describe';
 
 async function testDescribeArg() {
-    const describer = new Describer('en-US', 'America/Los_Angeles');
-    const describer2 = new Describer('en-US', 'Asia/Tokyo');
-    const describer3 = new Describer('en-US', 'Pacific/Honolulu');
+    const allocator = new Syntax.SequentialEntityAllocator({});
+    const describer = new Describer('en-US', 'America/Los_Angeles', allocator);
+    const describer2 = new Describer('en-US', 'Asia/Tokyo', allocator);
+    const describer3 = new Describer('en-US', 'Pacific/Honolulu', allocator);
     // we would like to test i18n here too but
     // travis's nodejs does not have full-icu so Intl is
     // broken (also on Android)
@@ -41,37 +42,37 @@ async function testDescribeArg() {
         [new Ast.Value.Boolean(true), 'true'],
         [new Ast.Value.Boolean(false), 'false'],
 
-        [new Ast.Value.String('some string'), `some string`],
-        [new Ast.Value.String('some string with "'), `some string with "`], //"
+        [new Ast.Value.String('some string'), `QUOTED_STRING_0`],
+        [new Ast.Value.String('some string with "'), `QUOTED_STRING_1`],
 
-        [new Ast.Value.Measure(21, 'C'), `21 C`],
-        [new Ast.Value.Measure(21, 'kmph'), `21 kmph`],
+        [new Ast.Value.Measure(21, 'C'), 'MEASURE_C_0'],
+        [new Ast.Value.Measure(21, 'kmph'), 'MEASURE_mps_0'],
         [new Ast.Value.Computation('+',
             [new Ast.Value.Measure(6, 'ft'),
              new Ast.Value.Measure(4, 'in')]),
-         `6 ft 4 in`],
-        [new Ast.Value.Number(4.0), `4`],
-        [new Ast.Value.Number(4.5), `4.5`],
-        [new Ast.Value.Number(1e+23), `100,000,000,000,000,000,000,000`],
+         `MEASURE_m_0 MEASURE_m_1`],
+        [new Ast.Value.Number(4.0), `NUMBER_0`],
+        [new Ast.Value.Number(4.5), `NUMBER_1`],
+        [new Ast.Value.Number(1e+23), `NUMBER_2`],
 
         // U+OOAO NO-BREAK SPACE
-        [new Ast.Value.Currency(1000, 'usd'), '$1,000.00'],
-        [new Ast.Value.Currency(1000.001, 'usd'), '$1,000.00'],
-        [new Ast.Value.Currency(1000.005, 'usd'), '$1,000.01'],
-        [new Ast.Value.Currency(1000.99, 'usd'), '$1,000.99'],
-        [new Ast.Value.Currency(1000.995, 'usd'), '$1,001.00'],
-        [new Ast.Value.Currency(1000, 'eur'), '€1,000.00'],
+        [new Ast.Value.Currency(1000, 'usd'), 'CURRENCY_0'],
+        [new Ast.Value.Currency(1000.001, 'usd'), 'CURRENCY_1'],
+        [new Ast.Value.Currency(1000.005, 'usd'), 'CURRENCY_2'],
+        [new Ast.Value.Currency(1000.99, 'usd'), 'CURRENCY_3'],
+        [new Ast.Value.Currency(1000.995, 'usd'), 'CURRENCY_4'],
+        [new Ast.Value.Currency(1000, 'eur'), 'CURRENCY_5'],
 
         [new Ast.Value.Location(new Ast.Location.Relative('home')), `home`],
         [new Ast.Value.Location(new Ast.Location.Relative('work')), `work`],
         [new Ast.Value.Location(new Ast.Location.Relative('current_location')), `here`],
-        [new Ast.Value.Location(new Ast.Location.Absolute(0, 0, 'North Pole')), `North Pole`],
-        [new Ast.Value.Location(new Ast.Location.Absolute(0, 0, null)), `[Latitude: 0 deg, Longitude: 0 deg]`],
+        [new Ast.Value.Location(new Ast.Location.Absolute(0, 0, 'North Pole')), `LOCATION_0`],
+        [new Ast.Value.Location(new Ast.Location.Absolute(0, 0, null)), `LOCATION_0`],
 
         [new Ast.Value.Time(new Ast.Time.Relative('morning')), 'the morning'],
         [new Ast.Value.Time(new Ast.Time.Relative('evening')), 'the evening'],
 
-        [new Ast.Value.Entity('foo', 'tt:foo', 'Some Entity'), 'Some Entity'],
+        [new Ast.Value.Entity('foo', 'tt:foo', 'Some Entity'), 'GENERIC_ENTITY_tt:foo_0'],
 
     ];
 
@@ -83,14 +84,14 @@ async function testDescribeArg() {
 
     const date = new Ast.Value.Date(new Date(2018, 9, 13, 0, 0, 0));
 
-    assert.strictEqual(describer.describeArg(date), 'Saturday, October 13, 2018');
-    assert.strictEqual(describer2.describeArg(date), 'Saturday, October 13, 2018');
-    assert.strictEqual(describer3.describeArg(date), 'Friday, October 12, 2018');
+    assert.strictEqual(describer.describeArg(date), 'DATE_0');
+    assert.strictEqual(describer2.describeArg(date), 'DATE_0');
+    assert.strictEqual(describer3.describeArg(date), 'DATE_0');
 
     const date2 = new Ast.Value.Date(new Date(2018, 9, 13, 1, 0, 0));
-    assert.strictEqual(describer.describeArg(date2), '10/13/2018, 1:00:00 AM');
-    assert.strictEqual(describer2.describeArg(date2), '10/13/2018, 5:00:00 PM');
-    assert.strictEqual(describer3.describeArg(date2), '10/12/2018, 10:00:00 PM');
+    assert.strictEqual(describer.describeArg(date2), 'DATE_1');
+    assert.strictEqual(describer2.describeArg(date2), 'DATE_1');
+    assert.strictEqual(describer3.describeArg(date2), 'DATE_1');
 }
 
 export default async function main() {


### PR DESCRIPTION
The goal of this refactor is two fold:
- We need to generate delexicalized agent utterances at inference
  time to pass to the NLG
- We want the actual text of the entity to be generated by the I18n
  code during postprocessing, so consistent postprocessing is
  applied to both synthetic and NLG sentences, and we can use
  locale-specific code.

To apply this refactoring, the system of inference time constants
is modified to make use of a SequentialEntityAllocator, which allocates
entity tokens (NUMBER_0, DATE_1, etc.) for each value that appears
in the context. This entity allocator is also passed to the Describe
module when that module extracts a value from the program.

At training time, we have only one SequentialEntityAllocator,
which is primed with the fake entities used during generation,
plus any entity that is generated by the simulator and observed
by Describe. At inference time, we reset the entity allocator
immediately prior to processing a new context.

The entities thus allocated are later passed to the I18n module for
postprocessing. This module gained code to automatically select
the most appropriate unit for a given size.

Fixes #447