### PR TITLE
dialogue-loop: catch errors from reading the next queue item

### DIFF
--- a/lib/dialogue-agent/dialogue-loop.ts
+++ b/lib/dialogue-agent/dialogue-loop.ts
@@ -663,8 +663,9 @@ export default class DialogueLoop {
             await this._showWelcome();
 
         while (!this._stopped) {
-            const item = await this.nextQueueItem();
+            let item;
             try {
+                item = await this.nextQueueItem();
                 if (item instanceof QueueItem.UserInput) {
                     this._lastNotificationApp = undefined;
                     await this._handleUserInput(item.command);


### PR DESCRIPTION
So we catch and handle any cancellation error that comes from the
inactivity timeout.

Fixes #471