### PR TITLE
Improve query refinement templates for empty searches

### DIFF
--- a/languages/thingtalk/dialogue_acts/empty-search.ts
+++ b/languages/thingtalk/dialogue_acts/empty-search.ts
@@ -30,7 +30,8 @@ import {
 } from '../state_manip';
 import {
     queryRefinement,
-    refineFilterToChangeFilter
+    refineFilterForEmptySearch,
+    RefineFilterCallback
 } from './refinement-helpers';
 import {
     isValidSearchQuestion
@@ -90,10 +91,11 @@ function isGoodEmptySearchQuestion(ctx : ContextInfo, question : C.ParamSlot) {
 }
 
 function emptySearchChangePhraseCommon(ctx : ContextInfo,
-                                       newFilter : Ast.BooleanExpression) {
+                                       newFilter : Ast.BooleanExpression,
+                                       refineFilter : RefineFilterCallback) {
     const currentStmt = ctx.current!.stmt;
     const currentExpression = currentStmt.expression;
-    const newExpression = queryRefinement(currentExpression, newFilter, refineFilterToChangeFilter, null);
+    const newExpression = queryRefinement(currentExpression, newFilter, refineFilter, null);
     if (newExpression === null)
         return null;
 
@@ -117,7 +119,7 @@ function preciseEmptySearchChangeRequest(ctx : ContextInfo,
     if (param !== null && !C.filterUsesParam(phrase.filter, param.name))
         return null;
 
-    return emptySearchChangePhraseCommon(ctx, phrase.filter);
+    return emptySearchChangePhraseCommon(ctx, phrase.filter, refineFilterForEmptySearch);
 }
 
 /**
@@ -144,7 +146,7 @@ function impreciseEmptySearchChangeRequest(ctx : ContextInfo,
     if (!C.checkFilter(base, answerFilter))
         return null;
 
-    return emptySearchChangePhraseCommon(ctx, answerFilter);
+    return emptySearchChangePhraseCommon(ctx, answerFilter, refineFilterForEmptySearch);
 }
 
 export {


### PR DESCRIPTION
We do not want to propagate the slots in case the user abandons
the search and starts something else entirely. This can occur
in case of agent errors, but also legitimately when the user changes
their mind.

----

This is quite tricky re MultiWOZ, because we want to match the semantics of human-human conversations even though this aspect is ambiguous. I think the new code is strictly a superset of the previous code for synthesis: the previous code would not synthesize cases where the user abandons an empty search and moves on to something else in the same domain at all.

Fixes #337