### PR TITLE
Add support for device names in result phrases

### DIFF
--- a/languages/thingtalk/dialogue_acts/coref-questions.ts
+++ b/languages/thingtalk/dialogue_acts/coref-questions.ts
@@ -147,7 +147,7 @@ function displayResultSearchQuestionReply(ctx : ContextInfo, questions : C.Param
 
 function listProposalSearchQuestionReply(ctx : ContextInfo, [name, questions] : [Ast.Value|null, C.ParamSlot[]]) {
     const proposal = ctx.aux as ListProposal;
-    const [results, info] = proposal;
+    const { results, info } = proposal;
 
     if (name !== null) {
         let good = false;

--- a/languages/thingtalk/dialogue_acts/list-proposal.ts
+++ b/languages/thingtalk/dialogue_acts/list-proposal.ts
@@ -53,9 +53,14 @@ import {
     DirectAnswerPhrase
 } from './results';
 
-export type ListProposal = [Ast.DialogueHistoryResultItem[], SlotBag|null, Ast.Invocation|null, boolean];
+export interface ListProposal {
+    results : Ast.DialogueHistoryResultItem[];
+    info : SlotBag|null;
+    action : Ast.Invocation|null;
+    hasLearnMore : boolean;
+}
 
-export function listProposalKeyFn([results, info, action, hasLearnMore] : ListProposal) {
+export function listProposalKeyFn({ results, info, action, hasLearnMore } : ListProposal) {
     return {
         idType: results[0].value.id ? results[0].value.id.getType() : null,
         queryName: info ? info.schema!.qualifiedName : null,
@@ -102,7 +107,7 @@ function checkListProposal(nameList : NameList, info : SlotBag|null, hasLearnMor
 
 
     const action = ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null;
-    return [results, info, action, hasLearnMore];
+    return { results, info, action, hasLearnMore };
 }
 
 export type ThingpediaListProposal = [ContextInfo, SlotBag];
@@ -133,7 +138,7 @@ export function checkThingpediaListProposal(proposal : ThingpediaListProposal, a
         return null;
 
     const action = ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null;
-    return [ctx.results!, mergedInfo, action, false];
+    return { results: ctx.results!, info: mergedInfo, action, hasLearnMore: false };
 }
 
 export function addActionToListProposal(nameList : NameList, action : Ast.Invocation) : ListProposal|null {
@@ -155,7 +160,7 @@ export function addActionToListProposal(nameList : NameList, action : Ast.Invoca
     if (ctxAction && !C.isSameFunction(ctxAction.schema!, action.schema!))
         return null;
 
-    return [results, null, action, false];
+    return { results, info: null, action, hasLearnMore: false };
 }
 
 export function makeListProposalFromDirectAnswers(...phrases : DirectAnswerPhrase[]) : ListProposal|null {
@@ -205,11 +210,11 @@ export function makeListProposalFromDirectAnswers(...phrases : DirectAnswerPhras
 
     const results = ctx.results!.slice(0, phrases.length);
 
-    return [results, null, null, false];
+    return { results, info: null, action: null, hasLearnMore: false };
 }
 
 function makeListProposalReply(ctx : ContextInfo, proposal : ListProposal) {
-    const [results, /*info*/, action, hasLearnMore] = proposal;
+    const { results, action, hasLearnMore } = proposal;
     const options : AgentReplyOptions = {
         numResults: results.length
     };
@@ -248,7 +253,7 @@ function positiveListProposalReply(loader : ThingpediaLoader,
     // we treat it as "execute" dialogue act and add a filter that causes the program to return a single result
 
     const proposal = ctx.aux as ListProposal;
-    const [results, /*info*/, actionProposal] = proposal;
+    const { results, action: actionProposal } = proposal;
     let good = false;
     for (const result of results) {
         if (result.value.id.equals(name)) {
@@ -296,8 +301,8 @@ function positiveListProposalReply(loader : ThingpediaLoader,
 function positiveListProposalReplyActionByName(loader : ThingpediaLoader,
                                                ctx : ContextInfo,
                                                action : Ast.Invocation) {
-    const proposal = ctx.aux;
-    const [results,] = proposal;
+    const proposal = ctx.aux as ListProposal;
+    const { results } = proposal;
 
     let name = null;
     const acceptedAction = action.clone();
@@ -324,7 +329,7 @@ function negativeListProposalReply(ctx : ContextInfo, [preamble, request] : [Ast
         return null;
 
     const proposal = ctx.aux as ListProposal;
-    const [results, info] = proposal;
+    const { results, info } = proposal;
     const proposalType = results[0].value.id.getType();
     request = combinePreambleAndRequest(preamble, request, info, proposalType);
     if (request === null)
@@ -339,7 +344,7 @@ function listProposalLearnMoreReply(ctx : ContextInfo, name : Ast.Value) {
     // in a list proposal, we add a filter "id == "
 
     const proposal = ctx.aux as ListProposal;
-    const [results,] = proposal;
+    const { results } = proposal;
     let good = false;
     for (const result of results) {
         if (result.value.id.equals(name)) {

--- a/languages/thingtalk/dialogue_acts/recommendation.ts
+++ b/languages/thingtalk/dialogue_acts/recommendation.ts
@@ -44,6 +44,7 @@ import {
     combinePreambleAndRequest,
     proposalReply
 } from './refinement-helpers';
+import type { ListProposal } from './list-proposal';
 
 export interface Recommendation {
     ctx : ContextInfo;
@@ -307,6 +308,16 @@ function makeDisplayResultReply(ctx : ContextInfo, proposal : Recommendation) {
         numResults: 1
     };
     if (action || hasAnythingElse)
+        options.end = false;
+    return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_display_result', null), proposal, null, options);
+}
+
+export function makeDisplayResultReplyFromList(ctx : ContextInfo, proposal : ListProposal) {
+    const { results, action, hasLearnMore } = proposal;
+    const options : AgentReplyOptions = {
+        numResults: results.length
+    };
+    if (action || hasLearnMore)
         options.end = false;
     return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_display_result', null), proposal, null, options);
 }

--- a/languages/thingtalk/en/dialogue.genie
+++ b/languages/thingtalk/en/dialogue.genie
@@ -304,6 +304,8 @@ $agent : S.AgentReplyRecord = {
     // query results
     ctx:ctx_display_nonlist_result proposal:system_nonlist_result
         => D.makeDisplayResultReply(ctx, proposal);
+    ctx:ctx_display_nonlist_result proposal:system_list_proposal
+        => D.makeDisplayResultReplyFromList(ctx, proposal);
 
     // aggregation results
     ( ctx:ctx_aggregation_question reply:count_aggregation_reply

--- a/languages/thingtalk/load-thingpedia.ts
+++ b/languages/thingtalk/load-thingpedia.ts
@@ -1240,6 +1240,8 @@ export default class ThingpediaLoader {
                         names.push(param);
                         if (additionalArguments.includes(param))
                             return true;
+                        if (param === '__device')
+                            return true;
 
                         const arg = functionDef.getArgument(param);
                         if (!arg)

--- a/lib/dialogue-agent/abstract_dialogue_agent.ts
+++ b/lib/dialogue-agent/abstract_dialogue_agent.ts
@@ -322,14 +322,12 @@ export default abstract class AbstractDialogueAgent<PrivateStateType> {
 
         const kind = selector.kind;
         const name = selector.getAttribute('name');
-        if (hints.devices.has(kind) && !selector.all) {
+        if (!name && hints.devices.has(kind) && !selector.all) {
             // if we have already selected a device for this kind in the context, reuse what
             // we chose before without asking again
             const [previousId, previousName] = hints.devices.get(kind)!;
             selector.id = previousId;
-            if (name && previousName)
-                name.value = previousName.value;
-            else if (previousName)
+            if (previousName)
                 selector.attributes.push(previousName.clone());
             return;
         }

--- a/lib/dialogue-agent/simulator/helpers.ts
+++ b/lib/dialogue-agent/simulator/helpers.ts
@@ -1,0 +1,54 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2021 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+import { SchemaRetriever } from 'thingtalk';
+
+export async function getAllDevicesOfKind(schemas : SchemaRetriever, kind : string) {
+    let numDevices = 1;
+
+    if (kind.startsWith('org.thingpedia.iot.')) { // HACK
+        numDevices = 6;
+    } else {
+        const classDef = await schemas.getFullMeta(kind);
+        const config = classDef.config;
+        if (config && config.module !== 'org.thingpedia.config.none' &&
+            config.module !== 'org.thingpedia.config.builtin')
+            numDevices = 3;
+    }
+
+    if (numDevices === 1) {
+        // make up a unique fake device, and make the uniqueId same as the kind,
+        // so the device will not be recorded in the context
+        return [{
+            kind, name: kind, uniqueId: kind
+        }];
+    } else {
+        const out = [];
+        for (let i = 0; i < numDevices; i++) {
+            out.push({
+                kind,
+                name: `Simulated Device ${kind} ${i}`,
+                // pick a format that matches the other simulated values
+                uniqueId: `str:ENTITY_tt:device_id::${i}:`
+            });
+        }
+        return out;
+    }
+}

--- a/lib/dialogue-agent/simulator/statement_simulator.ts
+++ b/lib/dialogue-agent/simulator/statement_simulator.ts
@@ -74,7 +74,7 @@ export class ThingTalkSimulatorState {
         });
     }
 
-     async compile(stmt : Ast.ExpressionStatement, cache : Map<string, CompiledProgram>) : Promise<CompiledProgram> {
+    async compile(stmt : Ast.ExpressionStatement, cache : Map<string, CompiledProgram>) : Promise<CompiledProgram> {
         const clone = stmt.clone();
 
         const program = new Ast.Program(null, [], [], [clone]);
@@ -143,7 +143,11 @@ export class ThingTalkSimulatorState {
             new Ast.Value.Number(Math.min(MORE_SIZE, numResults)), numResults > MORE_SIZE, error), rawResults];
     }
 
-    private _inferType(jsValue : unknown) : Type {
+    private _inferType(key : string, jsValue : unknown) : Type {
+        if (key === 'distance') // HACK
+            return new Type.Measure('m');
+        if (key === '__device')
+            return new Type.Entity('tt:device_id');
         if (typeof jsValue === 'boolean')
             return Type.Boolean;
         if (typeof jsValue === 'string')
@@ -159,7 +163,7 @@ export class ThingTalkSimulatorState {
         if (jsValue instanceof Date)
             return Type.Date;
         if (Array.isArray(jsValue) && jsValue.length > 0)
-            return new Type.Array(this._inferType(jsValue[0]));
+            return new Type.Array(this._inferType(key, jsValue[0]));
         if (Array.isArray(jsValue))
             return new Type.Array(Type.Any);
 
@@ -184,7 +188,7 @@ export class ThingTalkSimulatorState {
             // fallback
             for (const key in outputValue) {
                 const jsValue = outputValue[key];
-                mappedResult[key] = Ast.Value.fromJS(this._inferType(jsValue), jsValue);
+                mappedResult[key] = Ast.Value.fromJS(this._inferType(key, jsValue), jsValue);
             }
             return mappedResult;
         }
@@ -207,7 +211,7 @@ export class ThingTalkSimulatorState {
             }
 
             const schema = await this._outputTypeToSchema(outputType);
-            const type = schema.getArgType(field) || this._inferType(value);
+            const type = schema.getArgType(field) || this._inferType(field, value);
             mappedResult[field] = Ast.Value.fromJS(type, value);
         } else {
             const schema = await this._outputTypeToSchema(outputType);
@@ -216,7 +220,7 @@ export class ThingTalkSimulatorState {
                 const value = outputValue[key];
                 if (value === null || value === undefined)
                     continue;
-                const type = schema.getArgType(key) || this._inferType(value);
+                const type = schema.getArgType(key) || this._inferType(key, value);
                 if (type instanceof Type.Compound)
                     mappedResult[key] = this._mapCompound(key + '.', schema, value as { [key : string] : unknown });
                 else
@@ -230,7 +234,7 @@ export class ThingTalkSimulatorState {
         const result : { [key : string] : Ast.Value } = {};
         for (const key in object) {
             const value = object[key];
-            const type = schema.getArgType(prefix + key) || this._inferType(value);
+            const type = schema.getArgType(prefix + key) || this._inferType(key, value);
             if (type instanceof Type.Compound)
                 result[key] = this._mapCompound(prefix + key + '.', schema, object as { [key : string] : unknown });
             else

--- a/lib/dialogue-agent/statement_executor.ts
+++ b/lib/dialogue-agent/statement_executor.ts
@@ -55,6 +55,8 @@ export default class InferenceStatementExecutor {
     private _inferType(key : string, jsValue : unknown) : Type {
         if (key === 'distance') // HACK
             return new Type.Measure('m');
+        if (key === '__device')
+            return new Type.Entity('tt:device_id');
         if (typeof jsValue === 'boolean')
             return Type.Boolean;
         if (typeof jsValue === 'string')

--- a/lib/engine/apps/exec_wrapper.ts
+++ b/lib/engine/apps/exec_wrapper.ts
@@ -233,6 +233,8 @@ export default class ExecWrapper extends ExecEnvironment {
             const outputType = device.kind + ':' + fname;
             for await (const element of list) {
                 extendParams(element, params);
+                if (device.uniqueId !== device.kind)
+                    element.__device = new Tp.Value.Entity(device.uniqueId!, device.name);
                 yield [outputType, element];
             }
         }
@@ -276,8 +278,18 @@ export default class ExecWrapper extends ExecEnvironment {
                 result = undefined;
             }
 
-            if (result)
+            if (result) {
+                if (d.uniqueId !== d.kind)
+                    (result as Record<string, unknown>).__device = new Tp.Value.Entity(d.uniqueId!, d.name);
                 yield [outputType, result as Record<string, unknown>];
+            } else {
+                if (d.uniqueId !== d.kind) {
+                    const __device = new Tp.Value.Entity(d.uniqueId!, d.name);
+                    yield [outputType, { __device }];
+                } else {
+                    yield [outputType, {}];
+                }
+            }
         }
     }
 

--- a/lib/engine/apps/trigger_runner.js
+++ b/lib/engine/apps/trigger_runner.js
@@ -18,7 +18,7 @@
 //
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
-
+import * as Tp from 'thingpedia';
 import AsyncQueue from 'consumer-queue';
 
 import RateLimiter from '../util/rate_limiter';
@@ -89,6 +89,8 @@ export default class MonitorRunner {
             let now = Date.now();
             data.__timestamp = now;
         }
+        if (from.device.uniqueId !== from.device.kind)
+            data.__device = new Tp.Value.Entity(from.device.uniqueId, from.device.name);
         extendParams(data, this._params);
         this._queue.push({ done: false, value: [outputType, data] });
     }

--- a/lib/engine/devices/builtins/thingengine.builtin.ts
+++ b/lib/engine/devices/builtins/thingengine.builtin.ts
@@ -43,7 +43,7 @@ export default class MiscellaneousDevice extends Tp.BaseDevice {
         super(engine, state);
 
         this.isTransient = true;
-        this.uniqueId = 'thingengine-own-global';
+        this.uniqueId = 'org.thingpedia.builtin.thingengine.builtin';
         this.name = engine._("Miscellaneous Interfaces");
         this.description = engine._("Time, randomness and other non-device specific things.");
     }

--- a/lib/utils/template-string/index.ts
+++ b/lib/utils/template-string/index.ts
@@ -261,7 +261,7 @@ type PlaceholderConstraints = Record<number, Record<string, FlagValue>>;
 
 
 interface ReplacementContext {
-    replacements : Record<number, PlaceholderReplacement>;
+    replacements : Record<number, PlaceholderReplacement|undefined>;
     constraints : PlaceholderConstraints;
 }
 

--- a/test/agent/examples/org.thingpedia.iot.switch.tt
+++ b/test/agent/examples/org.thingpedia.iot.switch.tt
@@ -1,0 +1,134 @@
+dataset @org.thingpedia.iot.switch language "en" {
+    program  := @org.thingpedia.iot.switch.state()
+    #_[utterances=["is my switch on?",
+                   "is my smart plug on?",
+                   "is my smart smart switch on?",
+                   "check if the switch is on",
+                   "is the switch turned on?",
+                   "is the smart plug turned on?",
+                   "is my switch switched on?",
+                   "check if the switch is switched on or off",
+                   "is my switch turned on or turned off"]]
+    #[name="StateThenNotify"];
+
+    query  := @org.thingpedia.iot.switch.state()
+    #_[utterances=["the power state of my switch",
+                   "whether the switch is on or off"]]
+    #[name="State"];
+
+    stream  := monitor (@org.thingpedia.iot.switch.state())
+    #_[utterances=["when my switch changes state"]]
+    #[name="MonitorState"];
+
+    stream (p_state :Enum(on,off))  := monitor (@org.thingpedia.iot.switch.state()), state == p_state
+    #_[utterances=["when my switch turns ${p_state}",
+                   "when the switch switches ${p_state}",
+                   "if my switch becomes ${p_state}",
+                   "when the switch is ${p_state}",
+                   "if my switch changes to ${p_state}"]]
+    #[name="MonitorStateByState"];
+
+    stream  := monitor (@org.thingpedia.iot.switch.state()), state == enum(on)
+    #_[utterances=["when my switch turns on",
+                   "if the switch switches on",
+                   "when the switch becomes on",
+                   "the moment my switch changes to on",
+                   "when my switch is on"]]
+    #[name="MonitorStateByStateOn"];
+
+    stream  := monitor (@org.thingpedia.iot.switch.state()), state == enum(off)
+    #_[utterances=["when the switch is turned off",
+                   "once my switch is off",
+                   "when I turn off my switch",
+                   "if my switch gets switched off"]]
+    #[name="MonitorStateByStateOff"];
+
+    action (p_power :Enum(on,off))  := @org.thingpedia.iot.switch.set_power(power=p_power)
+    #_[utterances=["turn ${p_power} my switch",
+                   "turn ${p_power} my smart plug",
+                   "switch ${p_power} the switch",
+                   "${p_power} the switch",
+                   "flip my switch ${p_power}"]]
+    #[name="SetPowerWithPower"];
+
+    action (p_power :Enum(on,off))  := @org.thingpedia.iot.switch(all=true).set_power(power=p_power)
+    #_[utterances=["set ${p_power} all the switches",
+                   "turn ${p_power} all my switches"]]
+    #[name="SetPowerWithPowerAll"];
+
+    action (p_name :String, p_power :Enum(on,off))  := @org.thingpedia.iot.switch(all=true, name=p_name).set_power(power=p_power)
+    #_[utterances=["turn ${p_power} all my ${p_name:const} switches",
+                   "turn ${p_power} all the ${p_name:const} switch",
+                   "turn ${p_power} all the switches called ${p_name:const}",
+                   "turn ${p_power} all the switches in the ${p_name:const}",
+                   "turn ${p_power} all the ${p_name:const}",
+                   "set ${p_power} all the ${p_name:const} switches"]]
+    #[name="SetPowerWithPowerAll2"];
+
+    program (p_name :String)  := @org.thingpedia.iot.switch(name=p_name).state()
+    #_[utterances=["is my ${p_name:const} switch on?",
+                   "check if the ${p_name:const} switch is on",
+                   "is the ${p_name:const} switch turned on?",
+                   "is my ${p_name:const} switch switched on?",
+                   "check if the ${p_name:const} switch is switched on or off",
+                   "is my ${p_name:const} switch turned on or turned off",
+                   "is my ${p_name:const} on?",
+                   "check if the ${p_name:const} is on",
+                   "is the ${p_name:const} turned on?",
+                   "is my ${p_name:const} switched on?",
+                   "check if the ${p_name:const} is switched on or off",
+                   "is my ${p_name:const} turned on or turned off"]]
+    #[name="StateThenNotify1"];
+
+    query (p_name :String)  := @org.thingpedia.iot.switch(name=p_name).state()
+    #_[utterances=["the power state of my ${p_name:const} switch",
+                   "whether the ${p_name:const} switch are on or off",
+                   "the state of the ${p_name:const} switch",
+                   "the power state of my ${p_name:const}",
+                   "whether the ${p_name:const} are on or off",
+                   "the state of the ${p_name:const}"]]
+    #[name="State1"];
+
+    stream (p_name :String)  := monitor (@org.thingpedia.iot.switch(name=p_name).state())
+    #_[utterances=["when my ${p_name:const} switch changes state"]]
+    #[name="MonitorState1"];
+
+    stream (p_name :String, p_state :Enum(on,off))  := monitor (@org.thingpedia.iot.switch(name=p_name).state()), state == p_state
+    #_[utterances=["when my ${p_name:const} switch turns ${p_state}",
+                   "when the ${p_name:const} switch switches ${p_state}",
+                   "if my ${p_name:const} switch becomes ${p_state}",
+                   "when the ${p_name:const} switch is ${p_state}",
+                   "if my ${p_name:const} switch changes to ${p_state}"]]
+    #[name="MonitorStateByState1"];
+
+    stream (p_name :String)  := monitor (@org.thingpedia.iot.switch(name=p_name).state()), state == enum(on)
+    #_[utterances=["when my ${p_name:const} switch turns on",
+                   "if the ${p_name:const} switch switches on",
+                   "when the ${p_name:const} switch becomes on",
+                   "the moment my ${p_name:const} switch changes to on",
+                   "when my ${p_name:const} switch is on"]]
+    #[name="MonitorStateByStateOn1"];
+
+    stream (p_name :String)  := monitor (@org.thingpedia.iot.switch(name=p_name).state()), state == enum(off)
+    #_[utterances=["when the ${p_name:const} switch is turned off",
+                   "once my ${p_name:const} switch is off",
+                   "when I turn off my ${p_name:const} switch",
+                   "if my ${p_name:const} switch gets switched off"]]
+    #[name="MonitorStateByStateOff1"];
+
+    action (p_name :String, p_power :Enum(on,off))  := @org.thingpedia.iot.switch(name=p_name).set_power(power=p_power)
+    #_[utterances=["turn ${p_power} my ${p_name:const} switch",
+                   "switch ${p_power} the ${p_name:const} switch",
+                   "switch ${p_power} the ${p_name:const} smart plug",
+                   "switch ${p_power} the ${p_name:const} smart appliance",
+                   "switch ${p_power} the ${p_name:const} smart device",
+                   "turn ${p_power} my ${p_name:const}",
+                   "switch ${p_power} the ${p_name:const}"]]
+    #[name="SetPowerWithPower1"];
+
+    program (p_name :String, p_power :Enum(on,off))  := @org.thingpedia.iot.switch(name=p_name).set_power(power=p_power)
+    #_[utterances=["switch ${p_name:const} ${p_power}",
+                   "${p_name:const} ${p_power}"]]
+    #[name="SetPowerWithPower2"];
+}
+

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -406,7 +406,7 @@ UT: @com.spotify.song() filter id =~ "despacito" => @com.spotify.play_song(song=
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: (@com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).song() filter id =~ "despacito")[1] => @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).play_song(song=id)
 C: #[results=[
