### PR TITLE
Support for multiple devices during training

### DIFF
--- a/languages/thingtalk/dialogue_acts/streams.ts
+++ b/languages/thingtalk/dialogue_acts/streams.ts
@@ -45,6 +45,10 @@ export function addStream(ctx : ContextInfo, stream : Ast.Expression) {
     if (currentExpression.first.schema!.functionType === 'stream')
         return null;
 
+    // no self-joins
+    if (C.isSameFunction(currentExpression.schema!, stream.schema!))
+        return null;
+
     return addNewStatement(ctx, 'execute', null, 'accepted',
         new Ast.ChainExpression(null, [stream, currentExpression], C.resolveChain([stream, currentExpression])));
 }

--- a/languages/thingtalk/state_manip.ts
+++ b/languages/thingtalk/state_manip.ts
@@ -500,7 +500,7 @@ class ApplyDeviceIDVisitor extends Ast.NodeVisitor {
     }
 
     visitDeviceSelector(selector : Ast.DeviceSelector) {
-        if (selector.attributes.length > 0)
+        if (selector.attributes.length > 0 || selector.all)
             return false;
         if (selector.id)
             return false;

--- a/languages/thingtalk/state_manip.ts
+++ b/languages/thingtalk/state_manip.ts
@@ -556,7 +556,6 @@ function addNewItem(ctx : ContextInfo,
         // add the new history item right after the current one, keep
         // all the accepted items, and remove all proposed items
 
-        const newState = new Ast.DialogueState(null, POLICY_NAME, dialogueAct, null, []);
         if (ctx.currentIdx !== null) {
             for (let i = 0; i <= ctx.currentIdx; i++)
                 newState.history.push(ctx.state.history[i]);

--- a/languages/thingtalk/state_manip.ts
+++ b/languages/thingtalk/state_manip.ts
@@ -487,6 +487,10 @@ class CollectDeviceIDVisitor extends Ast.NodeVisitor {
     collection = new Map<string, string>();
 
     visitDeviceSelector(selector : Ast.DeviceSelector) {
+        if (selector.all) {
+            this.collection.set(selector.kind, 'all');
+            return false;
+        }
         if (!selector.id)
             return false;
         this.collection.set(selector.kind, selector.id);
@@ -506,7 +510,9 @@ class ApplyDeviceIDVisitor extends Ast.NodeVisitor {
             return false;
 
         const existing = this.collection.get(selector.kind);
-        if (existing)
+        if (existing === 'all')
+            selector.all = true;
+        else if (existing)
             selector.id = existing;
         return false;
     }

--- a/lib/dataset-tools/augmentation/replace_parameters.ts
+++ b/lib/dataset-tools/augmentation/replace_parameters.ts
@@ -36,7 +36,8 @@ import * as ThingTalkUtils from '../../utils/thingtalk';
 import { SentenceExample, SentenceFlags } from '../parsers';
 
 function isReplaceToken(tok : string) : boolean {
-    return /^(?:GENERIC_ENTITY|LOCATION|NUMBER|QUOTED_STRING|HASHTAG|USERNAME)_/.test(tok);
+    return /^(?:GENERIC_ENTITY|LOCATION|NUMBER|QUOTED_STRING|HASHTAG|USERNAME)_/.test(tok) &&
+        !tok.startsWith('GENERIC_ENTITY_tt:device_id_');
 }
 
 function tokenCanAppearInSentence(token : string) {
@@ -880,7 +881,7 @@ export default class ParameterReplacer {
                 varref.token = token;
                 entities[slot] = varref;
                 out.push(slot);
-            } else if (/^[A-Za-z_]+?_[0-9]+$/.test(token)) {
+            } else if (/^[A-Za-z_:]+_[0-9]+$/.test(token)) {
                 entities[token] = makeDummyEntity(token);
                 out.push(token);
             } else {

--- a/lib/dialogue-agent/abstract_dialogue_agent.ts
+++ b/lib/dialogue-agent/abstract_dialogue_agent.ts
@@ -325,7 +325,7 @@ export default abstract class AbstractDialogueAgent<PrivateStateType> {
             return;
         }
 
-        const alldevices = this.getAllDevicesOfKind(kind);
+        const alldevices = await this.getAllDevicesOfKind(kind);
 
         if (alldevices.length === 0) {
             this.debug('No device of kind ' + kind + ' available, attempting configure...');
@@ -468,7 +468,7 @@ export default abstract class AbstractDialogueAgent<PrivateStateType> {
      * @param {string} kind - the kind to check
      * @returns {Array<DeviceInfo>} - the list of configured devices
      */
-    protected getAllDevicesOfKind(kind : string) : DeviceInfo[] {
+    protected async getAllDevicesOfKind(kind : string) : Promise<DeviceInfo[]> {
         throw new TypeError('Abstract method');
     }
 

--- a/lib/dialogue-agent/dialogue-loop.ts
+++ b/lib/dialogue-agent/dialogue-loop.ts
@@ -213,10 +213,14 @@ export default class DialogueLoop {
         for (const key in args) {
             names.push(key);
             const value = args[key];
-            replacements.push({
-                text: value instanceof ReplacedResult ? value : new ReplacedConcatenation([String(value)], {}, {}),
-                value,
-            });
+            if (value !== null && value !== undefined) {
+                replacements.push({
+                    text: value instanceof ReplacedResult ? value : new ReplacedConcatenation([String(value)], {}, {}),
+                    value,
+                });
+            } else {
+                replacements.push(undefined);
+            }
         }
 
         const tmpl = Replaceable.get(msg, this._langPack, names);

--- a/lib/dialogue-agent/execution_dialogue_agent.ts
+++ b/lib/dialogue-agent/execution_dialogue_agent.ts
@@ -127,12 +127,11 @@ export default class ExecutionDialogueAgent extends AbstractDialogueAgent<undefi
                        hint ?: string) : Promise<number> {
         let question : string;
         if (type === 'device') {
-            question = this._dlg.interpolate(this._("You have multiple ${?“${name}” }${device} devices. Which one do you want to use?"), {
-                name,
-                device: cleanKind(hint!)
-            })!;
+            question = this._dlg.interpolate(this._("You have multiple {${name}| }${device} devices. Which one do you want to use?"), {
+                name, device: cleanKind(hint!)
+            });
         } else {
-            question = this._dlg.interpolate(this._("Multiple contacts match “${name}”. Who do you mean?"), { name })!;
+            question = this._dlg.interpolate(this._("Multiple contacts match “${name}”. Who do you mean?"), { name });
         }
         return this._dlg.askChoices(question, choices);
     }

--- a/lib/dialogue-agent/execution_dialogue_agent.ts
+++ b/lib/dialogue-agent/execution_dialogue_agent.ts
@@ -100,7 +100,7 @@ export default class ExecutionDialogueAgent extends AbstractDialogueAgent<undefi
         return this._executor;
     }
 
-    getAllDevicesOfKind(kind : string) {
+    async getAllDevicesOfKind(kind : string) {
         return this._engine.getDeviceInfos(kind);
     }
 
@@ -170,7 +170,7 @@ export default class ExecutionDialogueAgent extends AbstractDialogueAgent<undefi
                     device: factory.text,
                     choices: new ReplacedList(factory.choices.map((f) => new ReplacedConcatenation([f.text], {}, {})), this._engine.platform.locale, 'disjunction')
                 });
-            } else if (this.getAllDevicesOfKind(factory.kind).length > 0) {
+            } else if ((await this.getAllDevicesOfKind(factory.kind)).length > 0) {
                 await this._dlg.replyInterp(this._("You do not have a ${device} configured. You will need to configure it inside your ${factory} before you can use that command."), {
                     device: cleanKind(kind),
                     factory: factory.text,

--- a/lib/prediction/localparserclient.ts
+++ b/lib/prediction/localparserclient.ts
@@ -113,29 +113,6 @@ export default class LocalParserClient {
         this._exactmatcher = await builder.load();
     }
 
-    private _applyPreHeuristics(contextCode : string[]) : string[] {
-        // remove "attribute:id = GENERIC_ENTITY_tt:device_id_*" from the context because
-        // we never generate that in training
-
-        const newCode = [];
-        let inString = false;
-        for (let i = 0; i < contextCode.length; i++) {
-            const token = contextCode[i];
-            if (token === '"')
-                inString = !inString;
-            if (inString) {
-                newCode.push(token);
-                continue;
-            }
-            if (token === 'attribute:id') {
-                i += 2; // skip "attribute:id" and "=", the loop increment will skip GENERIC_ENTITY
-                continue;
-            }
-            newCode.push(token);
-        }
-        return newCode;
-    }
-
     private _applyPostHeuristics(programs : PredictionCandidate[], contextCode : string[]|undefined) {
         // only work on contextual
         if (!contextCode)
@@ -212,9 +189,6 @@ export default class LocalParserClient {
         }
 
         if (result === null) {
-            if (contextCode)
-                contextCode = this._applyPreHeuristics(contextCode);
-
             let candidates;
             if (contextCode)
                 candidates = await this._predictor.predict(contextCode.join(' '), tokens.join(' '), answer, NLU_TASK, options.example_id);

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -107,14 +107,15 @@ UT: @com.twitter.post();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post();
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: You have multiple Twitter devices. Which one do you want to use?
 A: What do you want to tweet?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_slot_fill(status);
 AT: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post();
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
-U: @com.twitter.post(status="hello world");
+U: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status="hello world");
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: @com.twitter.post(status="hello world");
+UT: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status="hello world");
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status="hello world");
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
@@ -123,10 +124,10 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_confirm_action;
 AT: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status="hello world");
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
-U: @com.twitter.post(status="hello world")
+U: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status="hello world")
 U: #[confirm=enum confirmed];
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
-UT: @com.twitter.post(status="hello world")
+UT: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status="hello world")
 UT: #[confirm=enum confirmed];
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status="hello world")
@@ -580,11 +581,12 @@ U: @com.twitter.post();
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: @com.twitter.post();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post();
+C: @com.twitter(id="twitter-bar"^^tt:device_id("Twitter Account bar")).post();
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: You have multiple Twitter devices. Which one do you want to use?
 A: What do you want to tweet?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_slot_fill(status);
-AT: @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post();
+AT: @com.twitter(id="twitter-bar"^^tt:device_id("Twitter Account bar")).post();
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t $nevermind;
 UT: $nevermind;
@@ -1027,7 +1029,7 @@ C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: Nice For What is a song by Drake in the album Scorpion. Would you like to play it on Spotify?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: @com.spotify.play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
+AT: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
 AT: #[confirm=enum proposed];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t $yes;
@@ -1037,7 +1039,7 @@ C: @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).song() filter
 C: #[results=[
 C:   { id="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"), artists=["spotify:artist:3TVXtAsR1Inumwj472S9r4"^^com.spotify:artist("Drake")], album="spotify:album:1ATL5GLyefJaxhQzSPVrLX"^^com.spotify:album("Scorpion"), genres=["canadian hip hop", "canadian pop", "hip hop", "pop rap", "rap", "toronto rap"], release_date=new Date("2018-06-29T00:00:00.000Z"), popularity=79, energy=90, danceability=58 }
 C: ]];
-C: @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
+C: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
 C: #[results=[
 C:   { song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device }
 C: ]];
