### PR TITLE
Use relative terms to display dates current to now in NLG

### DIFF
--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -1740,3 +1740,47 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.weather.forecast();
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.thingpedia.weather.forecast();
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: @org.thingpedia.weather.forecast(location=new Location(37.4275, -122.1697), date=$end_of(day))
+C: #[results=[
+C:   { date=new Date("2021-03-06T08:00:00.000Z"), location=new Location(37.4275, -122.1697), temperature=41C, wind_speed=7mps, humidity=15, cloudiness=7, fog=15, status=enum cloudy, icon="str:ENTITY_tt:picture::40:"^^tt:picture }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: It will be cloudy tomorrow in [Latitude: 37.428 deg, Longitude: -122.17 deg] and the temperature will be 105.8 F.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
+#! vote: up
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.weather.forecast(date=$start_of(day));
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.thingpedia.weather.forecast(date=$start_of(day));
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: @org.thingpedia.weather.forecast(date=$start_of(day), location=new Location(37.4275, -122.1697))
+C: #[results=[
+C:   { date=new Date("2021-03-05T08:00:00.000Z"), location=new Location(37.4275, -122.1697), temperature=41C, wind_speed=7mps, humidity=15, cloudiness=7, fog=15, status=enum cloudy, icon="str:ENTITY_tt:picture::40:"^^tt:picture }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: It will be cloudy today in [Latitude: 37.428 deg, Longitude: -122.17 deg] and the temperature will be 105.8 F.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
+#! vote: down
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -766,3 +766,34 @@ U: [rating, geo] of @com.yelp.restaurant(), id =~ "ramen nagi";
 A: Ramen Nagi is a restaurant near [Latitude: 37.446 deg, Longitude: -122.161 deg] rated 4.5 star.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ rating , geo ] of @com.yelp . restaurant ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , rating = NUMBER_0 , geo = LOCATION_0 } ] ] ; // {"QUOTED_STRING_0":"ramen nagi","GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"vhfPni9pci29SEHrN1OtRg","display":"Ramen Nagi"},"NUMBER_0":4.5,"LOCATION_0":{"latitude":37.445523,"longitude":-122.1607073261,"display":null}}
 A: >> expecting = null
+
+====
+# 52-weather-forecast
+
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.weather.forecast();
+
+A: It will be cloudy tomorrow in [Latitude: 37.428 deg, Longitude: -122.17 deg] and the temperature will be 105.8 F.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.weather . forecast ( location = LOCATION_0 , date = $end_of ( day ) ) #[ results = [ { date = DATE_0 , location = LOCATION_0 , temperature = MEASURE_C_0 , wind_speed = MEASURE_mps_0 , humidity = NUMBER_0 , cloudiness = 7 , fog = NUMBER_0 , status = enum cloudy , icon = PICTURE_0 } ] ] ; // {"LOCATION_0":{"latitude":37.4275,"longitude":-122.1697,"display":null},"DATE_0":"2021-03-06T08:00:00.000Z","MEASURE_C_0":{"unit":"C","value":41},"MEASURE_mps_0":{"unit":"mps","value":7},"NUMBER_0":15,"PICTURE_0":"str:ENTITY_tt:picture::40:"}
+A: >> expecting = null
+
+====
+# 53-weather-forecast-2
+
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.weather.forecast(date=$start_of(day));
+
+A: It will be cloudy today in [Latitude: 37.428 deg, Longitude: -122.17 deg] and the temperature will be 105.8 F.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.weather . forecast ( date = $start_of ( day ) , location = LOCATION_0 ) #[ results = [ { date = DATE_0 , location = LOCATION_0 , temperature = MEASURE_C_0 , wind_speed = MEASURE_mps_0 , humidity = NUMBER_0 , cloudiness = 7 , fog = NUMBER_0 , status = enum cloudy , icon = PICTURE_0 } ] ] ; // {"LOCATION_0":{"latitude":37.4275,"longitude":-122.1697,"display":null},"DATE_0":"2021-03-05T08:00:00.000Z","MEASURE_C_0":{"unit":"C","value":41},"MEASURE_mps_0":{"unit":"mps","value":7},"NUMBER_0":15,"PICTURE_0":"str:ENTITY_tt:picture::40:"}
+A: >> expecting = null
+
+#====
+# this one does not work because ThingTalk did not implement weekday dates
+# 54-weather-forecast-3
+
+#U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+#U: @org.thingpedia.weather.forecast(date=new Date(enum tuesday));
+
+#A: Ramen Nagi is a restaurant near [Latitude: 37.446 deg, Longitude: -122.161 deg] rated 4.5 star.
+#A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ rating , geo ] of @com.yelp . restaurant ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , rating = NUMBER_0 , geo = LOCATION_0 } ] ] ; // {"QUOTED_STRING_0":"ramen nagi","GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"vhfPni9pci29SEHrN1OtRg","display":"Ramen Nagi"},"NUMBER_0":4.5,"LOCATION_0":{"latitude":37.445523,"longitude":-122.1607073261,"display":null}}
+#A: >> expecting = null