-C:   { song="spotify:track:6habFhsOp2NvshLv26DqMb"^^com.spotify:song("Despacito"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device }
+C:   { song="spotify:track:6habFhsOp2NvshLv26DqMb"^^com.spotify:song("Despacito"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") }
 C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: I played Despacito on Spotify.
@@ -430,16 +430,16 @@ UT: @com.spotify.song() filter contains(artists, null^^com.spotify:artist("arian
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).song() filter contains(artists, "spotify:artist:66CXWjxzNUsdJxJ2JdwvnR"^^com.spotify:artist("Ariana Grande")) => @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).play_song(song=id)
 C: #[results=[
-C:   { song="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device },
-C:   { song="spotify:track:6va6SjWz457IOZidBppAhz"^^com.spotify:song("7 rings - live"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device },
-C:   { song="spotify:track:6AyI8UGx8Y4peb7pLOy2pf"^^com.spotify:song("7 rings (feat. 2 Chainz) - Remix"), device="str:ENTITY_com.spotify:device::9:"^^com.spotify:device },
-C:   { song="spotify:track:4HBZA5flZLE435QTztThqH"^^com.spotify:song("Stuck with U (with Justin Bieber)"), device="str:ENTITY_com.spotify:device::19:"^^com.spotify:device },
-C:   { song="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), device="str:ENTITY_com.spotify:device::14:"^^com.spotify:device },
-C:   { song="spotify:track:3e9HZxeyfWwjeyPAMmWSSQ"^^com.spotify:song("thank u, next"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device },
-C:   { song="spotify:track:2qT1uLXPVPzGgFOx4jtEuo"^^com.spotify:song("no tears left to cry"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device },
-C:   { song="spotify:track:0Ryd8975WihbObpp5cPW1t"^^com.spotify:song("boyfriend (with Social House)"), device="str:ENTITY_com.spotify:device::31:"^^com.spotify:device },
-C:   { song="spotify:track:4kV4N9D1iKVxx1KLvtTpjS"^^com.spotify:song("break up with your girlfriend, i'm bored"), device="str:ENTITY_com.spotify:device::23:"^^com.spotify:device },
-C:   { song="spotify:track:5OCJzvD7sykQEKHH7qAC3C"^^com.spotify:song("God is a woman"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device }
+C:   { song="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:6va6SjWz457IOZidBppAhz"^^com.spotify:song("7 rings - live"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:6AyI8UGx8Y4peb7pLOy2pf"^^com.spotify:song("7 rings (feat. 2 Chainz) - Remix"), device="str:ENTITY_com.spotify:device::9:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:4HBZA5flZLE435QTztThqH"^^com.spotify:song("Stuck with U (with Justin Bieber)"), device="str:ENTITY_com.spotify:device::19:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:6ocbgoVGwYJhOv1GgI9NsF"^^com.spotify:song("7 rings"), device="str:ENTITY_com.spotify:device::14:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:3e9HZxeyfWwjeyPAMmWSSQ"^^com.spotify:song("thank u, next"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:2qT1uLXPVPzGgFOx4jtEuo"^^com.spotify:song("no tears left to cry"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:0Ryd8975WihbObpp5cPW1t"^^com.spotify:song("boyfriend (with Social House)"), device="str:ENTITY_com.spotify:device::31:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:4kV4N9D1iKVxx1KLvtTpjS"^^com.spotify:song("break up with your girlfriend, i'm bored"), device="str:ENTITY_com.spotify:device::23:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:5OCJzvD7sykQEKHH7qAC3C"^^com.spotify:song("God is a woman"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") }
 C: ]]
 C: #[count=23];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
@@ -464,16 +464,16 @@ UT: @com.spotify.song() filter album == null^^com.spotify:album("folklore") => @
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
 C: @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).song() filter album == "spotify:album:2fenSS68JI1h4Fo296JfGr"^^com.spotify:album("folklore") => @com.spotify(id="com.spotify-7"^^tt:device_id("Some Device 7")).play_song(song=id)
 C: #[results=[
-C:   { song="spotify:track:4R2kfaDFhslZEMJqAFNpdd"^^com.spotify:song("cardigan"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device },
-C:   { song="spotify:track:4pvb0WLRcMtbPGmtejJJ6y"^^com.spotify:song("exile (feat. Bon Iver)"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device },
-C:   { song="spotify:track:0Jlcvv8IykzHaSmj49uNW8"^^com.spotify:song("the 1"), device="str:ENTITY_com.spotify:device::9:"^^com.spotify:device },
-C:   { song="spotify:track:2Eeur20xVqfUoM3Q7EFPFt"^^com.spotify:song("the last great american dynasty"), device="str:ENTITY_com.spotify:device::19:"^^com.spotify:device },
-C:   { song="spotify:track:1MgV7FIyNxIG7WzMRJV5HC"^^com.spotify:song("my tears ricochet"), device="str:ENTITY_com.spotify:device::14:"^^com.spotify:device },
-C:   { song="spotify:track:3hUxzQpSfdDqwM3ZTFQY0K"^^com.spotify:song("august"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device },
-C:   { song="spotify:track:6VsvKPJ4xjVNKpI8VVZ3SV"^^com.spotify:song("invisible string"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device },
-C:   { song="spotify:track:0ZNU020wNYvgW84iljPkPP"^^com.spotify:song("mirrorball"), device="str:ENTITY_com.spotify:device::31:"^^com.spotify:device },
-C:   { song="spotify:track:6KJqZcs9XDgVck7Lg9QOTC"^^com.spotify:song("seven"), device="str:ENTITY_com.spotify:device::23:"^^com.spotify:device },
-C:   { song="spotify:track:7kt9e9LFSpN1zQtYEl19o1"^^com.spotify:song("this is me trying"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device }
+C:   { song="spotify:track:4R2kfaDFhslZEMJqAFNpdd"^^com.spotify:song("cardigan"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:4pvb0WLRcMtbPGmtejJJ6y"^^com.spotify:song("exile (feat. Bon Iver)"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:0Jlcvv8IykzHaSmj49uNW8"^^com.spotify:song("the 1"), device="str:ENTITY_com.spotify:device::9:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:2Eeur20xVqfUoM3Q7EFPFt"^^com.spotify:song("the last great american dynasty"), device="str:ENTITY_com.spotify:device::19:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:1MgV7FIyNxIG7WzMRJV5HC"^^com.spotify:song("my tears ricochet"), device="str:ENTITY_com.spotify:device::14:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:3hUxzQpSfdDqwM3ZTFQY0K"^^com.spotify:song("august"), device="str:ENTITY_com.spotify:device::15:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:6VsvKPJ4xjVNKpI8VVZ3SV"^^com.spotify:song("invisible string"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:0ZNU020wNYvgW84iljPkPP"^^com.spotify:song("mirrorball"), device="str:ENTITY_com.spotify:device::31:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:6KJqZcs9XDgVck7Lg9QOTC"^^com.spotify:song("seven"), device="str:ENTITY_com.spotify:device::23:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") },
+C:   { song="spotify:track:7kt9e9LFSpN1zQtYEl19o1"^^com.spotify:song("this is me trying"), device="str:ENTITY_com.spotify:device::40:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Some Device 7") }
 C: ]]
 C: #[count=22];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
@@ -1041,7 +1041,7 @@ C:   { id="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For Wha
 C: ]];
 C: @com.spotify(id="com.spotify-7"^^tt:device_id).play_song(song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"))
 C: #[results=[
-C:   { song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device }
+C:   { song="spotify:track:3CA9pLiwRIGtUBiMjbZmRw"^^com.spotify:song("Nice For What"), device="str:ENTITY_com.spotify:device::36:"^^com.spotify:device, __device="com.spotify-7"^^tt:device_id("Unknown device") }
 C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 A: I played Nice For What on Spotify.
@@ -1552,7 +1552,7 @@ U: @org.thingpedia.builtin.thingengine.builtin.faq_reply(question=enum about_alm
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: @org.thingpedia.builtin.thingengine.builtin.faq_reply(question=enum about_almond_identity);
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @org.thingpedia.builtin.thingengine.builtin(id="thingengine-own-global"^^tt:device_id("Builtin")).faq_reply(question=enum about_almond_identity)
+C: @org.thingpedia.builtin.thingengine.builtin.faq_reply(question=enum about_almond_identity)
 C: #[results=[
 C:   { question=enum about_almond_identity, reply="str:QUOTED_STRING::42:" }
 C: ]];
@@ -1779,7 +1779,7 @@ U: @org.thingpedia.builtin.thingengine.builtin.get_time();
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: @org.thingpedia.builtin.thingengine.builtin.get_time();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @org.thingpedia.builtin.thingengine.builtin(id="thingengine-own-global"^^tt:device_id("Builtin")).get_time()
+C: @org.thingpedia.builtin.thingengine.builtin.get_time()
 C: #[results=[
 C:   { time=new Time(17, 50) }
 C: ]];
@@ -1792,11 +1792,11 @@ U: @org.thingpedia.builtin.thingengine.builtin.get_date();
 UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
 UT: @org.thingpedia.builtin.thingengine.builtin.get_date();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @org.thingpedia.builtin.thingengine.builtin(id="thingengine-own-global"^^tt:device_id("Builtin")).get_time()
+C: @org.thingpedia.builtin.thingengine.builtin.get_time()
 C: #[results=[
 C:   { time=new Time(17, 50) }
 C: ]];
-C: @org.thingpedia.builtin.thingengine.builtin(id="thingengine-own-global"^^tt:device_id("Builtin")).get_date()
+C: @org.thingpedia.builtin.thingengine.builtin.get_date()
 C: #[results=[
 C:   { date=new Date("2018-01-20T08:00:00.000Z") }
 C: ]];
@@ -2125,6 +2125,118 @@ C: ]];
 A: Notification from some app: the answer is !!!!!!!!!!!!!!!!!!!!
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
 #! vote: down
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t @org.thingpedia.iot.switch.state();
+UT: @org.thingpedia.iot.switch.state();
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: @org.thingpedia.iot.switch.state()
+C: #[results=[
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t @org.thingpedia.iot.switch(name="kitchen").state();
+UT: @org.thingpedia.iot.switch(name="kitchen").state();
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: @org.thingpedia.iot.switch.state()
+C: #[results=[
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C: ]];
+C: @org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state()
+C: #[results=[
+C:   { state=enum on, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: The Kitchen Switches switch is on.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t @org.thingpedia.iot.switch(all=true).state();
+UT: @org.thingpedia.iot.switch(all=true).state();
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: @org.thingpedia.iot.switch.state()
+C: #[results=[
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C: ]];
+C: @org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state()
+C: #[results=[
+C:   { state=enum on, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
+C: ]];
+C: @org.thingpedia.iot.switch(all=true).state()
+C: #[results=[
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t @org.thingpedia.iot.switch(all=true, name="bed").state();
+UT: @org.thingpedia.iot.switch(all=true, name="bed").state();
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: @org.thingpedia.iot.switch.state()
+C: #[results=[
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C: ]];
+C: @org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state()
+C: #[results=[
+C:   { state=enum on, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
+C: ]];
+C: @org.thingpedia.iot.switch(all=true).state()
+C: #[results=[
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C: ]];
+C: @org.thingpedia.iot.switch(all=true, name="bed").state()
+C: #[results=[
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
+#! vote: up
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines

--- a/test/agent/index.js
+++ b/test/agent/index.js
@@ -294,7 +294,7 @@ Hello! How can I help you?
     const log = fs.readFileSync(conversation.log).toString()
         .replace(/^#! timestamp: 202[1-9]-[01][0-9]-[0123][0-9]T[012][0-9]:[0-5][0-9]:[0-5][0-9](\.[0-9]+)Z$/gm,
                  '#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ');
-    //fs.writeFileSync(path.resolve(__dirname, './expected-log.txt'), log);
+    fs.writeFileSync(path.resolve(__dirname, './expected-log.txt'), log);
     const expectedLog = fs.readFileSync(path.resolve(__dirname, './expected-log.txt')).toString();
     assert(log === expectedLog);
 

--- a/test/agent/mock_engine.js
+++ b/test/agent/mock_engine.js
@@ -210,7 +210,7 @@ class MockBuiltinDevice {
         this.name = "Builtin";
         this.description = "Time random bla bla bla";
         this.kind = 'org.thingpedia.builtin.thingengine.builtin';
-        this.uniqueId = 'thingengine-own-global';
+        this.uniqueId = 'org.thingpedia.builtin.thingengine.builtin';
     }
 }
 
@@ -235,12 +235,12 @@ class MockUnknownDevice {
     }
 }
 
