### PR TITLE
Fix agent tests

### DIFF
--- a/test/agent/index.js
+++ b/test/agent/index.js
@@ -180,7 +180,7 @@ async function mockNLU(conversation) {
                     err.code = command.error.code;
                     throw err;
                 }
-                return { tokens, entities, candidates: command.candidates, intent: { ignore: 0, command: 1, other: 0 } };
+                return { tokens, entities, candidates: command.candidates, intent: command.intent || { ignore: 0, command: 1, other: 0 } };
             }
         }
 

--- a/test/agent/mock-nlu.yaml
+++ b/test/agent/mock-nlu.yaml
@@ -76,3 +76,14 @@
   error:
     code: 500
     message: 'Internal Server Error'
+
+-
+  utterance: 'What are the side effects of the vaccine?'
+  candidates:
+    - code: ['$dialogue', '@org.thingpedia.dialogue.transaction', '.', 'execute', ';',
+             '@org.thingpedia.covid-vaccine', '.', 'appointment', '(', ')', ';']
+      score: 1
+  intent:
+    command: 0.2
+    other: 0.8
+    ignore: 0


### PR DESCRIPTION
Add an entry in mock-nlu so we don't rely on the real model, which
may or may not have ood detection enabled.