### PR TITLE
Make primitive templates out of action canonical forms

### DIFF
--- a/languages/thingtalk/load-thingpedia.ts
+++ b/languages/thingtalk/load-thingpedia.ts
@@ -999,6 +999,25 @@ export default class ThingpediaLoader {
         }
     }
 
+    private _getPrimitiveTemplatePriority(example : Ast.Example) {
+        // add a priority boost to each template, depending on how many parameters it uses
+        // this is important for thingpedia_complete_action_past, so we choose primitive templates with
+        // parameters and not primitive templates without them
+        //
+        // except for enums we use a smaller boost because enum phrases can
+        // have domain-specific words that can be preferrable
+
+        let priority = 0;
+        for (const pname in example.args) {
+            const type = example.args[pname];
+            if (type.isEnum)
+                priority += 0.5;
+            else
+                priority += 1;
+        }
+        return priority;
+    }
+
     /**
      * Convert a primitive template into a regular template that performs
      * a join with parameter passing by replacing exactly one placeholder
@@ -1011,6 +1030,7 @@ export default class ThingpediaLoader {
                                                             options : string[],
                                                             example : Ast.Example) {
         const exParams = Object.keys(example.args);
+        const attributes = { priority: this._getPrimitiveTemplatePriority(example) };
 
         const fromNonTermNames =
             grammarCat === 'action_past' ? ['ctx_current_query'] :
@@ -1066,9 +1086,12 @@ export default class ThingpediaLoader {
                     else
                         intoNonTerm = 'action_replace_param_with_table';
 
+                    // add a priority boost to this template, depending on how many parameters it uses
+                    // this is important for thingpedia_complete_action_past, so we choose primitive templates with
+                    // parameters and not primitive templates without it
                     this._addRule<Array<Ast.Value|Ast.Expression>, Ast.ChainExpression>(intoNonTerm, clone,
                         (...args) => replacePlaceholderWithTableOrStream(example, names, paramIdx, args, this),
-                        keyfns.expressionKeyFn);
+                        keyfns.expressionKeyFn, attributes);
                 }
             }
         }
@@ -1082,9 +1105,10 @@ export default class ThingpediaLoader {
                                                      expansion : Array<string|Genie.SentenceGeneratorRuntime.NonTerminal>,
                                                      names : Array<string|null>,
                                                      example : Ast.Example) {
+        const attributes = { priority: this._getPrimitiveTemplatePriority(example) };
         this._addRule<Ast.Value[], Ast.Expression>('thingpedia_complete_' + grammarCat, expansion,
             (...args) => replacePlaceholdersWithConstants(example, names, args),
-            keyfns.expressionKeyFn);
+            keyfns.expressionKeyFn, attributes);
     }
 
     private async _makeExampleFromAction(a : Ast.FunctionDef) {

--- a/languages/thingtalk/load-thingpedia.ts
+++ b/languages/thingtalk/load-thingpedia.ts
@@ -1087,6 +1087,27 @@ export default class ThingpediaLoader {
             keyfns.expressionKeyFn);
     }
 
+    private async _makeExampleFromAction(a : Ast.FunctionDef) {
+        const device = new Ast.DeviceSelector(null, a.class!.name, null, null);
+        const invocation = new Ast.Invocation(null, device, a.name, [], a);
+
+        const canonical : string[] = a.canonical ?
+            (Array.isArray(a.canonical) ? a.canonical : [a.canonical]) :
+            [this._ttUtils.clean(a.name)];
+
+        const action = new Ast.InvocationExpression(null, invocation, a);
+        await this._loadTemplate(new Ast.Example(
+            null,
+            -1,
+            'action',
+            {},
+            action,
+            canonical,
+            canonical,
+            {}
+        ));
+    }
+
     private async _makeExampleFromQuery(q : Ast.FunctionDef) {
         const device = new Ast.DeviceSelector(null, q.class!.name, null, null);
         const invocation = new Ast.Invocation(null, device, q.name, [], q);
@@ -1289,6 +1310,8 @@ export default class ThingpediaLoader {
     private async _loadFunction(functionDef : Ast.FunctionDef) {
         if (functionDef.functionType === 'query')
             await this._makeExampleFromQuery(functionDef);
+        else
+            await this._makeExampleFromAction(functionDef);
 
         if (functionDef.metadata.result)
             await this._loadCustomResultString(functionDef);

--- a/lib/sentence-generator/runtime.ts
+++ b/lib/sentence-generator/runtime.ts
@@ -200,6 +200,7 @@ class Derivation<ValueType> {
         if (newValue === null)
             return null;
         const newKey = keyFunction(newValue);
+
         return new Derivation(newKey, newValue, newSentence, newContext, newPriority);
     }
 }

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -442,7 +442,7 @@ C:   { song="spotify:track:5OCJzvD7sykQEKHH7qAC3C"^^com.spotify:song("God is a w
 C: ]]
 C: #[count=23];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: I played songs by Ariana Grande on Spotify for you.
+A: I played songs by Ariana Grande on Spotify.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! vote: up
 #! comment: test comment for dialogue turns
@@ -476,7 +476,7 @@ C:   { song="spotify:track:7kt9e9LFSpN1zQtYEl19o1"^^com.spotify:song("this is me
 C: ]]
 C: #[count=22];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: I played songs in the album folklore on Spotify for you.
+A: I played songs in the album folklore on Spotify.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! vote: down
 #! comment: test comment for dialogue turns
@@ -728,7 +728,7 @@ C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).player_repeat(repeat=enum track)
 C: #[results=[]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: I repeated this song.
+A: I set the repeat state to track.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! vote: up
 #! comment: test comment for dialogue turns
@@ -790,7 +790,7 @@ C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).player_shuffle(shuffle=enum on)
 C: #[results=[]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: I shuffled your Spotify.
+A: I turned shuffle on.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! vote: down
 #! comment: test comment for dialogue turns
@@ -1530,7 +1530,7 @@ C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.xkcd(id="com.xkcd-10"^^tt:device_id("Some Device 10")).comic() => @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status=title)
 C: #[results=[]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: Your request was completed successfully.
+A: I tweeted something.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! vote: down
 #! comment: test comment for dialogue turns

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -173,7 +173,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (@com.spotify.song(), contains(artists, null^^com.spotify:artist("ariana grande"))) => @com.spotify.play_song(song=id);
 
-A: I played songs by Ariana Grande on Spotify for you.
+A: I played songs by Ariana Grande on Spotify.
 A: >> context = null // {}
 A: >> expecting = null
 
@@ -183,7 +183,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (@com.spotify.song(), album == null^^com.spotify:album("folklore")) =>  @com.spotify.play_song(song=id);
 
-A: I played songs in the album folklore on Spotify for you.
+A: I played songs in the album folklore on Spotify.
 A: >> context = null // {}
 A: >> expecting = null
 
@@ -299,7 +299,7 @@ A: >> expecting = null
 # repeat this song
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.spotify.player_repeat(repeat=enum(track));
-A: I repeated this song.
+A: I set the repeat state to track.
 A: >> context = null // {}
 A: >> expecting = null
 
@@ -327,7 +327,7 @@ A: >> expecting = command
 # 18-agent-phrase-with-my
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.spotify.player_shuffle(shuffle=enum(on));
-A: I shuffled your Spotify.
+A: I turned shuffle on.
 A: >> context = null // {}
 A: >> expecting = null
 
@@ -662,9 +662,7 @@ A: >> expecting = yesno
 
 U: \t $yes;
 
-# (mock) Twitter doesn't return a result bag, so we cannot display
-# what we actually posted, and this is the best we can do
-A: Your request was completed successfully.
+A: I tweeted something.
 A: >> context = null // {}
 A: >> expecting = null
 

--- a/test/data/en-US/dataset.tt
+++ b/test/data/en-US/dataset.tt
@@ -85,10 +85,6 @@ dataset @org.thingpedia.everything {
     #[id=-1]
     #_[preprocessed=["autoretweet tweets with $p_hashtag", "autoretweet $p_hashtag"]];
 
-    action () := @com.twitter.post()
-    #[id=0]
-    #_[preprocessed=["tweet something", "post on twitter"]];
-
     action (p_status : String) := @com.twitter.post(status=p_status)
     #[id=1]
     #_[preprocessed=["tweet ${p_status}", "post ${p_status} on twitter"]];


### PR DESCRIPTION
Similar to how we do it for queries.

This should solve some bad accuracy in IoT actions that have no parameters and no primitive templates.