### PR TITLE
Add support for lazy (async iterable) queries

### DIFF
--- a/lib/engine/devices/builtins/test.ts
+++ b/lib/engine/devices/builtins/test.ts
@@ -45,19 +45,17 @@ export default class TestDevice extends Tp.BaseDevice {
         this._sequenceNumber = 0;
     }
 
-    get_next_sequence() {
-        return [{ number: this._sequenceNumber ++ }];
+    async *get_next_sequence() {
+        yield { number: this._sequenceNumber ++ };
     }
 
-    get_get_data({ size, count } : { size : number, count : number }) {
+    async *get_get_data({ size, count } : { size : number, count : number }) {
         if (!(count >= 0))
             count = 1;
         console.log(`Generating ${size} bytes of fake data, ${count} times`);
 
-        const ret = [];
         for (let i = 0; i < count; i++)
-            ret.push({ data: genFakeData(size, '!'.charCodeAt(0) + i) });
-        return ret;
+            yield { data: genFakeData(size, '!'.charCodeAt(0) + i) };
     }
     /**
      * @returns {stream.Readable}
@@ -77,7 +75,7 @@ export default class TestDevice extends Tp.BaseDevice {
             yield ({ data: genFakeData(size, 'A'.charCodeAt(0) + i) });
     }
 
-    get_dup_data({ data_in } : { data_in : string }) {
+    async get_dup_data({ data_in } : { data_in : string }) {
         return [{ data_out: data_in + data_in }];
     }
     do_eat_data(args : { data : string }) {

--- a/lib/engine/util/restartable_async_iterable.ts
+++ b/lib/engine/util/restartable_async_iterable.ts
@@ -1,0 +1,82 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+/**
+ * An async iterable data-structure that wraps another async-iterable
+ * so that iteration happens lazily, but can be restarted at any time.
+ *
+ * Multiple callers can iterate the same iterable concurrently.
+ */
+export default class RestartableAsyncIterable<T> {
+    private _cache : T[] = [];
+    private _done = false;
+    private _iterator : Iterator<T>|AsyncIterator<T>;
+    private _nextPromise : Promise<IteratorResult<T>>|null = null;
+
+    constructor(inner : Iterable<T>|AsyncIterable<T>) {
+        if (typeof (inner as any)[Symbol.asyncIterator] === 'function')
+            this._iterator = (inner as AsyncIterable<T>)[Symbol.asyncIterator]();
+        else
+            this._iterator = (inner as Iterable<T>)[Symbol.iterator]();
+    }
+
+    [Symbol.asyncIterator]() : AsyncIterator<T> {
+        const self = this;
+        const iterator = {
+            _index: 0,
+            async next() : Promise<IteratorResult<T>> {
+                // first return the cached values
+                if (this._index < self._cache.length) {
+                    const value = self._cache[this._index++];
+                    return { value, done: false };
+                }
+                // try to get more values from the underlying iterable
+                const result = await self._next();
+                // if there is a value, _next() will increment the cache
+                // make sure we skip that value at the next iteration
+                if (!result.done)
+                    this._index++;
+                return result;
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            }
+        };
+        return iterator;
+    }
+
+    private async _internalNextElement() {
+        const next = await this._iterator.next();
+        if (next.done)
+            this._done = true;
+        else
+            this._cache.push(next.value);
+        this._nextPromise = null;
+        return next;
+    }
+
+    private async _next() : Promise<IteratorResult<T>> {
+        if (this._done)
+            return { value: undefined, done: true };
+        if (!this._nextPromise)
+            this._nextPromise = this._internalNextElement();
+        return this._nextPromise;
+    }
+}

--- a/test/engine/test_devices.js
+++ b/test/engine/test_devices.js
@@ -163,11 +163,18 @@ async function testUpdateDevice(engine) {
     await engine.upgradeDevice('com.twitter');
 }
 
+async function iterate(iterable) {
+    const ret = [];
+    for await (const el of iterable)
+        ret.push(el);
+    return ret;
+}
+
 async function testDeviceMethods(engine) {
     const devices = engine.devices;
 
     const test = devices.getDevice('org.thingpedia.builtin.test');
-    const result = await test.get_get_data({ count: 2, size: 10 });
+    const result = await iterate(await test.get_get_data({ count: 2, size: 10 }));
     assert.deepStrictEqual(result, [{
         data: '!!!!!!!!!!',
     }, {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -67,6 +67,7 @@ do_test([
     ('./test_random'),
     ('./test_requoting'),
     ('./test_requote'),
+    ('./test_restartable_async_iterable'),
     ('./test_sentence_generator'),
     ('./test_stream_utils'),
     ('./test_template_string'),

--- a/test/unit/test_restartable_async_iterable.js
+++ b/test/unit/test_restartable_async_iterable.js
@@ -1,0 +1,137 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+import assert from 'assert';
+import RestartableAsyncIterable from '../../lib/engine/util/restartable_async_iterable';
+
+let _g1BeginCount = 0;
+let _g1EndCount = 0;
+async function* g1() {
+    _g1BeginCount ++;
+    for (let i = 0; i < 10; i++)
+        yield i;
+    _g1EndCount ++;
+}
+
+let _g2BeginCount = 0;
+let _g2EndCount = 0;
+function* g2() {
+    _g2BeginCount ++;
+    for (let i = 10; i > 0; i--)
+        yield i;
+    _g2EndCount ++;
+}
+
+async function iterateN(iterable, n = Infinity) {
+    const result = [];
+    for await (const el of iterable) {
+        result.push(el);
+        if (result.length >= n)
+            break;
+    }
+    return result;
+}
+
+async function testBasic() {
+    const i1 = new RestartableAsyncIterable(g1());
+
+    assert.strictEqual(_g1BeginCount, 0);
+    assert.strictEqual(_g1EndCount, 0);
+    assert.deepStrictEqual(await iterateN(i1), [0,1,2,3,4,5,6,7,8,9]);
+    assert.strictEqual(_g1BeginCount, 1);
+    assert.strictEqual(_g1EndCount, 1);
+
+    // same thing, but with a sync iterator
+    const i2 = new RestartableAsyncIterable(g2());
+
+    assert.strictEqual(_g2BeginCount, 0);
+    assert.strictEqual(_g2EndCount, 0);
+    assert.deepStrictEqual(await iterateN(i2), [10,9,8,7,6,5,4,3,2,1]);
+    assert.strictEqual(_g2BeginCount, 1);
+    assert.strictEqual(_g2EndCount, 1);
+}
+
+
+async function testRestart() {
+    const i1 = new RestartableAsyncIterable(g1());
+
+    // iterate the first time
+    assert.strictEqual(_g1BeginCount, 1);
+    assert.strictEqual(_g1EndCount, 1);
+    assert.deepStrictEqual(await iterateN(i1), [0,1,2,3,4,5,6,7,8,9]);
+    assert.strictEqual(_g1BeginCount, 2);
+    assert.strictEqual(_g1EndCount, 2);
+
+    // iterate the second time
+    assert.deepStrictEqual(await iterateN(i1), [0,1,2,3,4,5,6,7,8,9]);
+    assert.strictEqual(_g1BeginCount, 2);
+    assert.strictEqual(_g1EndCount, 2);
+}
+
+async function testInterrupt() {
+    const i1 = new RestartableAsyncIterable(g1());
+
+    // iterate the first 5 elements
+    const iterator = i1[Symbol.asyncIterator]();
+    assert.strictEqual(_g1BeginCount, 2);
+    assert.strictEqual(_g1EndCount, 2);
+    assert.deepStrictEqual(await iterateN(iterator, 5), [0,1,2,3,4]);
+    assert.strictEqual(_g1BeginCount, 3);
+    assert.strictEqual(_g1EndCount, 2);
+
+    // iterate from the beginning
+    // the first 5 elements will be cached and the second will be fetched
+    assert.deepStrictEqual(await iterateN(i1), [0,1,2,3,4,5,6,7,8,9]);
+    assert.strictEqual(_g1BeginCount, 3);
+    assert.strictEqual(_g1EndCount, 3);
+
+    // complete the first iterator
+    assert.deepStrictEqual(await iterateN(iterator), [5,6,7,8,9]);
+    assert.strictEqual(_g1BeginCount, 3);
+    assert.strictEqual(_g1EndCount, 3);
+}
+
+async function testParallel() {
+    const i1 = new RestartableAsyncIterable(g1());
+
+    assert.strictEqual(_g1BeginCount, 3);
+    assert.strictEqual(_g1EndCount, 3);
+    const p1 = iterateN(i1);
+    const p2 = iterateN(i1);
+    assert.strictEqual(_g1BeginCount, 4);
+    assert.strictEqual(_g1EndCount, 3);
+
+    const [c1, c2] = await Promise.all([p1, p2]);
+    assert.strictEqual(_g1BeginCount, 4);
+    assert.strictEqual(_g1EndCount, 4);
+
+    assert.deepStrictEqual(c1, [0,1,2,3,4,5,6,7,8,9]);
+    assert.deepStrictEqual(c2, [0,1,2,3,4,5,6,7,8,9]);
+}
+
+async function main() {
+    await testBasic();
+    await testRestart();
+    await testInterrupt();
+    await testParallel();
+}
+export default main;
+if (!module.parent)
+    main();


### PR DESCRIPTION
This is the last bit of infrastructure to support lazy queries,
that is, queries implemented using `async *get_foo` which yield
their results lazily instead of return an array with all the results.

The exec environment caches the output of queries for a given
statement. The cache must be an iterable that can be iterated multiple
times, rather than a generator, which can be iterated only once.
To this end, we introduce a new class that wraps an iterable
and queries it lazily, but also caches each returned item so
iteration can be restarted.

Fixes #238