### PR TITLE
Do not treat ambiguous commands as implicitly applying to all devices

### DIFF
--- a/lib/dialogue-agent/abstract_dialogue_agent.ts
+++ b/lib/dialogue-agent/abstract_dialogue_agent.ts
@@ -352,10 +352,6 @@ export default abstract class AbstractDialogueAgent<PrivateStateType> {
         if (selector.all)
             return;
 
-        // HACK if we're doing IoT and we don't have a name, treat it like "all" devices
-        if (selector.kind.startsWith('org.thingpedia.iot.') && name === undefined)
-            return;
-
         let selecteddevices = alldevices;
         // note: we ignore the name if there is only one device configured - this protects against some bad parses
         if (alldevices.length > 1 && name !== undefined)

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -2016,92 +2016,73 @@ UT: $stop;
 U: \t @org.thingpedia.iot.switch.state();
 UT: @org.thingpedia.iot.switch.state();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @org.thingpedia.iot.switch.state()
+C: @org.thingpedia.iot.switch(id="switch-bed1"^^tt:device_id("Bed Switch 1")).state()
 C: #[results=[
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C:   { state=enum off, __device="switch-bed1"^^tt:device_id("Bed Switch 1") }
 C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: You have multiple switch devices. Which one do you want to use?
+A: The Bed Switch 1 switch is off.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t @org.thingpedia.iot.switch(name="kitchen").state();
 UT: @org.thingpedia.iot.switch(name="kitchen").state();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @org.thingpedia.iot.switch.state()
+C: @org.thingpedia.iot.switch(id="switch-bed1"^^tt:device_id("Bed Switch 1")).state()
 C: #[results=[
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C:   { state=enum off, __device="switch-bed1"^^tt:device_id("Bed Switch 1") }
 C: ]];
 C: @org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state()
 C: #[results=[
-C:   { state=enum on, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
+C:   { state=enum off, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
 C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: The Kitchen Switches switch is on.
+A: The Kitchen Switches switch is off.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t @org.thingpedia.iot.switch(all=true).state();
 UT: @org.thingpedia.iot.switch(all=true).state();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @org.thingpedia.iot.switch.state()
+C: @org.thingpedia.iot.switch(id="switch-bed1"^^tt:device_id("Bed Switch 1")).state()
 C: #[results=[
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C:   { state=enum off, __device="switch-bed1"^^tt:device_id("Bed Switch 1") }
 C: ]];
 C: @org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state()
 C: #[results=[
-C:   { state=enum on, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
+C:   { state=enum off, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
 C: ]];
 C: @org.thingpedia.iot.switch(all=true).state()
 C: #[results=[
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
 C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
 C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
 C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is off. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t @org.thingpedia.iot.switch(all=true, name="bed").state();
 UT: @org.thingpedia.iot.switch(all=true, name="bed").state();
 C: $dialogue @org.thingpedia.dialogue.transaction.execute;
-C: @org.thingpedia.iot.switch.state()
+C: @org.thingpedia.iot.switch(id="switch-bed1"^^tt:device_id("Bed Switch 1")).state()
 C: #[results=[
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C:   { state=enum off, __device="switch-bed1"^^tt:device_id("Bed Switch 1") }
 C: ]];
 C: @org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state()
 C: #[results=[
-C:   { state=enum on, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
+C:   { state=enum off, __device="switch-kitchen"^^tt:device_id("Kitchen Switches") }
 C: ]];
 C: @org.thingpedia.iot.switch(all=true).state()
 C: #[results=[
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 0") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
 C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
 C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
 C: ]];
 C: @org.thingpedia.iot.switch(all=true, name="bed").state()
 C: #[results=[
@@ -2109,11 +2090,11 @@ C:   { state=enum on, __device="str:ENTITY_tt:device_id::0:"^^tt:device_id("Simu
 C:   { state=enum on, __device="str:ENTITY_tt:device_id::1:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 1") },
 C:   { state=enum on, __device="str:ENTITY_tt:device_id::2:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 2") },
 C:   { state=enum on, __device="str:ENTITY_tt:device_id::3:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 3") },