@@ -1068,7 +1070,7 @@ C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: Nice For What is a song by Drake in the album Scorpion. Would you like to play it on Spotify?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: @com.spotify.play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
+AT: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
 AT: #[confirm=enum proposed];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t $no;
@@ -1158,7 +1160,7 @@ C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: Nice For What is a song released on June 28, 2018. Would you like to play it on Spotify?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: @com.spotify.play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
+AT: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
 AT: #[confirm=enum proposed];
 #! vote: up
 #! comment: test comment for dialogue turns
@@ -1192,7 +1194,7 @@ C: #[count=11];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: Hello? Is a song released on May 24, 2018. Would you like to play it on Spotify?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: @com.spotify.play_song(song="spotify:track:7qwt4xUIqQWCu1DJf96g2k"^^com.spotify:song("Hello?"))
+AT: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:7qwt4xUIqQWCu1DJf96g2k"^^com.spotify:song("Hello?"))
 AT: #[confirm=enum proposed];
 #! vote: down
 #! comment: test comment for dialogue turns
@@ -1310,7 +1312,7 @@ C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: Nice For What is a song by Drake in the album Scorpion. Would you like to play it on Spotify?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: @com.spotify.play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
+AT: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
 AT: #[confirm=enum proposed];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t $no;
@@ -1356,7 +1358,7 @@ C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: The most popular song is ROCKSTAR (feat. Roddy Ricch). It is a song by DaBaby in the album BLAME IT ON BABY. Would you like to play it on Spotify?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: @com.spotify.play_song(song="spotify:track:7ytR5pFWmSjzHJIeQkgog4"^^com.spotify:song("ROCKSTAR (feat. Roddy Ricch)"))
+AT: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:7ytR5pFWmSjzHJIeQkgog4"^^com.spotify:song("ROCKSTAR (feat. Roddy Ricch)"))
 AT: #[confirm=enum proposed];
 #! vote: up
 #! comment: test comment for dialogue turns
