### PR TITLE
Refactor logging to avoid files

### DIFF
--- a/lib/dialogue-agent/conversation.ts
+++ b/lib/dialogue-agent/conversation.ts
@@ -18,12 +18,9 @@
 //
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
-
-import path from "path";
-import fs from "fs";
 import * as events from 'events';
 import * as ThingTalk from 'thingtalk';
-import {v4 as uuidv4} from 'uuid';
+import * as Stream from "stream";
 
 import * as I18n from '../i18n';
 
@@ -33,9 +30,9 @@ import { PlatformData, MessageType, Message, RDL } from './protocol';
 import { EntityMap } from '../utils/entity-utils';
 import * as ThingTalkUtils from '../utils/thingtalk';
 import type Engine from '../engine';
-import * as StreamUtils from "../utils/stream-utils";
 import { DialogueSerializer, DialogueTurn } from "../dataset-tools/parsers";
 import AppExecutor from '../engine/apps/app_executor';
+import ConversationLogger from './logging';
 
 const DummyStatistics = {
     hit() {
@@ -78,105 +75,6 @@ export interface ConversationDelegate {
     addMessage(msg : Message) : Promise<void>;
 }
 
-export class DialogueTurnLog {
-    private readonly _turn : DialogueTurn;
-    private _done : boolean;
-    private _uuid : string;
-    private _uuidPrevious : string|null;
-    private _uuidDialogue : string|null;
-
-    constructor() {
-        this._turn = {
-            context: null,
-            agent: null,
-            agent_target: null,
-            intermediate_context: null,
-            user: '',
-            user_target: ''
-        };
-        this._done = false;
-        this._uuid = uuidv4();
-        this._uuidPrevious = null;
-        this._uuidDialogue = null;
-    }
-
-    get turn() {
-        return this._turn;
-    }
-
-    get done() {
-        return this._done;
-    }
-
-    get uuid() {
-        return this._uuid;
-    }
-
-    get uuidPrevious() {
-        return this._uuidPrevious;
-    }
-
-    set uuidPrevious(uuid : string|null) {
-        this._uuidPrevious = uuid;
-    }
-
-    get uuidDialogue() {
-        return this._uuidDialogue;
-    }
-
-    set uuidDialogue(uuid : string|null) {
-        this._uuidDialogue = uuid;
-    }
-
-    finish() {
-        this._done = true;
-    }
-
-    update(field : Exclude<keyof DialogueTurn,'agent_timestamp'|'user_timestamp'>, value : string) {
-        this._turn[field] = this._turn[field] ? this._turn[field] + '\n' + value : value;
-        if (field === 'user')
-            this._turn.user_timestamp = new Date;
-        else if (field === 'agent')
-            this._turn.agent_timestamp = new Date;
-    }
-}
-
-class DialogueLog {
-    private readonly _turns : DialogueTurnLog[];
-    private _done : boolean;
-    private _uuid : string;
-
-    constructor() {
-        this._turns = [];
-        this._done = false;
-        this._uuid = uuidv4();
-    }
-
-    get turns() {
-        return this._turns;
-    }
-
-    get done() {
-        return this._done;
-    }
-
-    get uuid() {
-        return this._uuid;
-    }
-
-    finish() {
-        this._done = true;
-        if (this.turns.length) {
-            const lastTurn = this.turns[this.turns.length - 1];
-            lastTurn.finish();
-        }
-    }
-
-    append(turn : DialogueTurnLog) {
-        this._turns.push(turn);
-    }
-}
-
 export interface ConversationState {
     history : Message[];
     dialogueState : Record<string, unknown>;
@@ -214,7 +112,7 @@ export default class Conversation extends events.EventEmitter {
     private _contextResetTimeout : NodeJS.Timeout|null;
     private _contextResetTimeoutSec : number;
 
-    private _log : DialogueLog[];
+    private _log : ConversationLogger;
 
     constructor(engine : Engine,
                 conversationId : string,
@@ -255,7 +153,7 @@ export default class Conversation extends events.EventEmitter {
         this._contextResetTimeout = null;
         this._contextResetTimeoutSec = options.contextResetTimeout || this._inactivityTimeoutSec;
 
-        this._log = [];
+        this._log = new ConversationLogger(engine.db.getLocalTable('conversation'), this._conversationId);
     }
 
     get isAnonymous() : boolean {
@@ -291,7 +189,7 @@ export default class Conversation extends events.EventEmitter {
     }
 
     async endRecording() {
-        await this.dialogueFinished();
+        await this._log.dialogueFinished();
         this._options.log = false;
     }
 
@@ -546,147 +444,39 @@ export default class Conversation extends events.EventEmitter {
         return this.addMessage({ type: MessageType.NEW_PROGRAM, ...program });
     }
 
-    private get _lastDialogue() {
-        if (this._log.length === 0)
-            return null;
-        return this._log[this._log.length - 1];
-    }
-
-    private get _lastTurn() {
-        const lastDialogue = this._lastDialogue;
-        if (!lastDialogue || lastDialogue.turns.length === 0)
-            return null;
-        return lastDialogue.turns[lastDialogue.turns.length - 1];
-    }
-
-    appendNewDialogue() {
-        this._log.push(new DialogueLog());
-    }
-
-    async insertOne(turn : DialogueTurnLog) {
-        if (this.inRecordingMode) {
-            const db = this.engine.db.getLocalTable('conversation');
-            const agentTimestamp = ('agent_timestamp' in turn.turn) ?
-                turn.turn.agent_timestamp!.toISOString() :
-                null;
-            const userTimestamp = ('user_timestamp' in turn.turn) ?
-                turn.turn.user_timestamp!.toISOString() :
-                null;
-            const vote = ('vote' in turn.turn) ?
-                turn.turn.vote! :
-                null;
-            const comment = ('comment' in turn.turn) ?
-                turn.turn.comment! :
-                null;
-            const row = {
-                conversationId : this.id,
-                previousId : turn.uuidPrevious,
-                dialogueId : turn.uuidDialogue!,
-                context : turn.turn.context,
-                agent : turn.turn.agent,
-                agentTimestamp : agentTimestamp,
-                agentTarget : turn.turn.agent_target,
-                intermediateContext : turn.turn.intermediate_context,
-                user : turn.turn.user,
-                userTimestamp : userTimestamp,
-                userTarget : turn.turn.user_target,
-                vote : vote,
-                comment : comment
-            };
-            await db.insertOne(turn.uuid, row);
-        }
-    }
-    
     async dialogueFinished() {
-        const last = this._lastDialogue;
-        if (last) {
-            last.finish();
-            const lastTurn = this._lastTurn;
-            if (lastTurn)
-                await this.insertOne(lastTurn);
-        }
+        if (!this.inRecordingMode)
+            return;
+        await this._log.dialogueFinished();
     }
 
     async turnFinished() {
-        const last = this._lastTurn;
-        if (last) {
-            last.finish();
-            await this.insertOne(last);
-        }
+        if (!this.inRecordingMode)
+            return;
+        await this._log.turnFinished();
     }
 
-    appendNewTurn(turn : DialogueTurnLog) {
-        const last = this._lastDialogue;
-        if (!last || last.done)
-            this.appendNewDialogue();
-        const dialogue = this._lastDialogue!;
-
-        if (this.inRecordingMode) {
-            turn.uuidDialogue = dialogue.uuid;
-            const lastTurn = this._lastTurn;
-            if (lastTurn)
-                turn.uuidPrevious = lastTurn.uuid;
-            else
-                turn.uuidPrevious = null;
-        }
-
-        dialogue.append(turn);
+    async voteLast(vote : 'up'|'down') {
+        if (!this.inRecordingMode)
+            return;
+        await this._log.voteLast(vote);
     }
 
-    voteLast(vote : 'up'|'down') {
-        const last = this._lastTurn;
-        if (!last)
-            throw new Error('No dialogue is logged');
-        last.turn.vote = vote;
-    }
-
-    commentLast(comment : string) {
-        const last = this._lastTurn;
-        if (!last)
-            throw new Error('No dialogue is logged');
-        last.turn.comment = comment;
+    async commentLast(comment : string) {
+        if (!this.inRecordingMode)
+            return;
+        await this._log.commentLast(comment);
     }
 
     updateLog(field : Exclude<keyof DialogueTurn,'agent_timestamp'|'user_timestamp'>, value : string) {
-        if (this.inRecordingMode) {
-            let last = this._lastTurn;
-            if (!last || last.done) {
-                last = new DialogueTurnLog();
-                this.appendNewTurn(last);
-            }
-            last.update(field, value);
-        }
+        if (!this.inRecordingMode)
+            return;
+        this._log.updateLog(field, value);
     }
 
-    async saveLog() {
-        const dir = path.join(this._engine.platform.getWritableDir(), 'logs');
-        try {
-            fs.mkdirSync(dir);
-        } catch(e) {
-            if (e.code !== 'EEXIST')
-                throw e;
-        }
-        const logfile = path.join(dir, this.id + '.txt');
+    readLog() {
+        const readable = Stream.Readable.from(this._log.read());
         const serializer = new DialogueSerializer({ annotations: true });
-
-        const output = fs.createWriteStream(logfile);
-
-        serializer.pipe(output);
-        for (const dialogue of this._log)
-            serializer.write({ id: this.id, turns: dialogue.turns.map((log) => log.turn) });
-        serializer.end();
-
-        await StreamUtils.waitFinish(output);
-    }
-
-    get log() : DialogueLog[] {
-        return this._log;
-    }
-
-    get logFileName() : string|null {
-        const log = path.join(this._engine.platform.getWritableDir(), 'logs', this.id + '.txt');
-        if (!fs.existsSync(log))
-            return null;
-        return log;
+        return readable.pipe(serializer);
     }
 }

--- a/lib/dialogue-agent/logging.ts
+++ b/lib/dialogue-agent/logging.ts
@@ -1,0 +1,205 @@
+// -*- mode: typescript; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Genie
+//
+// Copyright 2020 The Board of Trustees of the Leland Stanford Junior University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Silei Xu <silei@cs.stanford.edu>
+//         Kevin Tang
+//         Giovanni Campagna <gcampagn@cs.stanford.edu>
+
+import {v4 as uuidv4} from 'uuid';
+
+import { DialogueExample, DialogueTurn } from "../dataset-tools/parsers";
+import { ConversationRow, LocalTable } from "../engine/db";
+
+class DialogueTurnLog {
+    private readonly _conversationDB : LocalTable<ConversationRow>;
+    private readonly _turn : DialogueTurn;
+    private _conversationId : string;
+    private _dialogueId : string;
+    private _uniqueId : string;
+    private _previousId : string|null;
+
+    constructor(conversationDB : LocalTable<ConversationRow>,
+                conversationId : string,
+                dialogueId : string,
+                previousId : string|null) {
+        this._conversationDB = conversationDB;
+        this._turn = {
+            context: null,
+            agent: null,
+            agent_target: null,
+            intermediate_context: null,
+            user: '',
+            user_target: ''
+        };
+        this._conversationId = conversationId;
+        this._dialogueId = dialogueId;
+        this._uniqueId = uuidv4();
+        this._previousId = previousId;
+    }
+
+    get uniqueId() {
+        return this._uniqueId;
+    }
+
+    async save() {
+        const agentTimestamp = this._turn.agent_timestamp ?
+            this._turn.agent_timestamp!.toISOString() :
+            null;
+        const userTimestamp = this._turn.user_timestamp ?
+            this._turn.user_timestamp!.toISOString() :
+            null;
+        const vote = this._turn.vote ?? null;
+        const comment = this._turn.comment ?? null;
+        const row = {
+            conversationId: this._conversationId,
+            previousId: this._previousId,
+            dialogueId: this._dialogueId,
+            context: this._turn.context,
+            agent: this._turn.agent,
+            agentTimestamp: agentTimestamp,
+            agentTarget: this._turn.agent_target,
+            intermediateContext: this._turn.intermediate_context,
+            user: this._turn.user,
+            userTimestamp: userTimestamp,
+            userTarget: this._turn.user_target,
+            vote: vote,
+            comment: comment
+        };
+        await this._conversationDB.insertOne(this._uniqueId, row);
+    }
+
+    update(field : Exclude<keyof DialogueTurn,'agent_timestamp'|'user_timestamp'>, value : string) {
+        this._turn[field] = this._turn[field] ? this._turn[field] + '\n' + value : value;
+        if (field === 'user')
+            this._turn.user_timestamp = new Date;
+        else if (field === 'agent')
+            this._turn.agent_timestamp = new Date;
+    }
+}
+
+function* reorderTurns(rows : ConversationRow[]) : IterableIterator<DialogueTurn> {
+    interface TurnWithNext {
+        turn : DialogueTurn,
+        next : TurnWithNext|null
+    }
+    const turns = new Map<string, TurnWithNext>();
+
+    for (const row of rows) {
+        turns.set(row.uniqueId, {
+            turn: {
+                context: row.context,
+                agent: row.agent,
+                agent_target: row.agentTarget,
+                agent_timestamp: row.agentTimestamp ? new Date(row.agentTimestamp) : undefined,
+                intermediate_context: row.intermediateContext,
+                user: row.user,
+                user_target: row.userTarget,
+                user_timestamp: row.userTimestamp ? new Date(row.userTimestamp) : undefined,
+                vote: row.vote ?? undefined,
+                comment: row.comment ?? undefined
+            },
+            next: null
+        });
+    }
+
+    let first : TurnWithNext|null = null;
+    for (const row of rows) {
+        if (row.previousId === null)
+            first = turns.get(row.uniqueId)!;
+        else
+            turns.get(row.previousId)!.next = turns.get(row.uniqueId)!;
+    }
+
+    let turn = first;
+    while (turn !== null) {
+        yield turn.turn;
+        turn = turn.next;
+    }
+}
+
+function* reconstructDialogues(rows : ConversationRow[]) : IterableIterator<DialogueExample> {
+    const conversationId = rows[0].conversationId;
+    const dialogues = new Map<string, ConversationRow[]>();
+
+    for (const row of rows) {
+        const existing = dialogues.get(row.dialogueId);
+        if (existing)
+            existing.push(row);
+        else
+            dialogues.set(row.dialogueId, [row]);
+    }
+
+    for (const [dialogueId, rows] of dialogues) {
+        yield {
+            id : conversationId + '/' + dialogueId,
+            turns: Array.from(reorderTurns(rows)),
+        };
+    }
+}
+
+export default class ConversationLogger {
+    private readonly _conversationDB : LocalTable<ConversationRow>;
+    private _conversationId : string;
+    private _dialogueUniqueId : string;
+    private _currentTurn : DialogueTurnLog;
+    private _lastTurn : DialogueTurnLog;
+
+    constructor(conversationDB : LocalTable<ConversationRow>,
+                conversationId : string) {
+        this._conversationDB = conversationDB;
+        this._conversationId = conversationId;
+        this._dialogueUniqueId = uuidv4();
+        this._currentTurn = new DialogueTurnLog(this._conversationDB, this._conversationId, this._dialogueUniqueId, null);
+        this._lastTurn = this._currentTurn;
+    }
+
+    async dialogueFinished() {
+        await this._currentTurn.save();
+        this._dialogueUniqueId = uuidv4();
+        this._currentTurn = new DialogueTurnLog(this._conversationDB, this._conversationId, this._dialogueUniqueId, null);
+        // do not update lastTurn here, it should continue to point to the previous turn so we can update the votes
+        // for the agent speech right at the end of the dialogue
+    }
+
+    async turnFinished() {
+        await this._currentTurn.save();
+        const previousId = this._currentTurn.uniqueId;
+        this._currentTurn = new DialogueTurnLog(this._conversationDB, this._conversationId, this._dialogueUniqueId, previousId);
+        this._lastTurn = this._currentTurn;
+    }
+
+    async voteLast(vote : 'up'|'down') {
+        this._lastTurn.update('vote', vote);
+        await this._lastTurn.save();
+    }
+
+    async commentLast(comment : string) {
+        this._lastTurn.update('comment', comment);
+        await this._lastTurn.save();
+    }
+
+    updateLog(field : Exclude<keyof DialogueTurn,'agent_timestamp'|'user_timestamp'>, value : string) {
+        this._currentTurn.update(field, value);
+    }
+
+    async *read() : AsyncIterableIterator<DialogueExample> {
+        const rows = await this._conversationDB.getBy('conversationId', this._conversationId);
+
+        yield* reconstructDialogues(rows);
+    }
+}

--- a/lib/engine/db/dbproxy/local_table.ts
+++ b/lib/engine/db/dbproxy/local_table.ts
@@ -37,12 +37,17 @@ export default class LocalTable<RowType> {
     async getOne(uniqueId : string) : Promise<RowType|undefined> {
         try {
             const resp = await Tp.Helpers.Http.get(`${this._baseUrl}/localtable/user_${this.name}/${this._userId}/${encodeURIComponent(uniqueId)}`);
-            return JSON.parse(resp)['data']; 
+            return JSON.parse(resp)['data'];
         } catch(err) {
             if (err.code === 404)
                 return undefined;
             throw err;
         }
+    }
+
+    async getBy(field : keyof RowType, value : string) : Promise<RowType[]> {
+        const resp = await Tp.Helpers.Http.get(`${this._baseUrl}/localtable/user_${this.name}/by-${field}/${this._userId}/${encodeURIComponent(value)}`);
+        return JSON.parse(resp)['data'];
     }
 
     async insertOne(uniqueId : string, row : Omit<RowType, "uniqueId">) : Promise<void> {

--- a/lib/engine/db/index.ts
+++ b/lib/engine/db/index.ts
@@ -77,6 +77,7 @@ export interface LocalTable<RowType extends AbstractRow> {
 
     getAll() : Promise<RowType[]>;
     getOne(uniqueId : string) : Promise<RowType|undefined>;
+    getBy(field : keyof RowType, value : string) : Promise<RowType[]>;
     insertOne(uniqueId : string, row : Omit<RowType, "uniqueId">) : Promise<void>;
     deleteOne(uniqueId : string) : Promise<void>;
 }

--- a/lib/engine/db/sqlite/local_table.ts
+++ b/lib/engine/db/sqlite/local_table.ts
@@ -45,6 +45,12 @@ export default class LocalTable<RowType> {
         });
     }
 
+    getBy(field : keyof RowType, value : string) : Promise<RowType[]> {
+        return this._db.withClient((client) => {
+            return sql.selectOne(client, `select * from ${this.name} where ${field} = ?`, [value]);
+        });
+    }
+
     insertOne(uniqueId : string, row : Omit<RowType, "uniqueId">) : Promise<void> {
         return this._db.withTransaction(async (client) => {
             const insertSql = `insert or replace into ${this.name}(uniqueId, ${this._fields}) values(?,${this._fields.map(() => '?')})`;

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -849,12 +849,12 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_one;
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
 U: \t $stop;
 UT: $stop;
-====
-# test
 #! vote: down
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines
+====
+# test
 ====
 # test
 #! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ

--- a/test/agent/mock_engine.js
+++ b/test/agent/mock_engine.js
@@ -498,6 +498,10 @@ class MockLocalTable {
         });
     }
 
+    getBy(field, value) {
+        return this.getAll().then((rows) => rows.filter((row) => row[field] === value));
+    }
+
     getOne(uniqueId) {
         return new Promise((resolve) => {
             resolve(this._db[uniqueId]);


### PR DESCRIPTION
This is a follow up to #649 that cleans up the conversation logging code: now that we store everything in the main database, we don't need to write to local files, and we don't need to keep track of dialogues in memory.

Instead, we can store everything into the database and reconstruct the sequence of turns dynamically when needed.

Note that the reconstructed log is essentially identical to what we had before (see test changes).