### PR TITLE
Add conversation protocol to synchronize devices

### DIFF
--- a/data/builtins/thingengine.builtin/manifest.tt.in
+++ b/data/builtins/thingengine.builtin/manifest.tt.in
@@ -199,7 +199,7 @@ class @org.thingpedia.builtin.thingengine.builtin
                  #_[canonical=["time"]])
   #_[result="It is ${time}"]
   #_[formatted=[
-    { type="sound", name="alarm-clock-elapsed", exclusive=false }
+    { type="sound", name="alarm-clock-elapsed", exclusive=false, before=true }
   ]]
   #_[canonical="alert"]
   #[doc="makes Genie show/play a generic alert"]
@@ -209,7 +209,7 @@ class @org.thingpedia.builtin.thingengine.builtin
                       #_[canonical="duration"])
   #_[result="It has been ${duration}"]
   #_[formatted=[
-    { type="sound", name="alarm-clock-elapsed", exclusive=true }
+    { type="sound", name="alarm-clock-elapsed", exclusive=false, before=true }
   ]]
   #_[canonical="timer expire"]
   #[doc="makes Genie play a generic alert and show/say the elapsed time"]

--- a/lib/dialogue-agent/assistant_dispatcher.ts
+++ b/lib/dialogue-agent/assistant_dispatcher.ts
@@ -69,11 +69,14 @@ class StatelessConversationDelegate implements ConversationDelegate {
         };
     }
 
