### PR TITLE
engine/tier_manager: clear reconnection timeouts when stopped

### DIFF
--- a/lib/engine/tiers/tier_manager.js
+++ b/lib/engine/tiers/tier_manager.js
@@ -79,6 +79,7 @@ export default class TierManager extends events.EventEmitter {
         this._clientConfigurations = {};
         this._clientSockets = {};
         this._backoffs = {};
+        this._reconnectTimeouts = {};
 
         this._handlers = {};
     }
@@ -128,7 +129,8 @@ export default class TierManager extends events.EventEmitter {
             // Try again at some point in the future
             let timer = this._backoffTimer(address);
             console.log('Trying again in ' + Math.floor(timer/60000) + ' minutes');
-            setTimeout(() => {
+            this._reconnectTimeouts[address] = setTimeout(() => {
+                this._reconnectTimeouts[address] = undefined;
                 this._tryOpenClient(address);
             }, timer);
         });
@@ -218,6 +220,12 @@ export default class TierManager extends events.EventEmitter {
     }
 
     async stop() {
+        for (const address in this._reconnectTimeouts) {
+            const timeout = this._reconnecttTimeouts[address];
+            if (timeout)
+                clearTimeout(timeout);
+        }
+
         await Promise.all(Object.values(this._clientSockets).map((s) => s.close()));
     }
 


### PR DESCRIPTION
Otherwise, we will hang when the engine closes if we previously
lost the connection to the cloud. This causes the thingpedia-common-devices
unit tests to hang sometimes.