### PR TITLE
templates: handle notifications for timers without functions correctly

### DIFF
--- a/lib/templates/ast_manip.ts
+++ b/lib/templates/ast_manip.ts
@@ -1783,7 +1783,14 @@ function findFilterExpression(root : Ast.Expression) : Ast.FilterExpression|null
 }
 
 class GetInvocationVisitor extends Ast.NodeVisitor {
-    invocation : Ast.Invocation|undefined = undefined;
+    invocation : Ast.Invocation|Ast.FunctionCallExpression|undefined = undefined;
+
+    visitFunctionCallExpression(inv : Ast.FunctionCallExpression) : boolean {
+        // keep overwriting so we store the last invocation in traversal order
+        // which is also the last invocation in program order
+        this.invocation = inv;
+        return false; // no need to recurse
+    }
 
     visitInvocation(inv : Ast.Invocation) : boolean {
         // keep overwriting so we store the last invocation in traversal order
@@ -1793,7 +1800,7 @@ class GetInvocationVisitor extends Ast.NodeVisitor {
     }
 }
 
-function getInvocation(historyItem : Ast.Node) : Ast.Invocation {
+function getInvocation(historyItem : Ast.Node) : Ast.Invocation|Ast.FunctionCallExpression {
     assert(historyItem instanceof Ast.Node);
 
     const visitor = new GetInvocationVisitor();

--- a/lib/templates/dialogue_acts/action-confirm.ts
+++ b/lib/templates/dialogue_acts/action-confirm.ts
@@ -67,7 +67,7 @@ function actionConfirmChangeParam(ctx : ContextInfo, answer : Ast.Value|C.InputP
 
     const clone = ctx.next.clone();
     const action = C.getInvocation(clone);
-    if (!action) return null;
+    if (!action || !(action instanceof Ast.Invocation)) return null;
 
     setOrAddInvocationParam(action, answer.ast.name, answer.ast.value);
     return addNewItem(ctx, 'execute', null, 'confirmed', clone);

--- a/lib/templates/dialogue_acts/action-results.ts
+++ b/lib/templates/dialogue_acts/action-results.ts
@@ -86,6 +86,7 @@ function makeCompleteActionSuccessPhrase(ctx : ContextInfo, action : Ast.Express
     const ctxInvocation = C.getInvocation(ctx.current!);
     if (!C.isSameFunction(ctxInvocation.schema!, last.invocation.schema!))
         return null;
+    assert(ctxInvocation instanceof Ast.Invocation);
     if (!checkSelector(ctxInvocation.selector, last.invocation.selector))
         return null;
 
@@ -264,7 +265,7 @@ function actionErrorChangeParam(ctx : ContextInfo, answer : Ast.Value|C.InputPar
 
     const clone = ctx.current!.clone();
     const action = C.getInvocation(clone);
-    if (!action)
+    if (!action || !(action instanceof Ast.Invocation))
         return null;
     setOrAddInvocationParam(action, ipslot.ast.name, ipslot.ast.value);
     return addNewItem(ctx, 'execute', null, 'accepted', clone);

--- a/lib/templates/dialogue_acts/coref-actions.ts
+++ b/lib/templates/dialogue_acts/coref-actions.ts
@@ -29,7 +29,7 @@ import { ContextInfo } from '../state_manip';
 function contextualAction(ctx : ContextInfo, action : Ast.Invocation) {
     assert(action instanceof Ast.Invocation);
     const ctxInvocation = C.getInvocation(ctx.next!);
-    if (!ctxInvocation || !(ctxInvocation.selector instanceof Ast.DeviceSelector))
+    if (!ctxInvocation || !(ctxInvocation instanceof Ast.Invocation))
         return null;
     if (!C.isSameFunction(ctxInvocation.schema!, action.schema!))
         return null;

--- a/lib/templates/dialogue_acts/list-proposal.ts
+++ b/lib/templates/dialogue_acts/list-proposal.ts
@@ -71,6 +71,11 @@ export function listProposalKeyFn({ results, info, action, hasLearnMore } : List
     };
 }
 
+function checkInvocationCast(x : Ast.Invocation|Ast.FunctionCallExpression) : Ast.Invocation {
+    assert(x instanceof Ast.Invocation);
+    return x;
+}
+
 function checkListProposal(nameList : NameList, info : SlotBag|null, hasLearnMore : boolean) : ListProposal|null {
     const { ctx, results } = nameList;
     const resultType = results[0].value.id.getType();
@@ -109,7 +114,7 @@ function checkListProposal(nameList : NameList, info : SlotBag|null, hasLearnMor
     }
 
 
-    const action = ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null;
+    const action = ctx.nextInfo && ctx.nextInfo.isAction ? checkInvocationCast(C.getInvocation(ctx.next!)) : null;
     return { results, info, action, hasLearnMore };
 }
 
@@ -140,7 +145,7 @@ export function checkThingpediaListProposal(proposal : ThingpediaListProposal, a
     if (!mergedInfo)
         return null;
 
-    const action = ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null;
+    const action = ctx.nextInfo && ctx.nextInfo.isAction ? checkInvocationCast(C.getInvocation(ctx.next!)) : null;
     return { results: ctx.results!, info: mergedInfo, action, hasLearnMore: false };
 }
 
@@ -162,7 +167,7 @@ export function addActionToListProposal(nameList : NameList, action : Ast.Invoca
     const resultType = results[0].value.id.getType();
     if (!C.hasArgumentOfType(action, resultType))
         return null;
-    const ctxAction = ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null;
+    const ctxAction = ctx.nextInfo && ctx.nextInfo.isAction ? checkInvocationCast(C.getInvocation(ctx.next!)) : null;
     if (ctxAction && !C.isSameFunction(ctxAction.schema!, action.schema!))
         return null;
 

--- a/lib/templates/dialogue_acts/recommendation.ts
+++ b/lib/templates/dialogue_acts/recommendation.ts
@@ -63,7 +63,12 @@ export function recommendationKeyFn(rec : Recommendation) {
     };
 }
 
-function makeActionRecommendation(ctx : ContextInfo, action : Ast.Invocation) {
+function checkInvocationCast(x : Ast.Invocation|Ast.FunctionCallExpression) : Ast.Invocation {
+    assert(x instanceof Ast.Invocation);
+    return x;
+}
+
+function makeActionRecommendation(ctx : ContextInfo, action : Ast.Invocation) : Recommendation|null {
     // we don't offer actions during recommendations
     if (ctx.state.dialogueAct === 'notification')
         return null;
@@ -110,7 +115,7 @@ function makeArgMinMaxRecommendation(ctx : ContextInfo, name : Ast.Value, base :
     return makeRecommendation(ctx, name);
 }
 
-function makeRecommendation(ctx : ContextInfo, name : Ast.Value) {
+function makeRecommendation(ctx : ContextInfo, name : Ast.Value) : Recommendation|null {
     const results = ctx.results;
     assert(results && results.length > 0);
     const currentStmt = ctx.current!.stmt;
@@ -130,13 +135,13 @@ function makeRecommendation(ctx : ContextInfo, name : Ast.Value) {
     return {
         ctx, topResult,
         info: null,
-        action: ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null,
+        action: ctx.nextInfo && ctx.nextInfo.isAction ? checkInvocationCast(C.getInvocation(ctx.next!)) : null,
         hasLearnMore: false,
         hasAnythingElse: false
     };
 }
 
-function makeThingpediaRecommendation(ctx : ContextInfo, info : SlotBag) {
+function makeThingpediaRecommendation(ctx : ContextInfo, info : SlotBag) : Recommendation|null {
     const results = ctx.results;
     assert(results && results.length > 0);
     const currentStmt = ctx.current!.stmt;
@@ -154,13 +159,13 @@ function makeThingpediaRecommendation(ctx : ContextInfo, info : SlotBag) {
     return {
         ctx, topResult,
         info,
-        action: ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null,
+        action: ctx.nextInfo && ctx.nextInfo.isAction ? checkInvocationCast(C.getInvocation(ctx.next!)) : null,
         hasLearnMore: false,
         hasAnythingElse: false
     };
 }
 
-function checkRecommendation(rec : Recommendation, info : SlotBag|null) {
+function checkRecommendation(rec : Recommendation, info : SlotBag|null) : Recommendation|null {
     if (info && !isInfoPhraseCompatibleWithResult(rec.topResult, info))
         return null;
 
@@ -222,7 +227,7 @@ export function recommendationSetLearnMore(rec : Recommendation) {
     };
 }
 
-function makeDisplayResult(ctx : ContextInfo, info : SlotBag) {
+function makeDisplayResult(ctx : ContextInfo, info : SlotBag)  : Recommendation|null {
     const results = ctx.results;
     assert(results && results.length > 0);
     const topResult = results[0];
@@ -236,7 +241,7 @@ function makeDisplayResult(ctx : ContextInfo, info : SlotBag) {
     return {
         ctx, topResult,
         info,
-        action: ctx.nextInfo && ctx.nextInfo.isAction ? C.getInvocation(ctx.next!) : null,
+        action: ctx.nextInfo && ctx.nextInfo.isAction ? checkInvocationCast(C.getInvocation(ctx.next!)) : null,
         hasLearnMore: false,
         hasAnythingElse: false
     };

--- a/lib/templates/dialogue_acts/search-questions.ts
+++ b/lib/templates/dialogue_acts/search-questions.ts
@@ -200,7 +200,9 @@ function preciseSearchQuestionAnswer(ctx : ContextInfo, [answerTable, answerActi
                     return null;
             }
 
-            answerAction = addParametersFromContext(answerAction, C.getInvocation(ctx.next!));
+            const contextInvocation = C.getInvocation(ctx.next!);
+            assert(contextInvocation instanceof Ast.Invocation);
+            answerAction = addParametersFromContext(answerAction, contextInvocation);
         }
     }
 

--- a/lib/templates/dialogue_acts/slot-fill.ts
+++ b/lib/templates/dialogue_acts/slot-fill.ts
@@ -82,6 +82,7 @@ function makeSlotFillQuestion(ctx : ContextInfo, questions : C.ParamSlot[]) {
     assert(questions.length > 0);
     if (questions.length === 1) {
         const action = C.getInvocation(ctx.next!);
+        assert(action instanceof Ast.Invocation);
         const arg = action.schema!.getArgument(questions[0].name)!;
         const type = arg.type;
 
@@ -139,6 +140,7 @@ function preciseSlotFillAnswer(ctx : ContextInfo, answer : Ast.Invocation) {
 
     const clone = fastSemiShallowClone(ctx.next);
     const newInvocation = C.getInvocation(clone);
+    assert(newInvocation instanceof Ast.Invocation);
     assert(C.isSameFunction(newInvocation.schema!, answer.schema!));
     // modify in place
     mergeParameters(newInvocation, answer);
@@ -178,6 +180,7 @@ function impreciseSlotFillAnswer(ctx : ContextInfo, answer : Ast.Value|C.InputPa
 
     const clone = fastSemiShallowClone(ctx.next);
     const newAction = C.getInvocation(clone);
+    assert(newAction instanceof Ast.Invocation);
     if (!C.checkInvocationInputParam(ctx.loader, newAction, ipslot))
         return null;
 

--- a/lib/templates/state_manip.ts
+++ b/lib/templates/state_manip.ts
@@ -401,9 +401,8 @@ export function getContextInfo(loader : ThingpediaLoader,
     for (let idx = 0; idx < state.history.length; idx ++) {
         const item = state.history[idx];
         const itemschema = item.stmt.expression.schema!;
-        const device = itemschema.class!.name;
-        assert(typeof device === 'string');
-        if (currentDevice && device !== currentDevice)
+        const device = itemschema.class ? itemschema.class.name : null;
+        if (currentDevice && device && device !== currentDevice)
             previousDomainItemIdx = currentItemIdx;
         if (item.confirm === 'proposed') {
             proposedSkip ++;
@@ -712,6 +711,7 @@ function addActionParam(ctx : ContextInfo,
 
             newHistoryItem = next.clone();
             const newInvocation = C.getInvocation(newHistoryItem);
+            assert(newInvocation instanceof Ast.Invocation);
             setOrAddInvocationParam(newInvocation, pname, value);
             // also add the new parameters from this action, if any
             for (const param of action.in_params) {
@@ -1115,7 +1115,7 @@ function tryReplacePlaceholderPhrase(phrase : ParsedPlaceholderPhrase,
 
 function getDeviceName(describer : ThingTalkUtils.Describer,
                        resultItem : Ast.DialogueHistoryResultItem|undefined,
-                       invocation : Ast.Invocation) {
+                       invocation : Ast.Invocation|Ast.FunctionCallExpression) {
     if (resultItem) {
         // check in the result first
         // until ThingTalk is fixed, this will be present only if there was no
@@ -1128,6 +1128,8 @@ function getDeviceName(describer : ThingTalkUtils.Describer,
                 return { value: entity, text: description };
         }
     }
+    if (!(invocation instanceof Ast.Invocation))
+        return undefined;
 
     let name;
     for (const in_param of invocation.selector.attributes) {

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -2417,3 +2417,31 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_recommend_two;
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $dialogue @org.thingpedia.dialogue.transaction.notification;
+U: timer(base=$now, interval=1min)
+U: #[results=[
+U:   { __timestamp=1626399487 }
+U: ]];
+UT: $dialogue @org.thingpedia.dialogue.transaction.notification;
+UT: timer(base=$now, interval=1min)
+UT: #[results=[
+UT:   { __timestamp=1626399487 }
+UT: ]];
+C: $dialogue @org.thingpedia.dialogue.transaction.notification;
+C: timer(base=$now, interval=1min)
+C: #[results=[
+C:   { __timestamp=1626399487 }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: Your request was completed successfully.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
+#! vote: up
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -1151,3 +1151,16 @@ U: \t [dribble_attempts] of @com.goal_smart.player(league_id="39"^^com.goal_smar
 A: Both Adrien Silva and M. Shabani are player stats with the dribble equal to 0.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_recommend_two ; [ dribble_attempts ] of @com.goal_smart ( id = GENERIC_ENTITY_tt:device_id_0 ) . player ( league_id = GENERIC_ENTITY_com.goal_smart:soccer_league_0 ) #[ results = [ { league_id = GENERIC_ENTITY_com.goal_smart:soccer_league_0 , id = GENERIC_ENTITY_com.goal_smart:soccer_player_0 , dribble_attempts = 0 } ] ] #[ count = 3 ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"com.goal_smart-9","display":"Some Device 9"},"GENERIC_ENTITY_com.goal_smart:soccer_league_0":{"value":"39","display":"premier league"},"GENERIC_ENTITY_com.goal_smart:soccer_player_0":{"value":"114","display":"Adrien Silva"}}
 A: >> expecting = null
+
+====
+# 76-issue-695
+
+U: \t $dialogue @org.thingpedia.dialogue.transaction.notification;
+U: timer(base=$now, interval=1min)
+U: #[results=[{ __timestamp=1626399487 }]];
+
+# this reply is not great but this is an error case because this command
+# should never be generated in the first place.
+A: Your request was completed successfully.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_success ; timer ( base = $now , interval = DURATION_0 ) #[ results = [ { __timestamp = NUMBER_0 } ] ] ; // {"DURATION_0":{"unit":"min","value":1},"NUMBER_0":1626399487}
+A: >> expecting = null


### PR DESCRIPTION
If the user issues a command that gets parsed into a timer without
another Thingpedia function, the schema of the command will just
be the timer. This command does not have a class, and it is not
an Ast.Invocation.

Handle that case gracefully everywhere, even if it is an erroneous
program.

Fixes #695