@@ -1380,7 +1382,7 @@ C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: The least popular song is Love Yourself. It is a song by Justin Bieber in the album Romantic Pop Songs. Would you like to play it on Spotify?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
-AT: @com.spotify.play_song(song="spotify:track:0VXeNEtuiD77F2StUeUadK"^^com.spotify:song("Love Yourself"))
+AT: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:0VXeNEtuiD77F2StUeUadK"^^com.spotify:song("Love Yourself"))
 AT: #[confirm=enum proposed];
 #! vote: down
 #! comment: test comment for dialogue turns
@@ -1520,6 +1522,7 @@ UT: @com.xkcd.comic() => @com.twitter.post(status=title);
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.xkcd.comic() => @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status=title);
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: You have multiple Twitter devices. Which one do you want to use?
 A: Ok, do you want me to get xkcd comic and then tweet the title?
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_confirm_action;
 AT: @com.xkcd.comic() => @com.twitter(id="twitter-foo"^^tt:device_id("Twitter Account foo")).post(status=title);

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -59,19 +59,27 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.twitter.post();
 
+A: You have multiple Twitter devices. Which one do you want to use?
+A: choice 0: Twitter Account foo
+A: choice 1: Twitter Account bar
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . execute ; @com.twitter . post ( ) ; // {}
+A: >> expecting = choice
+
+U: \t $choice(0);
+
 A: What do you want to tweet?
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_slot_fill ( status ) ; @com.twitter ( id = GENERIC_ENTITY_tt:device_id_0 ) . post ( ) ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"twitter-foo","display":"Twitter Account foo"}}
 A: >> expecting = raw_string
 
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
-U: now => @com.twitter.post(status="hello world");
+U: now => @com.twitter(id="twitter-foo",name="Twitter Account foo").post(status="hello world");
 
 A: Ok, do you want me to tweet hello world?
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_confirm_action ; @com.twitter ( id = GENERIC_ENTITY_tt:device_id_0 ) . post ( status = QUOTED_STRING_0 ) ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"twitter-foo","display":"Twitter Account foo"},"QUOTED_STRING_0":"hello world"}
 A: >> expecting = yesno
 
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
-U: now => @com.twitter.post(status="hello world") #[confirm=enum(confirmed)];
+U: now => @com.twitter(id="twitter-foo",name="Twitter Account foo").post(status="hello world") #[confirm=enum(confirmed)];
 
 A: I tweeted hello world.
 A: >> context = null // {}
