### PR TITLE
Fix "yes" / "no" replies if the dialogue state is empty

### DIFF
--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -191,7 +191,7 @@ function answer(state : Ast.DialogueState, answer : Ast.Value, contextTable : Se
     const ctx = S.getContextInfo($loader, state, contextTable);
 
     // if the agent proposed something and the user says "yes", we accept the proposal
-    if (state.history[state.history.length-1].confirm === 'proposed' &&
+    if (state.history.length > 0 && state.history[state.history.length-1].confirm === 'proposed' &&
         answer instanceof Ast.BooleanValue && answer.value === true) {
         const item = state.history[state.history.length-1].clone();
         item.confirm = 'accepted';

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -1740,3 +1740,26 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $dialogue @org.thingpedia.dialogue.transaction.cancel;
+UT: $dialogue @org.thingpedia.dialogue.transaction.cancel;
+C: $dialogue @org.thingpedia.dialogue.transaction.cancel;
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: Is there anything else I can help you with?
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_anything_else;
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $no;
+UT: $no;
+C: $dialogue @org.thingpedia.dialogue.transaction.end;
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: Alright, good bye!
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_end;
+#! vote: up
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -766,3 +766,18 @@ U: [rating, geo] of @com.yelp.restaurant(), id =~ "ramen nagi";
 A: Ramen Nagi is a restaurant near [Latitude: 37.446 deg, Longitude: -122.161 deg] rated 4.5 star.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ rating , geo ] of @com.yelp . restaurant ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.yelp:restaurant_0 , rating = NUMBER_0 , geo = LOCATION_0 } ] ] ; // {"QUOTED_STRING_0":"ramen nagi","GENERIC_ENTITY_com.yelp:restaurant_0":{"value":"vhfPni9pci29SEHrN1OtRg","display":"Ramen Nagi"},"NUMBER_0":4.5,"LOCATION_0":{"latitude":37.445523,"longitude":-122.1607073261,"display":null}}
 A: >> expecting = null
+
+====
+# 52-issue-529
+
+U: \t $dialogue @org.thingpedia.dialogue.transaction.cancel;
+
+A: Is there anything else I can help you with?
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_anything_else ; // {}
+A: >> expecting = command
+
+U: \t $no;
+
+A: Alright, good bye!
+A: >> context = null // {}
+A: >> expecting = null


### PR DESCRIPTION
This can occur if the user issues "cancel" as the very first command
in the dialogue, and the agent asks "is there anything else I can
do for you?"

Fixes #529