### PR TITLE
evaluation: tokenize unresolved location names when comparing slots

### DIFF
--- a/lib/dataset-tools/evaluation/dialogue_evaluator.ts
+++ b/lib/dataset-tools/evaluation/dialogue_evaluator.ts
@@ -200,7 +200,7 @@ class DialogueEvaluatorStream extends Stream.Transform {
                 return this._tokenizeSlot(value.value.display||'');
             // unresolved
             assert(value.value instanceof Ast.UnresolvedLocation);
-            return value.value.name;
+            return this._tokenizeSlot(value.value.name);
         }
         if (value instanceof Ast.ContextRefValue)
             return 'context-' + value.name;


### PR DESCRIPTION
So we compare consistently between the generated program and the
gold program.

Fixes #457