--- a/test/agent/thingpedia.tt
+++ b/test/agent/thingpedia.tt
@@ -551,6 +551,65 @@ class @org.thingpedia.weather
   #[doc="Information about current weather"]
   #[confirm=false];
 
+  monitorable query forecast(in opt location: Location
+                            #_[prompt="what location do you want the weather forecast for"]
+                            #_[canonical={
+                              default="preposition",
+                              base=["location", "position", "place"],
+                              property=[],
+                              preposition=["in #", "around #", "for location #", "for #"]
+                            }]
+                            #[default=$location.current_location],
+                             in opt date: Date
+                            #_[prompt="what date or time do you want the forecast for"]
+                            #_[canonical={
+                              default="preposition",
+                              base=["time", "date"],
+                              property=[],
+                              preposition=["at #", "in #", "for #"]
+                            }]
+                            #[default=$end_of(day)],
+                            out temperature: Measure(C)
+                            #_[canonical="temperature"]
+                            // from the coldest artic to the death valley, in one filter
+                            #[min_number=-10C]
+                            #[max_number=50C],
+                            out wind_speed: Measure(mps)
+                            #_[canonical="wind speed"]
+                            #[min_number=0kmph]
+                            #[max_number=150kmph],
+                            out humidity: Number
+                            #_[canonical="humidity"]
+                            #[min_number=0]
+                            #[max_number=100],
+                            out cloudiness: Number
+                            #_[canonical="cloudiness"]
+                            #[min_number=0]
+                            #[max_number=100],
+                            out fog: Number
+                            #_[canonical="fog"]
+                            #[min_number=0]
+                            #[max_number=100],
+                            out status: Enum(raining,cloudy,sunny,snowy,sleety,drizzling,windy,foggy)
+                            #_[canonical="status"],
+                            out icon: Entity(tt:picture)
+                            #_[canonical="icon"])
+  #_[result=["it will be ${status} on ${date} in ${location} and the temperature will be ${temperature}",
+             "on ${date} the weather in ${location} will be ${status} . the temperature will be ${temperature} and the humidity will be ${humidity} %",
+             "on ${date} the weather in ${location} will be ${status} . the temperature will be ${temperature}",
+             "on ${date} the weather in ${location} will be ${status} . the humidity will be ${humidity} %",
+             "on ${date} the weather in ${location} will be ${status}",
+             "the weather in ${location} will be ${status} on ${date}"
+             ]]
+  #_[on_error={
+    no_past_forecast=["i cannot retrieve weather forecasts in the past"],
+    not_available=["the forecast for ${date} is not available yet"]
+  }]
+  #[minimal_projection=["status"]]
+  #_[canonical=["weather forecast", "forecasted weather outside", "future weather"]]
+  #[poll_interval=3600000ms]
+  #[doc="Information about future weather"]
+  #[confirm=false];
 }
 
 class @com.yelp

--- a/test/unit/test_describe.js
+++ b/test/unit/test_describe.js
@@ -328,7 +328,7 @@ const TEST_CASES = [
      `Get Date`],
 
     [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new Date(2020, 6, , 12, 0, 0) => notify;`,
-     `Get today's date such that the date is after 6/1/2020, 12:00:00 PM.`,
+     `Get today's date such that the date is after June 1, 2020 at 12:00 PM.`,
      `Get Date`],
 
     [`now => @org.thingpedia.builtin.thingengine.builtin.get_date(), date >= new Date(, 6, 3, 12, 0, 0) => notify;`,


### PR DESCRIPTION
If the day is today, tomorrow, or yesterday, use those words instead
of spelling out the day.

This will be used by the weather forecast function.