### PR TITLE
Add More Utterances for Timers/Reminders

### DIFF
--- a/data/builtins/thingengine.builtin/dataset.tt.in
+++ b/data/builtins/thingengine.builtin/dataset.tt.in
@@ -141,14 +141,19 @@ dataset @org.thingpedia.builtin.thingengine.builtin language "en" {
 
     program(p_date : Date, p_message : String) = ontimer(date=[p_date]) => @org.thingpedia.builtin.thingengine.builtin.say(message=p_message)
     #_[utterances=["remind me to ${p_message} on ${p_date}",
-                    "tell me to ${p_message} on ${p_date}"]];
+                    "tell me to ${p_message} at ${p_date}",
+                    "alarm at ${p_date} named ${p_message}"]];
 
     program(p_date : Date) = ontimer(date=[p_date]) => @org.thingpedia.builtin.thingengine.builtin.alert()
-    #_[utterances=["set an alarm for ${p_date}"]];
+    #_[utterances=["set an alarm for ${p_date}",
+                    "set a timer for ${p_date}"]];
 
     program(p_duration : Measure(ms)) = ontimer(date=[$now + p_duration]) => @org.thingpedia.builtin.thingengine.builtin.timer_expire()
-    #_[utterances=["set a timer for ${p_duration}"]];
+    #_[utterances=["set a timer for ${p_duration}",
+                    "alarm in ${p_duration}"]];
 
     program(p_duration : Measure(ms), p_message : String) = ontimer(date=[$now + p_duration]) => @org.thingpedia.builtin.thingengine.builtin.say(message=p_message)
-    #_[utterances=["remind me to ${p_message} in ${p_duration}"]];
+    #_[utterances=["remind me to ${p_message} in ${p_duration}",
+                    "tell me to ${p_message} in ${p_duration}",
+                    "alarm to ${p_message} in ${p_duration}"]];
 }

--- a/data/builtins/thingengine.builtin/dataset.tt.in
+++ b/data/builtins/thingengine.builtin/dataset.tt.in
@@ -142,7 +142,8 @@ dataset @org.thingpedia.builtin.thingengine.builtin language "en" {
     program(p_date : Date, p_message : String) = ontimer(date=[p_date]) => @org.thingpedia.builtin.thingengine.builtin.say(message=p_message)
     #_[utterances=["remind me to ${p_message} on ${p_date}",
                     "tell me to ${p_message} at ${p_date}",
-                    "alarm at ${p_date} named ${p_message}"]];
+                    "alarm at ${p_date} named ${p_message}",
+                    "set an alarm at ${p_date} named ${p_message}"]];
 
     program(p_date : Date) = ontimer(date=[p_date]) => @org.thingpedia.builtin.thingengine.builtin.alert()
     #_[utterances=["set an alarm for ${p_date}",
@@ -150,10 +151,13 @@ dataset @org.thingpedia.builtin.thingengine.builtin language "en" {
 
     program(p_duration : Measure(ms)) = ontimer(date=[$now + p_duration]) => @org.thingpedia.builtin.thingengine.builtin.timer_expire()
     #_[utterances=["set a timer for ${p_duration}",
-                    "alarm in ${p_duration}"]];
+                    "alarm in ${p_duration}",
+                    "set an alarm in ${p_duration}"]];
 
     program(p_duration : Measure(ms), p_message : String) = ontimer(date=[$now + p_duration]) => @org.thingpedia.builtin.thingengine.builtin.say(message=p_message)
     #_[utterances=["remind me to ${p_message} in ${p_duration}",
                     "tell me to ${p_message} in ${p_duration}",
-                    "alarm to ${p_message} in ${p_duration}"]];
+                    "alarm to ${p_message} in ${p_duration}",
+                    "set an alarm to ${p_message} in ${p_duration}",
+                    "set a timer for ${p_duration} named ${p_message}"]];
 }

--- a/data/builtins/thingengine.builtin/manifest.tt.in
+++ b/data/builtins/thingengine.builtin/manifest.tt.in
@@ -195,8 +195,10 @@ class @org.thingpedia.builtin.thingengine.builtin
   #[doc="makes Genie say something"]
   #[confirm=false];
 
-  action alert()
-  #_[result="Alert"]
+  action alert(out time: Time
+                 #_[canonical=["time"]]
+                 #[filterable=false])
+  #_[result="It is ${time}"]
   #_[formatted=[
     { type="sound", name="alarm-clock-elapsed", exclusive=true }
   ]]

--- a/data/builtins/thingengine.builtin/manifest.tt.in
+++ b/data/builtins/thingengine.builtin/manifest.tt.in
@@ -196,11 +196,10 @@ class @org.thingpedia.builtin.thingengine.builtin
   #[confirm=false];
 
   action alert(out time: Time
-                 #_[canonical=["time"]]
-                 #[filterable=false])
+                 #_[canonical=["time"]])
   #_[result="It is ${time}"]
   #_[formatted=[
-    { type="sound", name="alarm-clock-elapsed", exclusive=true }
+    { type="sound", name="alarm-clock-elapsed", exclusive=false }
   ]]
   #_[canonical="alert"]
   #[doc="makes Genie show/play a generic alert"]

--- a/lib/engine/devices/builtins/thingengine.builtin.ts
+++ b/lib/engine/devices/builtins/thingengine.builtin.ts
@@ -226,7 +226,10 @@ export default class MiscellaneousDevice extends Tp.BaseDevice {
         return cap.launchURL(String(url));
     }
 
-    do_alert() {}
+    do_alert() {
+        const now = new Date;
+        return { time: new Tp.Value.Time(now.getHours(), now.getMinutes()) };
+    }
 
     do_timer_expire(env : ExecWrapper) {
         const now = new Date;


### PR DESCRIPTION
Added some more phrases for timers/reminders for better coverage of potential cases.
Added the time result to alert() since it would be useful to know the time when an alarm goes off (since you cannot necessarily see the time given a virtual assistant).