### PR TITLE
In dialogue mode, adjust programs produced by the exact match

### DIFF
--- a/lib/prediction/exactbuilder.ts
+++ b/lib/prediction/exactbuilder.ts
@@ -102,6 +102,7 @@ export default class ExactMatchBuilder {
             flags: {
                 bookkeeping: true,
                 unbalanced: true,
+                dialogues: true,
             },
             rng: this._rng,
             locale: this._locale,

--- a/lib/templates/basic.genie
+++ b/lib/templates/basic.genie
@@ -22,6 +22,7 @@ import { Ast, } from 'thingtalk';
 
 // import the combinator library
 import * as C from './ast_manip';
+import * as D from './dialogue_acts';
 import ThingpediaLoader from './load-thingpedia';
 
 {
@@ -66,11 +67,24 @@ bookkeeping : Ast.ControlCommand = {
 $root : Ast.Input = {
     bookkeeping;
 
-    ( 'get' query:thingpedia_complete_query
-    | query:thingpedia_complete_get_command
-    ) => C.makeProgram($loader, query);
+    ?dialogues {
+        ( 'get' query:thingpedia_complete_query
+        | 'show me' query:thingpedia_complete_query
+        | query:thingpedia_complete_get_command
+        ) => C.makeProgram($loader, query);
 
-    action:thingpedia_complete_action => C.makeProgram($loader, action);
+        action:thingpedia_complete_action => C.makeProgram($loader, action);
 
-    'notify me' stream:thingpedia_complete_stream => C.makeProgram($loader, stream);
+        'notify me' stream:thingpedia_complete_stream => C.makeProgram($loader, stream);
+    }
+    !dialogues {
+        ( 'get' query:thingpedia_complete_query
+        | 'show me' query:thingpedia_complete_query
+        | query:thingpedia_complete_get_command
+        ) => D.initialRequest($loader, query);
+
+        action:thingpedia_complete_action => D.initialRequest($loader, action);
+
+        'notify me' stream:thingpedia_complete_stream => D.initialRequest($loader, stream);
+    }
 }

--- a/lib/templates/dialogue_acts/initial-request.ts
+++ b/lib/templates/dialogue_acts/initial-request.ts
@@ -168,7 +168,7 @@ function adjustStatementsForInitialRequest(loader : ThingpediaLoader,
     return newStatements.map(C.adjustDefaultParameters);
 }
 
-function initialRequest(loader : ThingpediaLoader, stmt : Ast.Expression) {
+export function initialRequest(loader : ThingpediaLoader, stmt : Ast.Expression) {
     const newStatements = adjustStatementsForInitialRequest(loader, C.toChainExpression(stmt));
     if (newStatements === null)
         return null;
@@ -181,7 +181,7 @@ function getStatementDevice(stmt : Ast.ChainExpression) {
     return stmt.last.schema!.class!.name;
 }
 
-function startNewRequest(loader : ThingpediaLoader, ctx : ContextInfo, expr : Ast.Expression) {
+export function startNewRequest(loader : ThingpediaLoader, ctx : ContextInfo, expr : Ast.Expression) {
     const stmt = C.toChainExpression(expr);
 
     if (loader.flags.strict_multidomain && ctx.current && getStatementDevice(ctx.current.stmt.expression) === getStatementDevice(stmt))
@@ -195,7 +195,7 @@ function startNewRequest(loader : ThingpediaLoader, ctx : ContextInfo, expr : As
     return addNewItem(ctx, 'execute', null, 'accepted', ...newItems);
 }
 
-function addInitialDontCare(expr : Ast.Expression, dontcare : C.FilterSlot) : Ast.Expression|null {
+export function addInitialDontCare(expr : Ast.Expression, dontcare : C.FilterSlot) : Ast.Expression|null {
     const chain = C.toChainExpression(expr);
     const table = chain.lastQuery;
     if (!table)
@@ -224,9 +224,3 @@ function addInitialDontCare(expr : Ast.Expression, dontcare : C.FilterSlot) : As
     filterExpression.filter = new Ast.BooleanExpression.And(null, [filterExpression.filter, dontcare.ast]).optimize();
     return clone;
 }
-
-export {
-    initialRequest,
-    startNewRequest,
-    addInitialDontCare
-};


### PR DESCRIPTION
Make sure that the output of the exact matcher is a dialogue
state, not a program, and that the statements are adjusted to
include all the implicit queries.

This avoids producing programs that are not valid and would
confuse the parser with unexpected slot fills.

---

Fixes #728 

The issue occurs because the exact matcher maps "play music" to `@org.thingpedia.media-player.play();`

In training, "play music" maps to `@org.thingpedia.media-source.playable() => @org.thingpedia.media-player.play(playable=id);` and we never see a slot fill for `@org.thingpedia.media-player.play();`, so the parser gets confused.

The real parser reacts to "play music" correctly, so let's avoid having the exact matcher confuse us.