### PR TITLE
Fix dbproxy sync interface

### DIFF
--- a/lib/engine/db/dbproxy/sync_table.ts
+++ b/lib/engine/db/dbproxy/sync_table.ts
@@ -18,7 +18,7 @@
 //
 
 import * as Tp from 'thingpedia';
-import { SyncRecord } from '..';
+import { SyncRecord, SyncAtReply } from '..';
 
 type Field<RowType> = Exclude<keyof RowType & string, "uniqueId">;
 
@@ -68,7 +68,7 @@ export default class SyncTable<RowType> {
         return JSON.parse(resp)['data'];
     }
 
-    async syncAt(lastModified : number, pushedChanges : Array<SyncRecord<RowType>>) : Promise<[number, Array<SyncRecord<RowType>>, boolean[]]> {
+    async syncAt(lastModified : number, pushedChanges : Array<SyncRecord<RowType>>) : Promise<SyncAtReply<RowType>> {
         const resp = await Tp.Helpers.Http.post(`${this._baseUrl}/synctable/sync/user_${this.name}/${this._userId}/${lastModified}`,
                 JSON.stringify(pushedChanges), { dataContentType: 'application/json' });
         return JSON.parse(resp)['data'];

--- a/lib/engine/db/index.ts
+++ b/lib/engine/db/index.ts
@@ -64,6 +64,12 @@ export interface LocalTable<RowType extends AbstractRow> {
 }
 
 export type SyncRecord<RowType> = { [K in keyof RowType] : RowType[K]|null } & { uniqueId : string; lastModified : number };
+export interface SyncAtReply<RowType> {
+    lastModified : number;
+    ourChanges : Array<SyncRecord<RowType>>;
+    done : boolean[];
+}
+
 export interface SyncTable<RowType extends AbstractRow>{
     name : string;
     fields : ReadonlyArray<keyof RowType>;
@@ -76,7 +82,7 @@ export interface SyncTable<RowType extends AbstractRow>{
     getRaw() : Promise<Array<SyncRecord<RowType>>>;
     getChangesAfter(lastModified : number) : Promise<Array<SyncRecord<RowType>>>;
     handleChanges(changes : Array<SyncRecord<RowType>>) : Promise<boolean[]>;
-    syncAt(lastModified : number, pushedChanges : Array<SyncRecord<RowType>>) : Promise<[number, Array<SyncRecord<RowType>>, boolean[]]>;
+    syncAt(lastModified : number, pushedChanges : Array<SyncRecord<RowType>>) : Promise<SyncAtReply<RowType>>;
     replaceAll(data : Array<SyncRecord<RowType>>) : Promise<void>;
 
     insertIfRecent(uniqueId : string, lastModified : number, row : Omit<RowType, "uniqueId">) : Promise<boolean>;

--- a/lib/engine/db/syncdb.ts
+++ b/lib/engine/db/syncdb.ts
@@ -322,7 +322,7 @@ export default class SyncDatabase<K extends keyof SyncTables> extends events.Eve
         if (this._debug)
             console.log(`syncdb sync request for ${this._table.name} from ${fromTier} at ${lastModified}`);
 
-        this._table.syncAt(lastModified, pushedChanges).then(([lastModified, ourChanges, done]) => {
+        this._table.syncAt(lastModified, pushedChanges).then(({ lastModified, ourChanges, done }) => {
             this._reportChanges(fromTier, pushedChanges, done);
             this._sendMessage(fromTier, {
                 op: 'sync-reply',


### PR DESCRIPTION
Use a struct based interface instead of a tuple interface because
it's more type-safe and also it works better from Go

Should help with #656 