### PR TITLE
builtin: fix random number if low > 6

### DIFF
--- a/lib/engine/devices/builtins/thingengine.builtin.ts
+++ b/lib/engine/devices/builtins/thingengine.builtin.ts
@@ -58,10 +58,16 @@ export default class MiscellaneousDevice extends Tp.BaseDevice {
         // FIXME convert to the right timezone...
         return [{ time: new Tp.Value.Time(now.getHours(), now.getMinutes(), now.getSeconds()) }];
     }
-    get_get_random_between({ low, high } : { low : number, high : number }) {
-        low = (low === null || low === undefined) ?  1 : low;
-        high = (high === null || high === undefined) ?  6 : high;
-        return [{ random: Math.round(low + (Math.random() * (high - low))) }];
+    get_get_random_between({ low, high } : { low : number|null|undefined, high : number|null|undefined }) {
+        if ((low === null || low === undefined) && (high === null || high === undefined)) {
+            low = 1;
+            high = 6;
+        } else if (low === null || low === undefined) {
+            low = high! < 0 ? Math.min(2 * high!, high! - 5) : 1;
+        } else if (high === null || high === undefined) {
+            high = low < 0 ? 0 : Math.max(2 * low, low + 5);
+        }
+        return [{ random: Math.round(low + (Math.random() * (high! - low))) }];
     }
 
     get_get_name() {

--- a/test/engine/test_builtins.js
+++ b/test/engine/test_builtins.js
@@ -58,14 +58,32 @@ async function testGetCommands(engine) {
     }
 }
 
+async function checkRandom(device, low, high, expectedLow, expectedHigh) {
+    for (let _try = 0; _try < 1000; _try++) {
+        const [random] = await device.get_get_random_between({ low, high });
+        assert.strictEqual(typeof random.random, 'number');
+        assert(random.random >= expectedLow, `got number ${random.random} which is less than ${expectedLow}`);
+        assert(random.random <= expectedHigh, `got number ${random.random} which is more than ${expectedHigh}`);
+        assert.strictEqual(Math.floor(random.random), random.random);
+    }
+}
+
 async function testOtherBuiltins(engine) {
     const device = engine.devices.getDevice('thingengine-own-global');
 
-    const [random] = await device.get_get_random_between({ low: 0, high: 7 });
-    assert.strictEqual(typeof random.random, 'number');
-    assert(random.random >= 0);
-    assert(random.random <= 7);
-    assert.strictEqual(Math.floor(random.random), random.random);
+    await checkRandom(device, 0, 7, 0, 7);
+    await checkRandom(device, 7, 0, 0, 7);
+    await checkRandom(device, undefined, undefined, 1, 6);
+
+    await checkRandom(device, 2, undefined, 2, 7);
+    await checkRandom(device, 10, undefined, 10, 20);
+    await checkRandom(device, 100, undefined, 100, 200);
+    await checkRandom(device, -100, undefined, -100, 0);
+    await checkRandom(device, undefined, 1, 1, 1);
+    await checkRandom(device, undefined, 10, 1, 10);
+    await checkRandom(device, undefined, -2, -7, -2);
+    await checkRandom(device, undefined, -10, -20, -10);
+    await checkRandom(device, undefined, -100, -200, -100);
 }
 
 function testBuiltinsAreExpected(engine) {


### PR DESCRIPTION
If low > high (which defaults to 6), the existing math is incorrect.
Instead, if low > high, raise the high to low + 6, keeping the default
range in case the user only specifies high.

Fixes #474