### PR TITLE
utils/describe: avoid using "program"-type examples for confirmations

### DIFF
--- a/lib/utils/thingtalk/describe.ts
+++ b/lib/utils/thingtalk/describe.ts
@@ -952,11 +952,13 @@ export class Describer {
                     return false;
                 const invocation = ex.value.invocation;
 
-                return invocation.selector.kind === kind && invocation.channel === functionName;
+                return ex.type === forSchema.functionType && invocation.selector.kind === kind && invocation.channel === functionName;
             });
         }
 
         const templates : Array<{ utterance : Replaceable, replaceablenames : string[], othernames : string[], score : number }> = [];
+
+        const hasDeviceName = forSelector ? (!!forSelector.id || !!this._getDeviceAttribute(forSelector, 'name')) : false;
 
         // map each example from a form with p_ parameters into a "confirmation"-like form
         for (const ex of relevantExamples) {
@@ -993,11 +995,11 @@ export class Describer {
                 assert(invocation.selector.attributes[0].value instanceof Ast.VarRefValue);
                 deviceNameParam = invocation.selector.attributes[0].value.name;
 
-                if (forSelector && forSelector.id)
+                if (hasDeviceName)
                     score += 1; // normal match
                 else
                     score -= 0.5; // placeholder
-            } else if (forSelector && forSelector.id) {
+            } else if (hasDeviceName) {
                 // missing a space to put a device name (and we won't append
                 // the device name later) so this is bad
                 //

--- a/test/agent/expected-log.txt
+++ b/test/agent/expected-log.txt
@@ -2722,3 +2722,22 @@ AT: $dialogue @org.thingpedia.dialogue.transaction.sys_action_success;
 #! comment: test comment for dialogue turns
 #!          additional
 #!          lines
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t $stop;
+UT: $stop;
+====
+# test
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+U: \t monitor(@org.thingpedia.iot.switch(name="kitchen").state()) filter state == enum on;
+UT: $dialogue @org.thingpedia.dialogue.transaction.execute;
+UT: monitor(@org.thingpedia.iot.switch(name="kitchen").state()) filter state == enum on;
+C: $dialogue @org.thingpedia.dialogue.transaction.execute;
+C: monitor(@org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state()) filter state == enum on
+C: #[results=[]];
+#! timestamp: XXXX-XX-XXTXX:XX:XX.XXXZ
+A: Alright, I will notify you when the power state of your Kitchen Switches switch changes and it becomes true that the state is equal to on.
+AT: $dialogue @org.thingpedia.dialogue.transaction.sys_rule_enable_success;
+#! vote: down
+#! comment: test comment for dialogue turns
+#!          additional
+#!          lines

--- a/test/agent/tests.txt
+++ b/test/agent/tests.txt
@@ -1284,3 +1284,12 @@ A: sound: alarm-clock-elapsed
 A: Str:QUOTED_STRING::42:.
 A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_action_success ; @org.thingpedia.builtin.thingengine.builtin . say ( message = QUOTED_STRING_0 ) #[ results = [ { message = QUOTED_STRING_0 , message_output = QUOTED_STRING_1 } ] ] ; // {"QUOTED_STRING_0":"hello","QUOTED_STRING_1":"str:QUOTED_STRING::42:"}
 A: >> expecting = null
+
+====
+# 87-iot-confirm
+
+U: \t monitor(@org.thingpedia.iot.switch(name="kitchen").state()), state == enum on;
+
+A: Alright, I will notify you when the power state of your Kitchen Switches switch changes and it becomes true that the state is equal to on.
+A: >> context = $dialogue @org.thingpedia.dialogue.transaction . sys_rule_enable_success ; monitor ( @org.thingpedia.iot.switch ( id = GENERIC_ENTITY_tt:device_id_0 ) . state ( ) ) filter state == enum on #[ results = [ ] ] ; // {"GENERIC_ENTITY_tt:device_id_0":{"value":"switch-kitchen","display":"Kitchen Switches"}}
+A: >> expecting = null

--- a/test/data/en-US/dataset.tt
+++ b/test/data/en-US/dataset.tt
@@ -416,4 +416,150 @@ dataset @org.thingpedia.iot.light-bulb language "en" {
     #[name="SetPowerWithPowerOff"];
 
 }
+dataset @org.thingpedia.iot.switch language "en" {
+    program  := @org.thingpedia.iot.switch.state()
+    #_[utterances=["is my switch on?",
+                   "is my smart plug on?",
+                   "is my smart smart switch on?",
+                   "check if the switch is on",
+                   "is the switch turned on?",
+                   "is the smart plug turned on?",
+                   "is my switch switched on?",
+                   "check if the switch is switched on or off",
+                   "is my switch turned on or turned off"]]
+    #[id=54339857]
+    #[name="StateThenNotify"];
 
+    query  := @org.thingpedia.iot.switch.state()
+    #_[utterances=["the power state of my switch",
+                   "whether the switch is on or off"]]
+    #[id=54339863]
+    #[name="State"];
+
+    stream  := monitor (@org.thingpedia.iot.switch.state())
+    #_[utterances=["when my switch changes state"]]
+    #[id=54339867]
+    #[name="MonitorState"];
+
+    stream (p_state :Enum(on,off))  := monitor (@org.thingpedia.iot.switch.state()), state == p_state
+    #_[utterances=["when my switch turns ${p_state}",
+                   "when the switch switches ${p_state}",
+                   "if my switch becomes ${p_state}",
+                   "when the switch is ${p_state}",
+                   "if my switch changes to ${p_state}"]]
+    #[id=54339868]
+    #[name="MonitorStateByState"];
+
+    stream  := monitor (@org.thingpedia.iot.switch.state()), state == enum(on)
+    #_[utterances=["when my switch turns on",
+                   "if the switch switches on",
+                   "when the switch becomes on",
+                   "the moment my switch changes to on",
+                   "when my switch is on"]]
+    #[id=54339873]
+    #[name="MonitorStateByStateOn"];
+
+    stream  := monitor (@org.thingpedia.iot.switch.state()), state == enum(off)
+    #_[utterances=["when the switch is turned off",
+                   "once my switch is off",
+                   "when I turn off my switch",
+                   "if my switch gets switched off"]]
+    #[id=54339878]
+    #[name="MonitorStateByStateOff"];
+
+    action (p_power :Enum(on,off))  := @org.thingpedia.iot.switch.set_power(power=p_power)
+    #_[utterances=["turn ${p_power} my switch",
+                   "turn ${p_power} my smart plug",
+                   "switch ${p_power} the switch",
+                   "${p_power} the switch",
+                   "flip my switch ${p_power}"]]
+    #[id=54339882]
+    #[name="SetPowerWithPower"];
+
+    action (p_power :Enum(on,off))  := @org.thingpedia.iot.switch(all=true).set_power(power=p_power)
+    #_[utterances=["set ${p_power} all the switches",
+                   "turn ${p_power} all my switches"]]
+    #[name="SetPowerWithPowerAll"];
+
+    action (p_name :String, p_power :Enum(on,off))  := @org.thingpedia.iot.switch(all=true, name=p_name).set_power(power=p_power)
+    #_[utterances=["turn ${p_power} all my ${p_name:const} switches",
+                   "turn ${p_power} all the ${p_name:const} switch",
+                   "turn ${p_power} all the switches called ${p_name:const}",
+                   "turn ${p_power} all the switches in the ${p_name:const}",
+                   "turn ${p_power} all the ${p_name:const}",
+                   "set ${p_power} all the ${p_name:const} switches"]]
+    #[name="SetPowerWithPowerAll2"];
+
+    program (p_name :String)  := @org.thingpedia.iot.switch(name=p_name).state()
+    #_[utterances=["is my ${p_name:const} switch on?",
+                   "check if the ${p_name:const} switch is on",
+                   "is the ${p_name:const} switch turned on?",
+                   "is my ${p_name:const} switch switched on?",
+                   "check if the ${p_name:const} switch is switched on or off",
+                   "is my ${p_name:const} switch turned on or turned off",
+                   "is my ${p_name:const} on?",
+                   "check if the ${p_name:const} is on",
+                   "is the ${p_name:const} turned on?",
+                   "is my ${p_name:const} switched on?",
+                   "check if the ${p_name:const} is switched on or off",
+                   "is my ${p_name:const} turned on or turned off"]]
+    #[id=54339892]
+    #[name="StateThenNotify1"];
+
+    query (p_name :String)  := @org.thingpedia.iot.switch(name=p_name).state()
+    #_[utterances=["the power state of my ${p_name:const} switch",
+                   "whether the ${p_name:const} switch are on or off",
+                   "the state of the ${p_name:const} switch",
+                   "the power state of my ${p_name:const}",
+                   "whether the ${p_name:const} are on or off",
+                   "the state of the ${p_name:const}"]]
+    #[id=54339898]
+    #[name="State1"];
+
+    stream (p_name :String)  := monitor (@org.thingpedia.iot.switch(name=p_name).state())
+    #_[utterances=["when my ${p_name:const} switch changes state"]]
+    #[id=54339902]
+    #[name="MonitorState1"];
+
+    stream (p_name :String, p_state :Enum(on,off))  := monitor (@org.thingpedia.iot.switch(name=p_name).state()), state == p_state
+    #_[utterances=["when my ${p_name:const} switch turns ${p_state}",
+                   "when the ${p_name:const} switch switches ${p_state}",
+                   "if my ${p_name:const} switch becomes ${p_state}",
+                   "when the ${p_name:const} switch is ${p_state}",
+                   "if my ${p_name:const} switch changes to ${p_state}"]]
+    #[id=54339903]
+    #[name="MonitorStateByState1"];
+
+    stream (p_name :String)  := monitor (@org.thingpedia.iot.switch(name=p_name).state()), state == enum(on)
+    #_[utterances=["when my ${p_name:const} switch turns on",
+                   "if the ${p_name:const} switch switches on",
+                   "when the ${p_name:const} switch becomes on",
+                   "the moment my ${p_name:const} switch changes to on",
+                   "when my ${p_name:const} switch is on"]]
+    #[id=54339908]
+    #[name="MonitorStateByStateOn1"];
+
+    stream (p_name :String)  := monitor (@org.thingpedia.iot.switch(name=p_name).state()), state == enum(off)
+    #_[utterances=["when the ${p_name:const} switch is turned off",
+                   "once my ${p_name:const} switch is off",
+                   "when I turn off my ${p_name:const} switch",
+                   "if my ${p_name:const} switch gets switched off"]]
+    #[id=54339913]
+    #[name="MonitorStateByStateOff1"];
+
+    action (p_name :String, p_power :Enum(on,off))  := @org.thingpedia.iot.switch(name=p_name).set_power(power=p_power)
+    #_[utterances=["turn ${p_power} my ${p_name:const} switch",
+                   "switch ${p_power} the ${p_name:const} switch",
+                   "switch ${p_power} the ${p_name:const} smart plug",
+                   "switch ${p_power} the ${p_name:const} smart appliance",
+                   "switch ${p_power} the ${p_name:const} smart device",
+                   "turn ${p_power} my ${p_name:const}",
+                   "switch ${p_power} the ${p_name:const}"]]
+    #[id=54339917]
+    #[name="SetPowerWithPower1"];
+
+    program (p_name :String, p_power :Enum(on,off))  := @org.thingpedia.iot.switch(name=p_name).set_power(power=p_power)
+    #_[utterances=["switch ${p_name:const} ${p_power}",
+                   "${p_name:const} ${p_power}"]]
+    #[name="SetPowerWithPower2"];
+}

