### PR TITLE
Update install.md to include relevant python dependency and installing genie-toolkit globally

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -12,6 +12,7 @@ The following OS packages are required to build and run Genie:
 - zip
 - GraphicsMagick (only for `genie assistant` command)
 - unzip (only for `genie assistant` command)
+- python
 
 The following commands can be used to install all the dependencies on common Linux distributions:
 
@@ -44,14 +45,7 @@ You can also install Genie using:
 npm install genie-toolkit
 ```
 
-This method will install Genie as a library, not as a command-line tool. It is
-suitable for integrating Genie in a larger project (such as Almond). 
-
-However you can acquire the ability to run the command line program ``genie`` if you run the following command to install the package globally:
-
-```
-npm install genie-toolkit -g
-```
+This method will install Genie as a library, not as a command-line tool. It is suitable for integrating Genie in a larger project (such as Almond). 
 
 ## Training
 


### PR DESCRIPTION
Hi, when running ``npm install genie-toolkit``one gets the following error  (tested on Ubuntu/Debian)

<img width="1326" alt="Screenshot 2021-08-26 at 12 39 39 pm" src="https://user-images.githubusercontent.com/75043245/130948765-6c7004b6-d6a9-47b1-9967-6de849c3a116.png">


To fix this I have added the installation candidate python in the apt command.  