-C:   { state=enum on, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
-C:   { state=enum off, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
+C:   { state=enum off, __device="str:ENTITY_tt:device_id::4:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 4") },
+C:   { state=enum on, __device="str:ENTITY_tt:device_id::5:"^^tt:device_id("Simulated Device org.thingpedia.iot.switch 5") }
 C: ]];
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
-A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is off.
 AT: $dialogue @org.thingpedia.dialogue.transaction.sys_display_result;
 #! vote: up
 #! comment: test comment for dialogue turns

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -963,25 +963,35 @@ A: >> expecting = null
 
 U: \t @org.thingpedia.iot.switch.state();
 
-A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch . state ( ) #[ results = [ { state = enum off , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] #[ count = 6 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"str:ENTITY_tt:device_id::0:","display":"Simulated Device org.thingpedia.iot.switch 0"}}
+A: You have multiple switch devices. Which one do you want to use?
+A: choice 0: Bed Switch 1
+A: choice 1: Bed Switch 2
+A: choice 2: Kitchen Switches
+A: choice 3: Ceiling Switches
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . execute ; @org.thingpedia.iot.switch . state ( ) ; // {}
+A: >> expecting = choice
+
+U: \t $choice(0);
+
+A: The Bed Switch 1 switch is off.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( id = GENERIC_ENTITY_tt:device_id_0 ) . state ( ) #[ results = [ { state = enum off , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"switch-bed1","display":"Bed Switch 1"}}
 A: >> expecting = null
 
 U: \t @org.thingpedia.iot.switch(name="kitchen").state();
 
-A: The Kitchen Switches switch is on.
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( id = GENERIC_ENTITY_tt:device_id_0 ) . state ( ) #[ results = [ { state = enum on , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"switch-kitchen","display":"Kitchen Switches"}}
+A: The Kitchen Switches switch is off.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( id = GENERIC_ENTITY_tt:device_id_0 ) . state ( ) #[ results = [ { state = enum off , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"switch-kitchen","display":"Kitchen Switches"}}
 A: >> expecting = null
 
 U: \t @org.thingpedia.iot.switch(all=true).state();
 
-A: The Simulated Device org.thingpedia.iot.switch 0 switch is off. The Simulated Device org.thingpedia.iot.switch 1 switch is off. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
-A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( all = true ) . state ( ) #[ results = [ { state = enum off , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] #[ count = 6 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"str:ENTITY_tt:device_id::0:","display":"Simulated Device org.thingpedia.iot.switch 0"}}
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is off. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( all = true ) . state ( ) #[ results = [ { state = enum on , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] #[ count = 6 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"str:ENTITY_tt:device_id::0:","display":"Simulated Device org.thingpedia.iot.switch 0"}}
 A: >> expecting = null
 
 U: \t @org.thingpedia.iot.switch(all=true, name="bed").state();
 
-A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is on.
+A: The Simulated Device org.thingpedia.iot.switch 0 switch is on. The Simulated Device org.thingpedia.iot.switch 1 switch is on. The Simulated Device org.thingpedia.iot.switch 2 switch is on. The Simulated Device org.thingpedia.iot.switch 3 switch is on. The Simulated Device org.thingpedia.iot.switch 4 switch is off.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_display_result ; @org.thingpedia.iot.switch ( all = true , name = QUOTED_STRING_0 ) . state ( ) #[ results = [ { state = enum on , __device = GENERIC_ENTITY_tt:device_id_0 } ] ] #[ count = 6 ] ; // {"QUOTED_STRING_0":"bed","GENERIC_ENTITY_tt:device_id_0":{"value":"str:ENTITY_tt:device_id::0:","display":"Simulated Device org.thingpedia.iot.switch 0"}}
 A: >> expecting = null
 


### PR DESCRIPTION
It is too dangerous if the command is misunderstood.

This partially reverts 818a21df9d3506c246b036b08f068a2f84af669a

Fixes #627