--- a/test/data/en-US/thingpedia.tt
+++ b/test/data/en-US/thingpedia.tt
@@ -950,7 +950,7 @@ abstract class @org.thingpedia.iot.switch
   #_[canonical=["switch state", "the state of my switch", "the state of the switch"]]
   #_[confirmation="the state of $__device"]
   #[confirm=false]
-  #_[result=["the {${__device}|} switch is ${state}"]];
+  #_[result=["the switch is ${state}"]];
 
   action set_power(in req power: Enum(on,off) #_[prompt="Do you want to turn it on or off?"] #_[canonical="power"])
   #_[canonical=["set the power of my switch", "set the power of the switch"]]

--- a/test/unit/test_describe.js
+++ b/test/unit/test_describe.js
@@ -463,6 +463,18 @@ const TEST_CASES = [
     [` @org.thingpedia.builtin.test(id="org.thingpedia.builtin.test").eat_data(data="some data ");`,
     `Eat data on test with data some data.`,
     `Test`],
+
+    [`monitor(@org.thingpedia.iot.switch.state());`,
+    `Notify me when the switch state changes.`,
+    `Switch`],
+
+    [`monitor(@org.thingpedia.iot.switch(name="kitchen").state());`,
+    `Notify me when the power state of my kitchen switch changes.`,
+    `Switch`],
+
+    [`monitor(@org.thingpedia.iot.switch(id="switch-kitchen"^^tt:device_id("Kitchen Switches")).state());`,
+    `Notify me when the power state of my Kitchen Switches switch changes.`,
+    `Switch`]
 ];
 
 async function test(i) {
@@ -481,8 +493,10 @@ async function test(i) {
         const kinds = new Set();
         for (const [, prim] of prog.iteratePrimitives(false))
             kinds.add(prim.selector.kind);
-        for (const kind of kinds)
-            describer.setDataset(kind, await schemaRetriever.getExamplesByKind(kind));
+        for (const kind of kinds) {
+            const dataset = await schemaRetriever.getExamplesByKind(kind);
+            describer.setDataset(kind, dataset);
+        }
 
         let reconstructed = describer.describe(prog).chooseBest();
         reconstructed = langPack.postprocessNLG(langPack.postprocessSynthetic(reconstructed, prog, null, 'agent'), allocator.entities, {


### PR DESCRIPTION
They don't fit grammatically

Also fix the fact that device names were not used in the description
if the ID was not set yet