### PR TITLE
DeviceDatabase: implement automatic device updates

### DIFF
--- a/lib/engine/devices/database.js
+++ b/lib/engine/devices/database.js
@@ -25,6 +25,11 @@ import * as Tp from 'thingpedia';
 const ObjectSet = Tp.ObjectSet;
 import SyncDatabase from '../db/syncdb';
 
+// check for updates of all devices every 3 hours
+// this is to catch bug fixes quickly
+// we'll lower this to 24 hours after the alpha release
+const UPDATE_FREQUENCY = 3 * 3600 * 1000;
+
 /**
  * The collection of all configured Thingpedia devices.
  */
@@ -59,6 +64,8 @@ export default class DeviceDatabase extends ObjectSet.Base {
         this._subdeviceRemovedListener = this._notifySubdeviceRemoved.bind(this);
 
         this._isUpdatingState = false;
+
+        this._updateTimer = null;
     }
 
     async loadOneDevice(serializedDevice, addToDB) {
@@ -99,6 +106,8 @@ export default class DeviceDatabase extends ObjectSet.Base {
                 console.error('Failed to load one device: ' + e);
             }
         }));
+
+        this._updateTimer = setInterval(() => this._updateAll(), UPDATE_FREQUENCY);
     }
 
     _onObjectAdded(uniqueId, row) {
@@ -123,6 +132,9 @@ export default class DeviceDatabase extends ObjectSet.Base {
 
     async stop() {
         this._syncdb.close();
+        if (this._updateTimer)
+            clearInterval(this._updateTimer);
+        this._updateTimer = null;
     }
 
     // return all devices directly stored in the database
@@ -375,10 +387,32 @@ export default class DeviceDatabase extends ObjectSet.Base {
         this.schemas.removeFromCache(kind);
 
         await this._factory.updateDeviceClass(kind);
+        await this._reloadAllDevices(kind);
+    }
+
+    async _reloadAllDevices(kind) {
         const devices = this._getValuesOfExactKind(kind);
 
         return Promise.all(devices.map((d) => {
             return this.reloadDevice(d);
         }));
+    }
+
+    async _updateAll() {
+        const kinds = new Map; // from kind to version
+
+        for (const dev of this._devices.values())
+            kinds.set(dev.kind, dev.constructor.metadata.version);
+
+        for (const [kind, oldVersion] of kinds) {
+            if (kind.startsWith('org.thingpedia.builtin'))
+                continue;
+
+            this.schemas.removeFromCache(kind);
+            await this._factory.updateDeviceClass(kind);
+            const newClass = await this._factory.getDeviceClass(kind);
+            if (newClass.metadata.version !== oldVersion)
+                await this._reloadAllDevices(kind);
+        }
     }
 }

--- a/tool/assistant.js
+++ b/tool/assistant.js
@@ -248,7 +248,7 @@ export function initArgparse(subparsers) {
 }
 
 export async function execute(args) {
-    const platform = new Platform(args.workdir, args.locale, args.thingpediaUrl);
+    const platform = new Platform(args.workdir, args.locale, args.thingpedia_url);
     const prefs = platform.getSharedPreferences();
     if (args.thingpedia_dir && args.thingpedia_dir.length)
         prefs.set('developer-dir', args.thingpedia_dir);


### PR DESCRIPTION
Run a timer to check for new versions of the skills every few
hours. That way, any bug fixes that are deployed to Thingpedia
become available to testers without me clearing the caches and
restarting the engines.