-    setHypothesis() {
+    async setHypothesis() {
+        // ignore
+    }
+    async addDevice() {
         // ignore
     }
 
-    setExpected(what : string|null) {
+    async setExpected(what : string|null) {
         assert(this._askSpecial === null);
         this._askSpecial = what;
     }

--- a/lib/dialogue-agent/card-output/card-formatter.ts
+++ b/lib/dialogue-agent/card-output/card-formatter.ts
@@ -86,8 +86,14 @@ export default class CardFormatter {
 
         // workaround a bug in ThingTalk with getFormatMetadata
 
-        const fndef = await this._schemas.getMeta(kind, ftype, fname_);
-        return fndef.metadata.formatted || [];
+        try {
+            const fndef = await this._schemas.getMeta(kind, ftype, fname_);
+            return fndef.metadata.formatted || [];
+        } catch(e) {
+            // workaround the fact that output type is wrong if the function is defined
+            // in the parent
+            return [];
+        }
     }
 
     async formatForType(outputType : string, outputValue : PlainObject) : Promise<Tp.FormatObjects.FormattedObject[]> {

--- a/lib/dialogue-agent/card-output/format_objects.ts
+++ b/lib/dialogue-agent/card-output/format_objects.ts
@@ -187,6 +187,7 @@ class SoundEffect extends BaseFormattedObject implements Tp.FormatObjects.SoundE
     type : 'sound';
     name : string;
     exclusive : boolean;
+    before : boolean;
 
     /**
      * Construct a new sound effect object.
@@ -195,7 +196,7 @@ class SoundEffect extends BaseFormattedObject implements Tp.FormatObjects.SoundE
      * @param {string} spec.name - the name of the sound, from the {@link http://0pointer.de/public/sound-theme-spec.html|Freedesktop Sound Theme Spec}
      *                             (with a couple Genie-specific extensions)
      */
-    constructor(spec : Tp.FormatObjects.SoundEffect) {
+    constructor(spec : Tp.FormatObjects.SoundEffect & { before ?: boolean }) {
         super();
 
         /**
@@ -205,6 +206,7 @@ class SoundEffect extends BaseFormattedObject implements Tp.FormatObjects.SoundE
         this.type = 'sound';
         this.name = spec.name;
         this.exclusive = spec.exclusive || false;
+        this.before = spec.before || false;
     }
 
     isValid() : boolean {

--- a/lib/dialogue-agent/conversation.ts
+++ b/lib/dialogue-agent/conversation.ts
@@ -348,7 +348,7 @@ export default class Conversation extends events.EventEmitter {
     async saveState(lastMessageId : number) {
         const conversationState = this.getState();
         const row = {
-            history: JSON.stringify(conversationState.history),
+            history: JSON.stringify(/* FIXME conversationState.history */ []),
             dialogueState: JSON.stringify(conversationState.dialogueState),
             lastMessageId: lastMessageId,
         };

--- a/lib/dialogue-agent/handlers/thingtalk.ts
+++ b/lib/dialogue-agent/handlers/thingtalk.ts
@@ -479,11 +479,18 @@ export default class ThingTalkDialogueHandler implements DialogueHandler<ThingTa
 
         this.icon = getProgramIcon(this._dialogueState!);
 
+        const before : Array<string|Tp.FormatObjects.FormattedObject> = [];
         const messages : Array<string|Tp.FormatObjects.FormattedObject> = [utterance];
 
         for (const [outputType, outputValue] of newResults.slice(0, policyResult.numResults)) {
             const formatted = await this._cardFormatter.formatForType(outputType, outputValue);
-            messages.push(...formatted);
+
+            for (const msg of formatted) {
+                if (msg.type === 'sound' && (msg as any).before)
+                    before.push(msg);
+                else
+                    messages.push(msg);
+            }
         }
 
         let expecting : ValueCategory|null;
@@ -508,7 +515,7 @@ export default class ThingTalkDialogueHandler implements DialogueHandler<ThingTa
             expecting = ValueCategory.Generic;
 
         return {
-            messages,
+            messages: before.concat(messages),
             context: oldState ? oldState!.prettyprint() : '',
             agent_target: agentTarget,
             expecting,

--- a/lib/dialogue-agent/handlers/thingtalk.ts
+++ b/lib/dialogue-agent/handlers/thingtalk.ts
@@ -538,11 +538,16 @@ export default class ThingTalkDialogueHandler implements DialogueHandler<ThingTa
                 assert(parsed instanceof Ast.DialogueState);
                 this._dialogueState = parsed;
 
-                // execute the current dialogue state
-                // this will attempt to run all the programs that failed in the
-                // previous conversation (most likely because they were executed
-                // in the anonymous context)
-                return this._executeCurrentState();
+                if (!this._dialogueState.dialogueAct.startsWith('sys_')) {
+                    // execute the current dialogue state
+                    // this will attempt to run all the programs that failed in the
+                    // previous conversation (most likely because they were executed
+                    // in the anonymous context)
+                    return this._executeCurrentState();
+                } else {
+                    this.icon = getProgramIcon(this._dialogueState);
+                    return null;
+                }
             }
         } else if (showWelcome) {
             // if we want to show the welcome message, we run the policy on the `null` state, which will return the sys_greet intent

--- a/lib/dialogue-agent/protocol.ts
+++ b/lib/dialogue-agent/protocol.ts
@@ -18,8 +18,6 @@
 //
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
-import type * as Tp from 'thingpedia';
-
 import { ConversationState } from './conversation';
 
 /**
@@ -173,13 +171,6 @@ export interface NewProgramMessage {
     icon : string|null;
 }
 
-export interface NewDeviceMessage {
-    id ?: number;
-    type : MessageType.NEW_DEVICE;
-    uniqueId : string;
-    state : Tp.BaseDevice.DeviceState;
-}
-
 export interface PingMessage {
     id ?: number;
     type : MessageType.PING;
@@ -194,5 +185,4 @@ export type Message = TextMessage
     | LinkMessage
     | ButtonMessage
     | NewProgramMessage
-    | NewDeviceMessage
     | PingMessage;

--- a/lib/dialogue-agent/protocol.ts
+++ b/lib/dialogue-agent/protocol.ts
@@ -18,6 +18,8 @@
 //
 // Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
 
+import type * as Tp from 'thingpedia';
+
 import { ConversationState } from './conversation';
 
 /**
@@ -73,11 +75,16 @@ export enum MessageType {
     LINK = 'link',
     BUTTON = 'button',
     RDL = 'rdl',
-    NEW_PROGRAM = 'new-program',
     SOUND_EFFECT = 'sound',
     AUDIO = 'audio',
     VIDEO = 'video',
-    PING = 'ping'
+
+    // status changes from the engine
+    NEW_PROGRAM = 'new-program',
+    NEW_DEVICE = 'new-device',
+
+    // control messages
+    PING = 'ping',
 }
 
 export interface TextMessage {
@@ -166,6 +173,13 @@ export interface NewProgramMessage {
     icon : string|null;
 }
 
+export interface NewDeviceMessage {
+    id ?: number;
+    type : MessageType.NEW_DEVICE;
+    uniqueId : string;
+    state : Tp.BaseDevice.DeviceState;
+}
+
 export interface PingMessage {
     id ?: number;
     type : MessageType.PING;
@@ -180,4 +194,5 @@ export type Message = TextMessage
     | LinkMessage
     | ButtonMessage
     | NewProgramMessage
+    | NewDeviceMessage
     | PingMessage;

--- a/lib/engine/devices/builtins/thingengine.builtin.ts
+++ b/lib/engine/devices/builtins/thingengine.builtin.ts
@@ -231,7 +231,7 @@ export default class MiscellaneousDevice extends Tp.BaseDevice {
         return { time: new Tp.Value.Time(now.getHours(), now.getMinutes()) };
     }
 
-    do_timer_expire(env : ExecWrapper) {
+    do_timer_expire(params : unknown, env : ExecWrapper) {
         const now = new Date;
         const duration = now.getTime() - env.app.metadata.startTime;
 

--- a/lib/engine/devices/database.ts
+++ b/lib/engine/devices/database.ts
@@ -297,6 +297,7 @@ export default class DeviceDatabase extends ObjectSet.Base<Tp.BaseDevice> {
     }
 
     private async _saveDevice(device : Tp.BaseDevice) {
+        this.emit('device-changed', device);
         if (device.isTransient)
             return;
         const state = device.serialize();

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -185,7 +185,7 @@ export default class AssistantEngine extends Tp.BaseEngine {
     private _devices : DeviceDatabase;
     private _appdb : AppDatabase;
     private _assistant : AssistantDispatcher;
-    private _audio : AudioController|null;
+    private _audio : AudioController;
     private _activityMonitor : ActivityMonitor|null;
 
     private _running : boolean;
@@ -224,10 +224,7 @@ export default class AssistantEngine extends Tp.BaseEngine {
 
         this._assistant = new AssistantDispatcher(this, options.nluModelUrl, options.notifications||{});
 
-        if (platform.hasCapability('sound'))
-            this._audio = new AudioController(this._devices);
-        else
-            this._audio = null;
+        this._audio = new AudioController(this._devices);
 
         this._activityMonitor = options.activityMonitorOptions ?
                 new ActivityMonitor(this._appdb, this._assistant, options.activityMonitorOptions) : null;

--- a/lib/speech/speech_handler.ts
+++ b/lib/speech/speech_handler.ts
@@ -122,9 +122,12 @@ export default class SpeechHandler extends events.EventEmitter {
     }
 
     // called from conversation
-    setHypothesis() : void {
+    async setHypothesis() {
         // ignore, this is called from the conversation when it broadcasts the hypothesis
         // to all listeners
+    }
+    async addDevice() {
+        // ignore
     }
 
     private _waitFinishSpeaking() {

--- a/lib/templates/dialogue_acts/action-results.ts
+++ b/lib/templates/dialogue_acts/action-results.ts
@@ -49,7 +49,7 @@ function makeThingpediaActionSuccessPhrase(ctx : ContextInfo, info : SlotBag) {
     // we don't need to check anything here, we know the context matches
     // because the generation enforces that, and we know that the result phrase
     // is correct by construction
-    return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_action_success', null), info);
+    return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_action_success', null), info, null, { numResults: 1 });
 }
 
 function checkSelector(ctxSelector : Ast.DeviceSelector, actionSelector : Ast.DeviceSelector) : boolean {
@@ -164,11 +164,11 @@ function makeCompleteActionSuccessPhrase(ctx : ContextInfo, action : Ast.Express
             return null;
     }
 
-    return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_action_success', null), info);
+    return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_action_success', null), info, null, { numResults: 1 });
 }
 
 function makeGenericActionSuccessPhrase(ctx : ContextInfo) {
-    return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_action_success', null), null);
+    return makeAgentReply(ctx, makeSimpleState(ctx, 'sys_action_success', null), null, null, { numResults: 0 });
 }
 
 export interface ErrorMessage {

--- a/lib/templates/dialogue_acts/reminders.ts
+++ b/lib/templates/dialogue_acts/reminders.ts
@@ -21,8 +21,13 @@ import {
     ContextInfo,
 } from '../state_manip';
 
-export function checkIsReminder(ctx : ContextInfo) {
-    return ctx.currentFunction!.qualifiedName === 'org.thingpedia.builtin.thingengine.builtin.say'
-    && ctx.current!.stmt.stream instanceof Ast.FunctionCallExpression && (ctx.current!.stmt.stream.name === 'ontimer' 
-    || ctx.current!.stmt.stream.name === 'attimer' || ctx.current!.stmt.stream.name === 'timer');
+export function checkIsReminder(ctx : ContextInfo, fname : string) : ContextInfo|null {
+    if (ctx.currentFunction!.qualifiedName !== ('org.thingpedia.builtin.thingengine.builtin.' + fname))
+        return null;
+
+    if (!(ctx.current!.stmt.stream instanceof Ast.FunctionCallExpression && (ctx.current!.stmt.stream.name === 'ontimer'
+        || ctx.current!.stmt.stream.name === 'attimer' || ctx.current!.stmt.stream.name === 'timer')))
+        return null;
+
+    return ctx;
 }

--- a/lib/templates/dlg/streams.genie
+++ b/lib/templates/dlg/streams.genie
@@ -28,8 +28,10 @@ import * as D from '../dialogue_acts';
 import ThingpediaLoader from '../load-thingpedia';
 
 notification_preamble : S.ContextInfo = {
-    ["reminder:", priority=1] : (ctx : ctx_with_notification) => D.checkIsReminder(ctx) ? ctx : null,
-    
+    ["reminder:", priority=1] : (ctx : ctx_with_notification) => D.checkIsReminder(ctx, 'say'),
+    ["alert:", priority=1] : (ctx : ctx_with_notification) => D.checkIsReminder(ctx, 'alert'),
+    ["alert:", priority=1] : (ctx : ctx_with_notification) => D.checkIsReminder(ctx, 'timer_expire'),
+
     ["notification from ${app}:"] : (ctx : ctx_with_notification, app : ctx_notification_app_name) => ctx,
 
     // empty preamble if we don't have the app name

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -2596,3 +2596,31 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $dialogue @org.thingpedia.dialogue.transaction.notification("Alert");
+U: ontimer(date=[$now + 10min]) => @org.thingpedia.builtin.thingengine.builtin.alert()
+U: #[results=[
+U:   { time=new Time(17, 50) }
+U: ]];
+UT: $dialogue @org.thingpedia.dialogue.transaction.notification("Alert");
+UT: ontimer(date=[$now + 10min]) => @org.thingpedia.builtin.thingengine.builtin.alert()
+UT: #[results=[
+UT:   { time=new Time(17, 50) }
+UT: ]];
+C: $dialogue @org.thingpedia.dialogue.transaction.notification("Alert");
+C: ontimer(date=[$now + 10min]) => @org.thingpedia.builtin.thingengine.builtin.alert()
+C: #[results=[
+C:   { time=new Time(17, 50) }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: Alert: it is 5:50 PM.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
+#! vote: up
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -2574,3 +2574,25 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.builtin.thingengine.builtin.alert();
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: @org.thingpedia.builtin.thingengine.builtin.alert();
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: @org.thingpedia.builtin.thingengine.builtin.alert()
+C: #[results=[
+C:   { time=new Time(17, 50) }
+C: ]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: It is 5:50 PM.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
+#! vote: down
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines

--- a/test/agent/index.js
+++ b/test/agent/index.js
@@ -97,6 +97,9 @@ class TestDelegate {
         this._testRunner.writeLine('>> context = ' + context.code.join(' ') + ' // ' + JSON.stringify(context.entities));
         this._testRunner.writeLine('>> expecting = ' + expect);
     }
+    addDevice(uniqueId, state) {
+        console.log('new-device ' + uniqueId + ', state = ' + JSON.stringify(state));
+    }
 
     addMessage(msg) {
         switch (msg.type) {
@@ -143,10 +146,6 @@ class TestDelegate {
         }
 
         case 'new-program':
-            console.log(JSON.stringify(msg));
-            break;
-
-        case 'new-device':
             console.log(JSON.stringify(msg));
             break;
         }

--- a/test/agent/index.js
+++ b/test/agent/index.js
@@ -118,6 +118,16 @@ class TestDelegate {
             this._testRunner.writeLine('picture: ' + msg.url);
             break;
 
+        case 'sound':
+            checkIcon(msg);
+            this._testRunner.writeLine('sound: ' + msg.name);
+            break;
+
+        case 'audio':
+            checkIcon(msg);
+            this._testRunner.writeLine('audio: ' + msg.url);
+            break;
+
         case 'rdl':
             checkIcon(msg);
             this._testRunner.writeLine('rdl: ' + msg.rdl.displayTitle + ' ' + (msg.rdl.callback || msg.rdl.webCallback));

--- a/test/agent/index.js
+++ b/test/agent/index.js
@@ -145,6 +145,10 @@ class TestDelegate {
         case 'new-program':
             console.log(JSON.stringify(msg));
             break;
+
+        case 'new-device':
+            console.log(JSON.stringify(msg));
+            break;
         }
     }
 }
@@ -273,6 +277,7 @@ async function main(onlyIds) {
         showWelcome: true,
         anonymous: false,
         rng: rng,
+        syncDevices: true,
 
         faqModels: {
             'covid-faq': {

--- a/test/agent/mock_engine.js
+++ b/test/agent/mock_engine.js
@@ -150,6 +150,10 @@ class MockDevice {
     queryInterface() {
         return null;
     }
+
+    serialize() {
+        return { kind: this.kind };
+    }
 }
 
 class MockTwitterDevice extends MockDevice {
@@ -333,10 +337,13 @@ class MockDeviceDatabase extends events.EventEmitter {
     addSerialized(blob) {
         if (blob.kind === 'com.bing') {
             console.log('MOCK: Loading bing');
-            return Promise.resolve(this._devices['com.bing'] = new MockBingDevice());
+            this._devices['com.bing'] = new MockBingDevice();
+            this.emit('device-added', this._devices['com.bing']);
+            return Promise.resolve();
         } else {
             console.log('MOCK: Loading device ' + JSON.stringify(blob));
             const device = new MockUnknownDevice(blob.kind);
+            this.emit('device-added', device);
             return Promise.resolve(this._devices[device.uniqueId] = device);
         }
     }

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -1220,7 +1220,7 @@ A: >> expecting = null
 U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
 U: @org.thingpedia.builtin.thingengine.builtin.alert();
 
-A: It is 5:50 PM.
 A: sound: alarm-clock-elapsed
+A: It is 5:50 PM.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_success ; @org.thingpedia.builtin.thingengine.builtin . alert ( ) #[ results = [ { time = TIME_0 } ] ] ; // {"TIME_0":{"hour":17,"minute":50,"second":0}}
 A: >> expecting = null

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -1224,3 +1224,16 @@ A: sound: alarm-clock-elapsed
 A: It is 5:50 PM.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_success ; @org.thingpedia.builtin.thingengine.builtin . alert ( ) #[ results = [ { time = TIME_0 } ] ] ; // {"TIME_0":{"hour":17,"minute":50,"second":0}}
 A: >> expecting = null
+
+====
+# 82-alert-notification
+
+U: \t $dialogue @org.thingpedia.dialogue.transaction.notification("Alert");
+U: ontimer(date=[$now + 10min]) => @org.thingpedia.builtin.thingengine.builtin.alert()
+U: #[results=[{ time=new Time(17,50) }]];
+
+# fixme the sound is not here due to how the test is set up, but it should play
+# correctly in real life
+A: Alert: it is 5:50 PM.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_success ; ontimer ( date = [ $now + DURATION_0 ] ) => @org.thingpedia.builtin.thingengine.builtin . alert ( ) #[ results = [ { time = TIME_0 } ] ] ; // {"DURATION_0":{"unit":"min","value":10},"TIME_0":{"hour":17,"minute":50,"second":0}}
+A: >> expecting = null

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -1213,3 +1213,14 @@ U: #[results=[{message_output="my reminder"}]];
 A: Reminder: my reminder.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_success ; ontimer ( date = [ $now + DURATION_0 ] ) => @org.thingpedia.builtin.thingengine.builtin . say ( message = QUOTED_STRING_0 ) #[ results = [ { message_output = QUOTED_STRING_0 } ] ] ; // {"DURATION_0":{"unit":"min","value":10},"QUOTED_STRING_0":"my reminder"}
 A: >> expecting = null
+
+====
+# 81-alert
+
+U: \t $dialogue @org.thingpedia.dialogue.transaction.execute;
+U: @org.thingpedia.builtin.thingengine.builtin.alert();
+
+A: It is 5:50 PM.
+A: sound: alarm-clock-elapsed
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_success ; @org.thingpedia.builtin.thingengine.builtin . alert ( ) #[ results = [ { time = TIME_0 } ] ] ; // {"TIME_0":{"hour":17,"minute":50,"second":0}}
+A: >> expecting = null

--- a/test/agent/thingpedia.tt
+++ b/test/agent/thingpedia.tt
@@ -177,7 +177,7 @@ class @org.thingpedia.builtin.thingengine.builtin
                  #_[canonical=["time"]])
   #_[result="It is ${time}"]
   #_[formatted=[
-    { type="sound", name="alarm-clock-elapsed", exclusive=false }
+    { type="sound", name="alarm-clock-elapsed", exclusive=false, before=true }
   ]]
   #_[canonical="alert"]
   #[doc="makes Genie show/play a generic alert"]
@@ -187,7 +187,7 @@ class @org.thingpedia.builtin.thingengine.builtin
                       #_[canonical="duration"])
   #_[result="It has been ${duration}"]
   #_[formatted=[
-    { type="sound", name="alarm-clock-elapsed", exclusive=true }
+    { type="sound", name="alarm-clock-elapsed", exclusive=false, before=true }
   ]]
   #_[canonical="timer expire"]
   #[doc="makes Genie play a generic alert and show/say the elapsed time"]

--- a/test/agent/thingpedia.tt
+++ b/test/agent/thingpedia.tt
@@ -173,6 +173,26 @@ class @org.thingpedia.builtin.thingengine.builtin
   #[doc="makes Almond say something"]
   #[confirm=false];
 
+  action alert(out time: Time
+                 #_[canonical=["time"]])
+  #_[result="It is ${time}"]
+  #_[formatted=[
+    { type="sound", name="alarm-clock-elapsed", exclusive=false }
+  ]]
+  #_[canonical="alert"]
+  #[doc="makes Genie show/play a generic alert"]
+  #[confirm=false];
+
+  action timer_expire(out duration: Measure(ms)
+                      #_[canonical="duration"])
+  #_[result="It has been ${duration}"]
+  #_[formatted=[
+    { type="sound", name="alarm-clock-elapsed", exclusive=true }
+  ]]
+  #_[canonical="timer expire"]
+  #[doc="makes Genie play a generic alert and show/say the elapsed time"]
+  #[confirm=false];
+
   action debug_log(in req message: String
                    #_[prompt=["what should I write in the logs", "what do you want me to write"]]
                    #[string_values="tt:long_free_text"])

--- a/test/engine/test_conversation_state.js
+++ b/test/engine/test_conversation_state.js
@@ -29,14 +29,14 @@ export default async function testConversationState(engine) {
 
     const state_0 = conversation.getState();
     const id = state_0.history.length === 0 ? 1 : state_0.lastMessageId+2;
-    const count = state_0.history.length + 2;
+    /* const count = state_0.history.length + 2; */
 
     await conversation.addMessage({type: MessageType.COMMAND, command});
     await conversation.addMessage({type: MessageType.COMMAND, command});
 
     // conversation state should have two more messages
     const state_1 = await engine.assistant.getConversationState(conversationId);
-    assert.strictEqual(state_1.history.length, count);
+    /* assert.strictEqual(state_1.history.length, count); */
     assert.strictEqual(state_1.lastMessageId, id);
 
     await engine.close();
@@ -46,11 +46,11 @@ export default async function testConversationState(engine) {
 
     // conversation should resume from last message id
     const state_2 = restored.getState();
-    assert.strictEqual(state_2.history.length, count);
+    /* assert.strictEqual(state_2.history.length, count); */
     assert.strictEqual(state_2.lastMessageId, id);
 
     await conversation.addMessage({type: MessageType.COMMAND, command});
     const state_3 = restored.getState();
-    assert.strictEqual(state_3.history.length, count+1);
+    /* assert.strictEqual(state_3.history.length, count+1); */
     assert.strictEqual(state_3.lastMessageId, id+1);
 }

--- a/tool/assistant.ts
+++ b/tool/assistant.ts
@@ -20,6 +20,7 @@
 
 import * as argparse from 'argparse';
 import * as readline from 'readline';
+import * as Tp from 'thingpedia';
 
 import Engine from '../lib/engine';
 import Platform from './lib/cmdline-platform';
@@ -37,7 +38,7 @@ class CommandLineDelegate {
         this._rl = rl;
     }
 
-    setHypothesis(hypothesis : string) {
+    async setHypothesis(hypothesis : string) {
         // go to beginning of line
         this._rl.write('', { ctrl: true, name: 'a' });
         // erase line
@@ -45,8 +46,11 @@ class CommandLineDelegate {
         // write the new hypothesis
         this._rl.write(hypothesis);
     }
-    setExpected(expect : string) {
+    async setExpected(expect : string) {
         console.log('>> expecting: ' + expect);
+    }
+    async addDevice(uniqueId : string, state : Tp.BaseDevice.DeviceState) {
+        // nothing to do
     }
 
     async addMessage(msg : Message) {


### PR DESCRIPTION
This PR contains all the genie-toolkit changes for the 9/3 demo.

The most questionable change is the new protocol to reveal the access token to the conversation clients (first commit).
This is a bit of a hack, for a couple of reasons:
- conceptually this code does not belong there, it has nothing to do with the conversation and its history
- the permission story in almond-cloud gets murky, because now an OAuth token with "user-exec-commands" permissions can also see the raw device credentials (which should require "user-sync" permissions)

Also questionable is the hack around the history field of the conversation state. Putting a json blob in there makes almond-cloud choke. For now, there is no history, but we should store the history in the db in a reasonable way (one row per message) and restore it correctly with proper on-demand/infinite back scroll.