@@ -227,8 +235,16 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => @com.twitter.post();
 
+A: You have multiple Twitter devices. Which one do you want to use?
+A: choice 0: Twitter Account foo
+A: choice 1: Twitter Account bar
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . execute ; @com.twitter . post ( ) ; // {}
+A: >> expecting = choice
+
+U: \r $choice ( 1 ) ;
+
 A: What do you want to tweet?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_slot_fill ( status ) ; @com.twitter ( id = GENERIC_ENTITY_tt:device_id_0 ) . post ( ) ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"twitter-foo","display":"Twitter Account foo"}}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_slot_fill ( status ) ; @com.twitter ( id = GENERIC_ENTITY_tt:device_id_0 ) . post ( ) ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"twitter-bar","display":"Twitter Account bar"}}
 A: >> expecting = raw_string
 
 U: \r bookkeeping special special:nevermind
@@ -434,7 +450,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (@com.spotify.song(), id =~ "Nice For What") => notify;
 
 A: Nice For What is a song by Drake in the album Scorpion. Would you like to play it on Spotify?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_1 , QUOTED_STRING_2 , QUOTED_STRING_3 , QUOTED_STRING_4 , QUOTED_STRING_5 , QUOTED_STRING_6 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:3TVXtAsR1Inumwj472S9r4","display":"Drake"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:1ATL5GLyefJaxhQzSPVrLX","display":"Scorpion"},"QUOTED_STRING_1":"canadian hip hop","QUOTED_STRING_2":"canadian pop","QUOTED_STRING_3":"hip hop","QUOTED_STRING_4":"pop rap","QUOTED_STRING_5":"rap","QUOTED_STRING_6":"toronto rap","DATE_0":"2018-06-29T00:00:00.000Z","NUMBER_0":79,"NUMBER_1":90,"NUMBER_2":58}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_1 , QUOTED_STRING_2 , QUOTED_STRING_3 , QUOTED_STRING_4 , QUOTED_STRING_5 , QUOTED_STRING_6 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:3TVXtAsR1Inumwj472S9r4","display":"Drake"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:1ATL5GLyefJaxhQzSPVrLX","display":"Scorpion"},"QUOTED_STRING_1":"canadian hip hop","QUOTED_STRING_2":"canadian pop","QUOTED_STRING_3":"hip hop","QUOTED_STRING_4":"pop rap","QUOTED_STRING_5":"rap","QUOTED_STRING_6":"toronto rap","DATE_0":"2018-06-29T00:00:00.000Z","NUMBER_0":79,"NUMBER_1":90,"NUMBER_2":58}
 A: >> expecting = command
 
 # yes please
