### PR TITLE
Update the pruning size and depth default values

### DIFF
--- a/tool/generate-dialogs.ts
+++ b/tool/generate-dialogs.ts
@@ -71,7 +71,7 @@ export function initArgparse(subparsers : argparse.SubParser) {
     });
     parser.add_argument('--max-turns', {
         required: false,
-        default: 7,
+        default: 6,
         type: Number,
         help: `Maximum number of turns per dialog`
     });
@@ -117,13 +117,13 @@ export function initArgparse(subparsers : argparse.SubParser) {
     parser.add_argument('--maxdepth', {
         required: false,
         type: Number,
-        default: 4,
+        default: 8,
         help: 'Maximum depth of sentence generation',
     });
     parser.add_argument('--target-pruning-size', {
         required: false,
         type: Number,
-        default: 100,
+        default: 250,
         help: 'Pruning target for each non-terminal',
     });
     parser.add_argument('-B', '--minibatch-size', {

--- a/tool/generate.ts
+++ b/tool/generate.ts
@@ -84,13 +84,13 @@ export function initArgparse(subparsers : argparse.SubParser) {
     parser.add_argument('--maxdepth', {
         required: false,
         type: Number,
-        default: 5,
+        default: 8,
         help: 'Maximum depth of sentence generation',
     });
     parser.add_argument('--target-pruning-size', {
         required: false,
         type: Number,
-        default: 100000,
+        default: 500,
         help: 'Approximate target size of the generate dataset, for each $root rule and each depth',
     });
 


### PR DESCRIPTION
For generate and generate-dialogs.

Fixes an issue with the basic tutorial, which doesn't pass the command-line arguments and runs out of memory very quickly. 