### PR TITLE
Avoid surfacing unexpected error messages to the user

### DIFF
--- a/languages/thingtalk/en/dlg/action-results.genie
+++ b/languages/thingtalk/en/dlg/action-results.genie
@@ -115,13 +115,7 @@ short_action_error_message : S.ContextInfo = {
         ctx:ctx_completed_action_error msg:thingpedia_error_message with { functionName = ctx.currentFunction } '.' [priority=5]
             => D.checkThingpediaErrorMessage(ctx, msg);
 
-    ctx:ctx_completed_action_error msg:constant_String => {
-        const error = ctx.error!;
-        if (error.equals(msg))
-            return ctx;
-        else
-            return null;
-    };
+    ctx:ctx_completed_action_error 'there was an unexpected error with your command . please try again later or report this issue to my developers' => ctx;
 }
 
 long_action_error_message : S.ContextInfo = {
@@ -156,6 +150,9 @@ action_error_phrase : S.AgentReplyRecord = {
     sorry_preamble ctx:short_action_error_message '.' => D.makeActionErrorPhrase(ctx, []);
 
     !inference {
+        // FIXME this should be good for inference too but the phrase it generates is weird
+        sorry_preamble ctx:long_action_error_message '.' => D.makeActionErrorPhrase(ctx, []);
+
         ( sorry_preamble ctx:short_action_error_message '.' questions:one_param_try_different_param_question [weight=1, priority=0.5]
         | sorry_preamble ctx:short_action_error_message '.' questions:two_param_try_different_param_question [weight=0.5]
         | sorry_preamble ctx:long_action_error_message '.' questions:one_param_try_different_param_question [weight=1, priority=0.5]

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -1134,7 +1134,7 @@ C: @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).play_song(son
 C: #[results=[]]
 C: #[error="Some other error occurred"];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: Sorry, Some other error occurred.
+A: Sorry, there was an unexpected error with your command. Please try again later or report this issue to my developers.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_error;
 #! vote: down
 #! comment: test comment for dialogue turns
@@ -1657,7 +1657,7 @@ C: @org.thingpedia.weather.current(location=new Location(90, 0, "North Pole"))
 C: #[results=[]]
 C: #[error="unexpected weather error"];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: Sorry, unexpected weather error.
+A: Sorry, there was an unexpected error with your command. Please try again later or report this issue to my developers.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_error;
 #! vote: up
 #! comment: test comment for dialogue turns

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -484,7 +484,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.spotify.play_song(song="spotify:track:2zYzyRzz6pRmhPzyfMEC8s"^^com.spotify:song("Hello"));
 
-A: Sorry, Some other error occurred.
+A: Sorry, there was an unexpected error with your command. Please try again later or report this issue to my developers.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_error ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ results = [ ] ] #[ error = QUOTED_STRING_0 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:2zYzyRzz6pRmhPzyfMEC8s","display":"Hello"},"QUOTED_STRING_0":"Some other error occurred"}
 A: >> expecting = null
 
@@ -733,7 +733,7 @@ A: >> expecting = command
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: @org.thingpedia.weather.current(location=new Location(90, 0, "North Pole"));
 
-A: Sorry, unexpected weather error.
+A: Sorry, there was an unexpected error with your command. Please try again later or report this issue to my developers.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_error ; @org.thingpedia.weather . current ( location = LOCATION_0 ) #[ results = [ ] ] #[ error = QUOTED_STRING_0 ] ; // {"LOCATION_0":{"latitude":90,"longitude":0,"display":"North Pole"},"QUOTED_STRING_0":"unexpected weather error"}
 A: >> expecting = null
 


### PR DESCRIPTION
Unexpected error messages are likely to be too technical and
inappropriate to read out. The actual error message is still
present in the `#[error]` dialogue state annotation, so we
have it in recordings.

Fixes #522