@@ -451,7 +467,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (@com.spotify.song(), id =~ "Nice For What") => notify;
 
 A: Nice For What is a song by Drake in the album Scorpion. Would you like to play it on Spotify?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_1 , QUOTED_STRING_2 , QUOTED_STRING_3 , QUOTED_STRING_4 , QUOTED_STRING_5 , QUOTED_STRING_6 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:3TVXtAsR1Inumwj472S9r4","display":"Drake"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:1ATL5GLyefJaxhQzSPVrLX","display":"Scorpion"},"QUOTED_STRING_1":"canadian hip hop","QUOTED_STRING_2":"canadian pop","QUOTED_STRING_3":"hip hop","QUOTED_STRING_4":"pop rap","QUOTED_STRING_5":"rap","QUOTED_STRING_6":"toronto rap","DATE_0":"2018-06-29T00:00:00.000Z","NUMBER_0":79,"NUMBER_1":90,"NUMBER_2":58}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_1 , QUOTED_STRING_2 , QUOTED_STRING_3 , QUOTED_STRING_4 , QUOTED_STRING_5 , QUOTED_STRING_6 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:3TVXtAsR1Inumwj472S9r4","display":"Drake"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:1ATL5GLyefJaxhQzSPVrLX","display":"Scorpion"},"QUOTED_STRING_1":"canadian hip hop","QUOTED_STRING_2":"canadian pop","QUOTED_STRING_3":"hip hop","QUOTED_STRING_4":"pop rap","QUOTED_STRING_5":"rap","QUOTED_STRING_6":"toronto rap","DATE_0":"2018-06-29T00:00:00.000Z","NUMBER_0":79,"NUMBER_1":90,"NUMBER_2":58}
 A: >> expecting = command
 
 # no thanks
@@ -495,7 +511,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [release_date] of (@com.spotify.song(), id =~ "Nice For What") => notify;
 
 A: Nice For What is a song released on June 28, 2018. Would you like to play it on Spotify?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , release_date = DATE_0 } ] ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"DATE_0":"2018-06-29T00:00:00.000Z"}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , release_date = DATE_0 } ] ] ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"DATE_0":"2018-06-29T00:00:00.000Z"}
 A: >> expecting = command
 
 ====
@@ -506,7 +522,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => [release_date] of (@com.spotify.song(), id =~ "hello") => notify;
 
 A: Hello? Is a song released on May 24, 2018. Would you like to play it on Spotify?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , release_date = DATE_0 } ] ] #[ count = 11 ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"hello","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:7qwt4xUIqQWCu1DJf96g2k","display":"Hello?"},"DATE_0":"2018-05-25T00:00:00.000Z"}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; [ release_date ] of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , release_date = DATE_0 } ] ] #[ count = 11 ] ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"hello","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:7qwt4xUIqQWCu1DJf96g2k","display":"Hello?"},"DATE_0":"2018-05-25T00:00:00.000Z"}
 A: >> expecting = command
 
 ====
