### PR TITLE
Add a command to set the default temperature unit

### DIFF
--- a/data/builtins/thingengine.builtin/dataset.tt.in
+++ b/data/builtins/thingengine.builtin/dataset.tt.in
@@ -127,4 +127,8 @@ dataset @org.thingpedia.builtin.thingengine.builtin language "en" {
     program (p_type : Enum(current,home,work), p_location : Location) = @org.thingpedia.builtin.thingengine.builtin.set_location(type=p_type, location=p_location)
     #_[utterances=["my ${p_type} address is ${p_location}",
                    "my ${p_type} is at ${p_location}"]];
+
+    program (p_unit : Enum(celsius,fahrenheit,kelvin)) = @org.thingpedia.builtin.thingengine.builtin.set_temperature_unit(unit=p_unit)
+    #_[utterances=["use ${p_unit} for temperatures", "use ${p_unit} to display temperatures",
+                   "tell me the temperature in ${p_unit}"]];
 }

--- a/data/builtins/thingengine.builtin/manifest.tt.in
+++ b/data/builtins/thingengine.builtin/manifest.tt.in
@@ -315,4 +315,15 @@ class @org.thingpedia.builtin.thingengine.builtin
   #_[confirmation="change your ${type} location to ${name}"]
   #[doc="change the user's preferred locations (a setting)"]
   #[confirm=false];
+
+  action set_temperature_unit(in req unit : Enum(celsius,fahrenheit,kelvin)
+                              #_[prompt="what unit should i use"]
+                              #_[canonical={
+                                base=["unit"],
+                                preposition=["to #", "as #"],
+                              }])
+  #_[canonical=["set my preferred temperature unit", "change the temperature unit",
+                "set the default temperature unit"]]
+  #[doc="change the user's preferred temperature unit (a setting)"]
+  #[confirm=false];
 }

--- a/lib/engine/devices/builtins/thingengine.builtin.ts
+++ b/lib/engine/devices/builtins/thingengine.builtin.ts
@@ -314,4 +314,10 @@ export default class MiscellaneousDevice extends Tp.BaseDevice {
         prefs.set('context-$context.location.' + (type === 'current' ? 'current_location' : type),
             new TT.Ast.LocationValue(new TT.Ast.AbsoluteLocation(location.lat, location.lon, location.display)).toJS());
     }
+
+    do_set_temperature_unit({ unit } : { unit : string }) {
+        const platform = this.platform;
+        const prefs = platform.getSharedPreferences();
+        prefs.set('preferred-temperature', unit[0].toUpperCase());
+    }
 }


### PR DESCRIPTION
Commands from the user that are ambiguous ("XX degrees") and
replies from the agent will use the configured default temperature
unit.

Fixes #487