### PR TITLE
Disable support for multidomain contexts

### DIFF
--- a/languages/thingtalk/en/dlg/search-questions.genie
+++ b/languages/thingtalk/en/dlg/search-questions.genie
@@ -226,13 +226,15 @@ specific_dontcare_phrase : C.FilterSlot = {
 }
 
 coref_constant : Ast.Value = {
-    ( ctx:ctx_multidomain ('the' | 'the same') base:base_table '\'s' param:out_param_Any with { functionName = base.functionName } '.'
-    | ctx:ctx_multidomain generic_preamble_for_answer ('the' | 'the same') base:base_table '\'s' param:out_param_Any with { functionName = base.functionName } '.'
-    | ctx:ctx_multidomain 'the same' param:out_param_Any 'as' 'the' base:base_table with { functionName = param.functionName } '.'
-    | ctx:ctx_multidomain generic_preamble_for_answer 'the same' param:out_param_Any 'as' 'the' base:base_table with { functionName = param.functionName } '.'
-    | ctx:ctx_multidomain ('the same as the' | 'the') param:out_param_Any 'of' 'the' base:base_table with { functionName = param.functionName } '.'
-    | ctx:ctx_multidomain generic_preamble_for_answer ('the same as the' | 'the') param:out_param_Any 'of' 'the' base:base_table with { functionName = param.functionName } '.'
-    ) => D.corefConstant(ctx, base, param);
+    ?multidomain {
+        ( ctx:ctx_multidomain ('the' | 'the same') base:base_table '\'s' param:out_param_Any with { functionName = base.functionName } '.'
+        | ctx:ctx_multidomain generic_preamble_for_answer ('the' | 'the same') base:base_table '\'s' param:out_param_Any with { functionName = base.functionName } '.'
+        | ctx:ctx_multidomain 'the same' param:out_param_Any 'as' 'the' base:base_table with { functionName = param.functionName } '.'
+        | ctx:ctx_multidomain generic_preamble_for_answer 'the same' param:out_param_Any 'as' 'the' base:base_table with { functionName = param.functionName } '.'
+        | ctx:ctx_multidomain ('the same as the' | 'the') param:out_param_Any 'of' 'the' base:base_table with { functionName = param.functionName } '.'
+        | ctx:ctx_multidomain generic_preamble_for_answer ('the same as the' | 'the') param:out_param_Any 'of' 'the' base:base_table with { functionName = param.functionName } '.'
+        ) => D.corefConstant(ctx, base, param);
+    }
 }
 
 imprecise_search_coref_answer : Ast.Value|C.FilterSlot = {

--- a/lib/utils/thingtalk/dialogue_state_utils.ts
+++ b/lib/utils/thingtalk/dialogue_state_utils.ts
@@ -155,6 +155,8 @@ export function computeNewState(state : Ast.DialogueState|null, prediction : Ast
     return clone;
 }
 
+const ENABLE_MULTIDOMAIN_CONTEXT = false;
+
 export function prepareContextForPrediction(context : Ast.DialogueState|null, forTarget : 'user'|'agent') : Ast.DialogueState|null {
     if (context === null)
         return null;
@@ -167,10 +169,18 @@ export function prepareContextForPrediction(context : Ast.DialogueState|null, fo
         const item = context.history[i];
         if (item.results === null)
             break;
-        if (lastItems.length > 0 && item.compatible(lastItems[lastItems.length-1]))
-            lastItems[lastItems.length-1] = item;
-        else
-            lastItems.push(item);
+
+        if (ENABLE_MULTIDOMAIN_CONTEXT) {
+            if (lastItems.length > 0 && item.compatible(lastItems[lastItems.length-1]))
+                lastItems[lastItems.length-1] = item;
+            else
+                lastItems.push(item);
+        } else {
+            if (lastItems.length > 0)
+                lastItems[0] = item;
+            else
+                lastItems.push(item);
+        }
     }
 
     // include at most the last 3 last items, or we'll run out of context length


### PR DESCRIPTION
This is a large hammer to solve some of the batch size issues we're
seeing in the Thingpedia model, as we generate contexts that are
too long. With this change, the context will contain at most
one statement, and therefore will be quite short, at the expense
of not supporting any multi-domain parameter passing.

This commit is incompatible with MultiWOZ and will need to be
reverted or made into an option.

@s-jse comments? I can't see any other way to avoid continuous batch size problems.