@@ -555,7 +571,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (@com.spotify.song(), id =~ "Nice For What") => notify;
 
 A: Nice For What is a song by Drake in the album Scorpion. Would you like to play it on Spotify?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_1 , QUOTED_STRING_2 , QUOTED_STRING_3 , QUOTED_STRING_4 , QUOTED_STRING_5 , QUOTED_STRING_6 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:3TVXtAsR1Inumwj472S9r4","display":"Drake"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:1ATL5GLyefJaxhQzSPVrLX","display":"Scorpion"},"QUOTED_STRING_1":"canadian hip hop","QUOTED_STRING_2":"canadian pop","QUOTED_STRING_3":"hip hop","QUOTED_STRING_4":"pop rap","QUOTED_STRING_5":"rap","QUOTED_STRING_6":"toronto rap","DATE_0":"2018-06-29T00:00:00.000Z","NUMBER_0":79,"NUMBER_1":90,"NUMBER_2":58}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) filter id =~ QUOTED_STRING_0 #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_1 , QUOTED_STRING_2 , QUOTED_STRING_3 , QUOTED_STRING_4 , QUOTED_STRING_5 , QUOTED_STRING_6 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"QUOTED_STRING_0":"Nice For What","GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:3CA9pLiwRIGtUBiMjbZmRw","display":"Nice For What"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:3TVXtAsR1Inumwj472S9r4","display":"Drake"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:1ATL5GLyefJaxhQzSPVrLX","display":"Scorpion"},"QUOTED_STRING_1":"canadian hip hop","QUOTED_STRING_2":"canadian pop","QUOTED_STRING_3":"hip hop","QUOTED_STRING_4":"pop rap","QUOTED_STRING_5":"rap","QUOTED_STRING_6":"toronto rap","DATE_0":"2018-06-29T00:00:00.000Z","NUMBER_0":79,"NUMBER_1":90,"NUMBER_2":58}
 A: >> expecting = command
 
 # no thanks
@@ -579,7 +595,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (sort popularity desc of @com.spotify.song())[1] => notify;
 
 A: The most popular song is ROCKSTAR (feat. Roddy Ricch). It is a song by DaBaby in the album BLAME IT ON BABY. Would you like to play it on Spotify?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; sort ( popularity desc of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) ) [ 1 ] #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 , GENERIC_ENTITY_com.spotify:artist_1 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_0 , QUOTED_STRING_1 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:7ytR5pFWmSjzHJIeQkgog4","display":"ROCKSTAR (feat. Roddy Ricch)"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:4r63FhuTkUYltbVAg5TQnk","display":"DaBaby"},"GENERIC_ENTITY_com.spotify:artist_1":{"value":"spotify:artist:757aE44tKEUQEqRuT6GnEB","display":"Roddy Ricch"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:623PL2MBg50Br5dLXC9E9e","display":"BLAME IT ON BABY"},"QUOTED_STRING_0":"north carolina hip hop","QUOTED_STRING_1":"rap","DATE_0":"2020-04-17T00:00:00.000Z","NUMBER_0":100,"NUMBER_1":69,"NUMBER_2":74}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; sort ( popularity desc of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) ) [ 1 ] #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 , GENERIC_ENTITY_com.spotify:artist_1 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_0 , QUOTED_STRING_1 ] , release_date = DATE_0 , popularity = NUMBER_0 , energy = NUMBER_1 , danceability = NUMBER_2 } ] ] ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:7ytR5pFWmSjzHJIeQkgog4","display":"ROCKSTAR (feat. Roddy Ricch)"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:4r63FhuTkUYltbVAg5TQnk","display":"DaBaby"},"GENERIC_ENTITY_com.spotify:artist_1":{"value":"spotify:artist:757aE44tKEUQEqRuT6GnEB","display":"Roddy Ricch"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:623PL2MBg50Br5dLXC9E9e","display":"BLAME IT ON BABY"},"QUOTED_STRING_0":"north carolina hip hop","QUOTED_STRING_1":"rap","DATE_0":"2020-04-17T00:00:00.000Z","NUMBER_0":100,"NUMBER_1":69,"NUMBER_2":74}
 A: >> expecting = command
 
 ====
