### PR TITLE
Fix loading queries that have parameters with no canonical

### DIFF
--- a/languages/thingtalk/load-thingpedia.ts
+++ b/languages/thingtalk/load-thingpedia.ts
@@ -1197,7 +1197,9 @@ export default class ThingpediaLoader {
         for (const argname of q.args) {
             const arg = q.getArgument(argname)!;
 
-            if (typeof arg.metadata.canonical === 'string' || Array.isArray(arg.metadata.canonical))
+            if (typeof arg.metadata.canonical === 'string' ||
+                typeof arg.metadata.canonical === 'undefined' ||
+                Array.isArray(arg.metadata.canonical))
                 continue;
 
             let op = '==';

--- a/test/data/en-US/thingpedia.tt
+++ b/test/data/en-US/thingpedia.tt
@@ -2839,13 +2839,12 @@ class @com.yelp
                           property=[]
                         }],
                         out image_url: Entity(tt:picture)
-                        #[genie=false]
+                        #[filterable=false]
                         #_[canonical={
                           base=["picture", "image", "photo"]
                         }],
                         out link: Entity(tt:url)
-                        #[genie=false]
-                        #_[canonical="link"],
+                        /* no #_[canonical], to test that we don't crash */,
                         out cuisines: Array(Entity(com.yelp:restaurant_cuisine))
                         #[conflict_filter=["id"]]
                         #_[canonical={


### PR DESCRIPTION
If there is no canonical, don't try to look for an implicit_identity
or reverse_property.

Fixes #466