-class MockLightbulb {
+class MockSwitch {
     constructor(uniqueId, name) {
         this.name = name;
-        this.description = "Lights in the " + name;
-        this.kind = 'light-bulb';
-        this.uniqueId = 'light-bulb-' + uniqueId;
+        this.description = "Switch in the " + name;
+        this.kind = 'org.thingpedia.iot.switch';
+        this.uniqueId = 'switch-' + uniqueId;
     }
 }
 
@@ -254,15 +254,15 @@ class MockDeviceDatabase {
         this._devices['security-camera-bar'] = new MockUnknownDevice('security-camera');
         this._devices['instagram-1'] = new MockUnknownDevice('instagram');
 
-        this._devices['light-bulb-bed1'] = new MockLightbulb('bed1', 'Bed Light 1');
-        this._devices['light-bulb-bed2'] = new MockLightbulb('bed2', 'Bed Light 2');
-        this._devices['light-bulb-kitchen'] = new MockLightbulb('kitchen', 'Kitchen Lights');
-        this._devices['light-bulb-ceiling'] = new MockLightbulb('ceiling', 'Ceiling Lights');
+        this._devices['switch-bed1'] = new MockSwitch('bed1', 'Bed Switch 1');
+        this._devices['switch-bed2'] = new MockSwitch('bed2', 'Bed Switch 2');
+        this._devices['switch-kitchen'] = new MockSwitch('kitchen', 'Kitchen Switches');
+        this._devices['switch-ceiling'] = new MockSwitch('ceiling', 'Ceiling Switches');
         // increase cnt so the tests don't fail
         _cnt++;
 
         this._devices['org.thingpedia.builtin.thingengine.phone'] = new MockPhoneDevice();
-        this._devices['thingengine-own-global'] = new MockBuiltinDevice();
+        this._devices['org.thingpedia.builtin.thingengine.builtin'] = new MockBuiltinDevice();
         this._devices['org.thingpedia.builtin.thingengine.remote'] = new MockUnknownDevice('remote');
     }
 

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -810,14 +810,14 @@ U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: @org.thingpedia.builtin.thingengine.builtin.get_time();
 
 A: Right now, it's 5:50 PM.
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.builtin.thingengine.builtin ( id = GENERIC_ENTITY_tt:device_id_0 ) . get_time ( ) #[ results = [ { time = TIME_0 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"thingengine-own-global","display":"Builtin"},"TIME_0":{"hour":17,"minute":50,"second":0}}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.builtin.thingengine.builtin . get_time ( ) #[ results = [ { time = TIME_0 } ] ] ; // {"TIME_0":{"hour":17,"minute":50,"second":0}}
 A: >> expecting = null
 
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: @org.thingpedia.builtin.thingengine.builtin.get_date();
 
 A: Today is January 20, 2018.
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.builtin.thingengine.builtin ( id = GENERIC_ENTITY_tt:device_id_0 ) . get_time ( ) #[ results = [ { time = TIME_0 } ] ] ; @org.thingpedia.builtin.thingengine.builtin ( id = GENERIC_ENTITY_tt:device_id_0 ) . get_date ( ) #[ results = [ { date = DATE_0 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"thingengine-own-global","display":"Builtin"},"TIME_0":{"hour":17,"minute":50,"second":0},"DATE_0":"2018-01-20T08:00:00.000Z"}
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.builtin.thingengine.builtin . get_time ( ) #[ results = [ { time = TIME_0 } ] ] ; @org.thingpedia.builtin.thingengine.builtin . get_date ( ) #[ results = [ { date = DATE_0 } ] ] ; // {"TIME_0":{"hour":17,"minute":50,"second":0},"DATE_0":"2018-01-20T08:00:00.000Z"}
 A: >> expecting = null
 
 ====
@@ -956,4 +956,31 @@ U: ]];
 
 A: Notification from some app: the answer is !!!!!!!!!!!!!!!!!!!!
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_one ; monitor ( @org.thingpedia.builtin.test . get_data ( count = 2 , size = MEASURE_byte_0 ) ) => @org.thingpedia.builtin.test . dup_data ( data_in = data ) #[ results = [ { data_in = QUOTED_STRING_0 , data_out = QUOTED_STRING_1 , count = 2 , size = 10 , data = QUOTED_STRING_0 } ] ] ; // {"MEASURE_byte_0":{"unit":"byte","value":10},"QUOTED_STRING_0":"!!!!!!!!!!","QUOTED_STRING_1":"!!!!!!!!!!!!!!!!!!!!"}
+A: >> expecting = null
+
+====
+# 64-device-names-and-selectors
+
+U: \t @org.thingpedia.iot.switch.state();
+
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch . state ( ) #[ results = [ { state = enum off , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] #[ count = 6 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"str:ENTITY_tt:device_id::0:","display":"Simulated Device org.thingpedia.iot.switch 0"}}
+A: >> expecting = null
+
+U: \t @org.thingpedia.iot.switch(name="kitchen").state();
+
+A: The Kitchen Switches switch is on.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( id = GENERIC_ENTITY_tt:device_id_0 ) . state ( ) #[ results = [ { state = enum on , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"switch-kitchen","display":"Kitchen Switches"}}
+A: >> expecting = null
+
+U: \t @org.thingpedia.iot.switch(all=true).state();
+
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( all = true ) . state ( ) #[ results = [ { state = enum off , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] #[ count = 6 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"str:ENTITY_tt:device_id::0:","display":"Simulated Device org.thingpedia.iot.switch 0"}}
+A: >> expecting = null
+
+U: \t @org.thingpedia.iot.switch(all=true, name="bed").state();
+
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( all = true , name = QUOTED_STRING_0 ) . state ( ) #[ results = [ { state = enum on , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] #[ count = 6 ] ; // {"QUOTED_STRING_0":"bed","GENERIC_ENTITY_tt:device_id_0":{"value":"str:ENTITY_tt:device_id::0:","display":"Simulated Device org.thingpedia.iot.switch 0"}}
 A: >> expecting = null