@@ -589,7 +605,7 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: now => (sort popularity asc of @com.spotify.song())[1] => notify;
 
 A: The least popular song is Love Yourself. It is a song by Justin Bieber in the album Romantic Pop Songs. Would you like to play it on Spotify?
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; sort ( popularity asc of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) ) [ 1 ] #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_0 , QUOTED_STRING_1 , QUOTED_STRING_2 ] , release_date = DATE_0 , popularity = 0 , energy = NUMBER_0 , danceability = NUMBER_1 } ] ] ; @com.spotify . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:0VXeNEtuiD77F2StUeUadK","display":"Love Yourself"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:1uNFoZAHBGtllmzznpCI3s","display":"Justin Bieber"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:74jDw6TsdKnT92V790QfvF","display":"Romantic Pop Songs"},"QUOTED_STRING_0":"canadian pop","QUOTED_STRING_1":"pop","QUOTED_STRING_2":"post-teen pop","DATE_0":"2020-08-10T00:00:00.000Z","NUMBER_0":43,"NUMBER_1":78}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; sort ( popularity asc of @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . song ( ) ) [ 1 ] #[ results = [ { id = GENERIC_ENTITY_com.spotify:song_0 , artists = [ GENERIC_ENTITY_com.spotify:artist_0 ] , album = GENERIC_ENTITY_com.spotify:album_0 , genres = [ QUOTED_STRING_0 , QUOTED_STRING_1 , QUOTED_STRING_2 ] , release_date = DATE_0 , popularity = 0 , energy = NUMBER_0 , danceability = NUMBER_1 } ] ] ; @com.spotify ( id = GENERIC_ENTITY_tt:device_id_0 ) . play_song ( song = GENERIC_ENTITY_com.spotify:song_0 ) #[ confirm = enum proposed ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.spotify-7","display":"Some Device 7"},"GENERIC_ENTITY_com.spotify:song_0":{"value":"spotify:track:0VXeNEtuiD77F2StUeUadK","display":"Love Yourself"},"GENERIC_ENTITY_com.spotify:artist_0":{"value":"spotify:artist:1uNFoZAHBGtllmzznpCI3s","display":"Justin Bieber"},"GENERIC_ENTITY_com.spotify:album_0":{"value":"spotify:album:74jDw6TsdKnT92V790QfvF","display":"Romantic Pop Songs"},"QUOTED_STRING_0":"canadian pop","QUOTED_STRING_1":"pop","QUOTED_STRING_2":"post-teen pop","DATE_0":"2020-08-10T00:00:00.000Z","NUMBER_0":43,"NUMBER_1":78}
 A: >> expecting = command
 
 ====
@@ -655,6 +671,13 @@ A: >> expecting = null
 
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: @com.xkcd.comic() => @com.twitter.post(status=title);
+
+A: You have multiple Twitter devices. Which one do you want to use?
+A: choice 0: Twitter Account foo
+A: choice 1: Twitter Account bar
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . execute ; @com.xkcd . comic ( ) => @com.twitter . post ( status = title ) ; // {}
+A: >> expecting = choice
+U: \t $choice ( 0 );
 
 A: Ok, do you want me to get xkcd comic and then tweet the title?
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_confirm_action ; @com.xkcd . comic ( ) => @com.twitter ( id = GENERIC_ENTITY_tt:device_id_0 ) . post ( status = title ) ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"twitter-foo","display":"Twitter Account foo"}}


### PR DESCRIPTION
I _think_ this is all that we need to have proper handling of multiple IoT devices.

- We simulate multiple devices at training time
- We propagate the choice of device across multiple turns if necessary
- We disambiguate device names if necessary

Fixes #306 
Fixes #540 

Does not affect #305 or #368 because we still use the disambiguation dialogues outside of the state machine, so the user must give a name when asked and nothing else.
The disambiguation dialogue doesn't work very well in voice because it uses choice buttons, but we'll see how that goes. There might be a follow up PR.

Needs testing in Kubeflow to see how bad we do.