### PR TITLE
Bug fix: actually disable recording when it is disabled

### DIFF
--- a/lib/dialogue-agent/conversation.ts
+++ b/lib/dialogue-agent/conversation.ts
@@ -275,6 +275,7 @@ export default class Conversation extends events.EventEmitter {
 
     endRecording() {
         this._options.log = false;
+        this.dialogueFinished();
     }
 
     notify(appId : string, icon : string|null, outputType : string, outputValue : Record<string, unknown>) {
@@ -517,12 +518,14 @@ export default class Conversation extends events.EventEmitter {
     }
 
     updateLog(field : keyof DialogueTurn, value : string) {
-        let last = this._lastTurn;
-        if (!last || last.done) {
-            last = new DialogueTurnLog();
-            this.appendNewTurn(last);
+        if (this.inRecordingMode) {
+            let last = this._lastTurn;
+            if (!last || last.done) {
+                last = new DialogueTurnLog();
+                this.appendNewTurn(last);
+            }
+            last.update(field, value);
         }
-        last.update(field, value);
     }
 
     async saveLog() {


### PR DESCRIPTION
Only update logs when in recording mode;
Also mark dialogue as finished immediately after recording is disabled,
so the next time recording gets enabled, we do not append to the last
unfinished dialogue.

Fix #503 