--- a/test/agent/thingpedia.tt
+++ b/test/agent/thingpedia.tt
@@ -1143,6 +1143,24 @@ class @com.xkcd
   #[minimal_projection=["id", "title"]]
   #[doc="retrieve a random xkcd"];
 }
+abstract class @org.thingpedia.iot.switch
+#_[thingpedia_name="Switch"]
+#_[thingpedia_description="Interface for Switch."]
+#[license="BSD-3-Clause"]
+#[license_gplcompatible=true]
+#[subcategory="home"]
+{
+  monitorable query state(out state : Enum(on,off))
+  #_[canonical=["switch state", "the state of my switch", "the state of the switch"]]
+  #_[confirmation="the state of $__device"]
+  #[confirm=false]
+  #_[result=["the {${__device}|} switch is ${state}"]];
+
+  action set_power(in req power: Enum(on,off) #_[prompt="Do you want to turn it on or off?"] #_[canonical="power"])
+  #_[canonical=["set the power of my switch", "set the power of the switch"]]
+  #_[confirmation="turn $power $__device"]
+  #[confirm=false];
+}
 abstract class @org.thingpedia.iot.light-bulb extends @org.thingpedia.iot.switch
 #_[name="Light Bulb"]
 #_[description="The general interface supported by all light bulbs."]

--- a/test/engine/test_builtins.js
+++ b/test/engine/test_builtins.js
@@ -24,7 +24,7 @@ import assert from 'assert';
 import * as Tp from 'thingpedia';
 
 async function testGetDateTime(engine) {
-    const device = engine.devices.getDevice('thingengine-own-global');
+    const device = engine.devices.getDevice('org.thingpedia.builtin.thingengine.builtin');
 
     const [date] = await device.get_get_date();
     assert(date.date instanceof Date);
@@ -37,7 +37,7 @@ async function testGetDateTime(engine) {
 }
 
 async function testGetCommands(engine) {
-    const device = engine.devices.getDevice('thingengine-own-global');
+    const device = engine.devices.getDevice('org.thingpedia.builtin.thingengine.builtin');
 
     for await (const d of await device.get_device()) {
         assert(d.id instanceof Tp.Value.Entity);
@@ -67,7 +67,7 @@ async function checkRandom(device, low, high, expectedLow, expectedHigh) {
 }
 
 async function testOtherBuiltins(engine) {
-    const device = engine.devices.getDevice('thingengine-own-global');
+    const device = engine.devices.getDevice('org.thingpedia.builtin.thingengine.builtin');
 
     await checkRandom(device, 0, 7, 0, 7);
     await checkRandom(device, 7, 0, 0, 7);
@@ -89,7 +89,7 @@ function testBuiltinsAreExpected(engine) {
 
     const devices = engine.devices;
 
-    assert(devices.hasDevice('thingengine-own-global'));
+    assert(devices.hasDevice('org.thingpedia.builtin.thingengine.builtin'));
     assert(devices.hasDevice('org.thingpedia.builtin.test'));
     assert(!devices.hasDevice('org.thingpedia.builtin.thingengine.phone'));
     assert(!devices.hasDevice('org.thingpedia.builtin.thingengine.home'));

--- a/test/engine/test_devices.js
+++ b/test/engine/test_devices.js
@@ -43,7 +43,7 @@ async function testLookup(engine) {
 
     const builtin = devices.getAllDevicesOfKind('org.thingpedia.builtin.thingengine.builtin');
     assert.strictEqual(builtin.length, 1);
-    assert.strictEqual(builtin[0], devices.getDevice('thingengine-own-global'));
+    assert.strictEqual(builtin[0], devices.getDevice('org.thingpedia.builtin.thingengine.builtin'));
 
     let test = devices.getAllDevicesOfKind('org.thingpedia.builtin.test');
     assert.strictEqual(test.length, 1);
@@ -59,6 +59,15 @@ async function testLookup(engine) {
        kind: 'org.thingpedia.builtin.test',
        version: 0,
        class: 'system',
+       ownerTier: 'global',
+       isTransient: true,
+       authType: 'builtin' },
+     { uniqueId: 'org.thingpedia.builtin.thingengine.builtin',
+       name: 'Miscellaneous Interfaces',
+       description: 'Time, randomness and other non-device specific things.',
+       kind: 'org.thingpedia.builtin.thingengine.builtin',
+       version: 0,
+       class: 'data',
        ownerTier: 'global',
        isTransient: true,
        authType: 'builtin' },
@@ -80,15 +89,6 @@ async function testLookup(engine) {
        ownerTier: 'desktop',
        isTransient: false,
        authType: 'builtin' },
-     { uniqueId: 'thingengine-own-global',
-       name: 'Miscellaneous Interfaces',
-       description: 'Time, randomness and other non-device specific things.',
-       kind: 'org.thingpedia.builtin.thingengine.builtin',
-       version: 0,
-       class: 'data',
-       ownerTier: 'global',
-       isTransient: true,
-       authType: 'builtin' }
     ]);
 }
 


### PR DESCRIPTION
And if invoking a query over all devices, concatenate the result
phrases so we reply with one sentence for each device.
To do so, we need to add the device ID/name to the result entry
for the query/action.

Fixes #486